### PR TITLE
added upgradeability flag and test

### DIFF
--- a/contracts/script/utils/ERC7201Helper.s.sol
+++ b/contracts/script/utils/ERC7201Helper.s.sol
@@ -12,7 +12,6 @@ import { console2 } from "forge-std/console2.sol";
 /// Thanks Mikhail Vladimirov for bytes32 to hex string conversion functions.
 /// https://stackoverflow.com/questions/67893318/solidity-how-to-represent-bytes32-as-string
 contract ERC7201HelperScript is Script {
-    
     string constant NAMESPACE = "story";
     string constant CONTRACT_NAME = "UpgradeabilityFlag";
 

--- a/contracts/script/utils/ERC7201Helper.s.sol
+++ b/contracts/script/utils/ERC7201Helper.s.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
+// solhint-disable quotes
 pragma solidity ^0.8.23;
 
 import { Script } from "forge-std/Script.sol";
+// solhint-disable-next-line no-console
 import { console2 } from "forge-std/console2.sol";
 
 /// @title ERC7201 Helper Script
@@ -18,6 +20,7 @@ contract ERC7201HelperScript is Script {
         bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);
         bytes32 hash = keccak256(abi.encode(uint256(keccak256(erc7201Key)) - 1)) & ~bytes32(uint256(0xff));
 
+        /* solhint-disable no-console */
         // Log natspec and storage structure
         console2.log(string(abi.encodePacked("/// @dev Storage structure for the ", CONTRACT_NAME)));
         console2.log(string(abi.encodePacked("/// @custom:storage-location erc7201:", erc7201Key)));
@@ -68,6 +71,7 @@ contract ERC7201HelperScript is Script {
         console2.log(string(abi.encodePacked("        $.slot := ", CONTRACT_NAME, "StorageLocation")));
         console2.log(string(abi.encodePacked("    }")));
         console2.log(string(abi.encodePacked("}")));
+        /* solhint-enable no-console */
     }
 
     function toHex16(bytes16 data) internal pure returns (bytes32 result) {

--- a/contracts/script/utils/ERC7201Helper.s.sol
+++ b/contracts/script/utils/ERC7201Helper.s.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+/// @title ERC7201 Helper Script
+/// @notice This script logs the boilerplate code for ERC7201 storage location and getter function, to
+/// help developers implement the ERC7201 interface in their contracts.
+/// Thanks Mikhail Vladimirov for bytes32 to hex string conversion functions.
+/// https://stackoverflow.com/questions/67893318/solidity-how-to-represent-bytes32-as-string
+contract ERC7201HelperScript is Script {
+    
+    string constant NAMESPACE = "story";
+    string constant CONTRACT_NAME = "UpgradeabilityFlag";
+
+    function run() external {
+        bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);
+        bytes32 hash = keccak256(abi.encode(uint256(keccak256(erc7201Key)) - 1)) & ~bytes32(uint256(0xff));
+
+        // Log natspec and storage structure
+        console2.log(string(abi.encodePacked("/// @dev Storage structure for the ", CONTRACT_NAME)));
+        console2.log(string(abi.encodePacked("/// @custom:storage-location erc7201:", erc7201Key)));
+        console2.log(string(abi.encodePacked("struct ", CONTRACT_NAME, "Storage {")));
+        console2.log("    // Write storage variables here...");
+        console2.log(string(abi.encodePacked("}")));
+        console2.log("");
+
+        // Log ERC7201 comment and storage location
+        console2.log(
+            string(
+                abi.encodePacked(
+                    "// keccak256(abi.encode(uint256(keccak256(",
+                    '"',
+                    erc7201Key,
+                    '"',
+                    ")) - 1)) & ~bytes32(uint256(0xff));"
+                )
+            )
+        );
+        console2.log(
+            string(
+                abi.encodePacked(
+                    "bytes32 private constant ",
+                    CONTRACT_NAME,
+                    "StorageLocation = ",
+                    toHexString(hash),
+                    ";"
+                )
+            )
+        );
+        console2.log("");
+
+        // Log getter function
+        console2.log(string(abi.encodePacked("/// @dev Returns the storage struct of ", CONTRACT_NAME, ".")));
+        console2.log(
+            string(
+                abi.encodePacked(
+                    "function _get",
+                    CONTRACT_NAME,
+                    "Storage() private pure returns (",
+                    CONTRACT_NAME,
+                    "Storage storage $) {"
+                )
+            )
+        );
+        console2.log(string(abi.encodePacked("    assembly {")));
+        console2.log(string(abi.encodePacked("        $.slot := ", CONTRACT_NAME, "StorageLocation")));
+        console2.log(string(abi.encodePacked("    }")));
+        console2.log(string(abi.encodePacked("}")));
+    }
+
+    function toHex16(bytes16 data) internal pure returns (bytes32 result) {
+        result =
+            (bytes32(data) & 0xFFFFFFFFFFFFFFFF000000000000000000000000000000000000000000000000) |
+            ((bytes32(data) & 0x0000000000000000FFFFFFFFFFFFFFFF00000000000000000000000000000000) >> 64);
+        result =
+            (result & 0xFFFFFFFF000000000000000000000000FFFFFFFF000000000000000000000000) |
+            ((result & 0x00000000FFFFFFFF000000000000000000000000FFFFFFFF0000000000000000) >> 32);
+        result =
+            (result & 0xFFFF000000000000FFFF000000000000FFFF000000000000FFFF000000000000) |
+            ((result & 0x0000FFFF000000000000FFFF000000000000FFFF000000000000FFFF00000000) >> 16);
+        result =
+            (result & 0xFF000000FF000000FF000000FF000000FF000000FF000000FF000000FF000000) |
+            ((result & 0x00FF000000FF000000FF000000FF000000FF000000FF000000FF000000FF0000) >> 8);
+        result =
+            ((result & 0xF000F000F000F000F000F000F000F000F000F000F000F000F000F000F000F000) >> 4) |
+            ((result & 0x0F000F000F000F000F000F000F000F000F000F000F000F000F000F000F000F00) >> 8);
+        result = bytes32(
+            0x3030303030303030303030303030303030303030303030303030303030303030 +
+                uint256(result) +
+                (((uint256(result) + 0x0606060606060606060606060606060606060606060606060606060606060606) >> 4) &
+                    0x0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F) *
+                39
+        );
+    }
+
+    function toHexString(bytes32 data) internal pure returns (string memory) {
+        return string(abi.encodePacked("0x", toHex16(bytes16(data)), toHex16(bytes16(data << 128))));
+    }
+}

--- a/contracts/src/protocol/IPTokenSlashing.sol
+++ b/contracts/src/protocol/IPTokenSlashing.sol
@@ -6,6 +6,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 import { IIPTokenSlashing } from "../interfaces/IIPTokenSlashing.sol";
 import { IPTokenStaking } from "./IPTokenStaking.sol";
+import { UpgradeabilityFlag } from "./UpradeabilityFlag.sol";
 import { Secp256k1 } from "../libraries/Secp256k1.sol";
 
 /**
@@ -13,7 +14,7 @@ import { Secp256k1 } from "../libraries/Secp256k1.sol";
  * @notice The EVM interface to the consensus chain's x/slashing module. Calls are proxied to the consensus chain, but
  *         not executed synchronously; execution is left to the consensus chain, which may fail.
  */
-contract IPTokenSlashing is IIPTokenSlashing, Ownable2StepUpgradeable, UUPSUpgradeable {
+contract IPTokenSlashing is IIPTokenSlashing, Ownable2StepUpgradeable, UUPSUpgradeable, UpgradeabilityFlag {
     /// @notice IPTokenStaking contract address.
     IPTokenStaking public immutable IP_TOKEN_STAKING;
 
@@ -97,7 +98,15 @@ contract IPTokenSlashing is IIPTokenSlashing, Ownable2StepUpgradeable, UUPSUpgra
         require(validatorExists, "IPTokenSlashing: Validator does not exist");
     }
 
+    //////////////////////////////// Upgradeability ////////////////////////////////////
+    
+    /// @notice Disables the upgradeability of the contract.
+    /// @dev WARNING: This action is irreversible.
+    function disableUpgradeability() external override onlyOwner {
+        _disableUpgradeability();
+    }
+
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner upgradeabilityEnabled {}
 }

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -8,12 +8,19 @@ import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableS
 
 import { IIPTokenStaking } from "../interfaces/IIPTokenStaking.sol";
 import { Secp256k1 } from "../libraries/Secp256k1.sol";
+import { UpgradeabilityFlag } from "./UpradeabilityFlag.sol";
 
 /**
  * @title IPTokenStaking
  * @notice The deposit contract for IP token staked validators.
  */
-contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeable {
+contract IPTokenStaking is
+    IIPTokenStaking,
+    Ownable2StepUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable,
+    UpgradeabilityFlag
+{
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @notice Default commission rate for a validator. Out of 100%, or 10_000.
@@ -550,7 +557,15 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         require(success, "IPTokenStaking: Failed to refund remainder");
     }
 
+    //////////////////////////////// Upgradeability ////////////////////////////////////
+
+    /// @notice Disables the upgradeability of the contract.
+    /// @dev WARNING: This action is irreversible.
+    function disableUpgradeability() external override onlyOwner {
+        _disableUpgradeability();
+    }
+
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner upgradeabilityEnabled {}
 }

--- a/contracts/src/protocol/UpgradeEntrypoint.sol
+++ b/contracts/src/protocol/UpgradeEntrypoint.sol
@@ -5,12 +5,12 @@ import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/acc
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import { IUpgradeEntrypoint } from "../interfaces/IUpgradeEntrypoint.sol";
-
+import { UpgradeabilityFlag } from "./UpradeabilityFlag.sol";
 /**
  * @title UpgradeEntrypoint
  * @notice Entrypoint contract for submitting x/upgrade module actions.
  */
-contract UpgradeEntrypoint is IUpgradeEntrypoint, Ownable2StepUpgradeable, UUPSUpgradeable {
+contract UpgradeEntrypoint is IUpgradeEntrypoint, Ownable2StepUpgradeable, UUPSUpgradeable, UpgradeabilityFlag {
     constructor() {
         _disableInitializers();
     }
@@ -35,7 +35,15 @@ contract UpgradeEntrypoint is IUpgradeEntrypoint, Ownable2StepUpgradeable, UUPSU
         emit SoftwareUpgrade({ name: name, height: height, info: info });
     }
 
+    //////////////////////////////// Upgradeability ////////////////////////////////////
+
+    /// @notice Disables the upgradeability of the contract.
+    /// @dev WARNING: This action is irreversible.
+    function disableUpgradeability() external override onlyOwner {
+        _disableUpgradeability();
+    }
+
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner upgradeabilityEnabled {}
 }

--- a/contracts/src/protocol/UpgradeEntrypoint.sol
+++ b/contracts/src/protocol/UpgradeEntrypoint.sol
@@ -6,6 +6,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 import { IUpgradeEntrypoint } from "../interfaces/IUpgradeEntrypoint.sol";
 import { UpgradeabilityFlag } from "./UpradeabilityFlag.sol";
+
 /**
  * @title UpgradeEntrypoint
  * @notice Entrypoint contract for submitting x/upgrade module actions.

--- a/contracts/src/protocol/UpradeabilityFlag.sol
+++ b/contracts/src/protocol/UpradeabilityFlag.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/ReentrancyGuard.sol)
+
+pragma solidity ^0.8.23;
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/**
+ * @title UpgradeabilityFlag
+ * @notice The UpgradeabilityFlag contract is used to signal the upgradeability of a UUPSUpgradeable contract.
+ * @dev To work, it must be:
+ * - inherited by a UUPSUpgradeable contract.
+ * - modifier `upgradeabilityEnabled` must be used in _authorizeUpgrade functions.
+ * - `disableUpgradeability()` must be protected by an access control mechanism.
+ * WARNING: Disabling upgradeability is an irreversible action.
+ */
+abstract contract UpgradeabilityFlag is Initializable {
+
+    event UpgradeabilityDisabled();
+
+    /// @dev Storage structure for the UpgradeabilityFlag
+    /// @custom:storage-location erc7201:story.UpgradeabilityFlag
+    struct UpgradeabilityFlagStorage {
+        bool upgradeabilityDisabled;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("story.UpgradeabilityFlag")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 private constant UpgradeabilityFlagStorageLocation =
+        0x75e222a2214bb4b88a6942927541e7b0da442e311bbd530a7a9ccee34f9dee00;
+
+
+    /// @dev moodifier to revert the transaction if upgradeability is disabled.
+    /// place it in _authorizeUpgrade functions.
+    modifier upgradeabilityEnabled() {
+        require(!_getUpgradeabilityFlagStorage().upgradeabilityDisabled, "UpgradeabilityFlag: disabled");
+        _;
+    }
+
+    /// @dev Implementation guide:
+    /// - set onlyOwner or other access control on this function.
+    /// - call _disableUpgradeability()
+    function disableUpgradeability() external virtual;
+
+    /// @notice Returns whether the upgradeability is disabled.
+    function upgradeabilityDisabled() external view returns (bool) {
+        return _getUpgradeabilityFlagStorage().upgradeabilityDisabled;
+    }
+
+    /// @notice Disables the upgradeability of the contract.
+    /// WARNING: Disabling upgradeability is an irreversible action.
+    function _disableUpgradeability() internal {
+        _getUpgradeabilityFlagStorage().upgradeabilityDisabled = true;
+        emit UpgradeabilityDisabled();
+    }
+
+    /// @dev Returns the storage struct of UpgradeabilityFlag.
+    function _getUpgradeabilityFlagStorage() private pure returns (UpgradeabilityFlagStorage storage $) {
+        assembly {
+            $.slot := UpgradeabilityFlagStorageLocation
+        }
+    }
+}

--- a/contracts/test/upgrade/UpgradeEntryPoint.t.sol
+++ b/contracts/test/upgrade/UpgradeEntryPoint.t.sol
@@ -61,9 +61,7 @@ contract UpgradeEntrypointTest is Test {
     }
 
     function testUpgradeEntrypoint_testUpgradeabilityACL() public {
-        address newImpl = address(
-            new MockUpgradeEntryPointV2()
-        );
+        address newImpl = address(new MockUpgradeEntryPointV2());
         // Network shall not allow non-owner to upgrade the contract.
         vm.expectRevert();
         upgradeEntrypoint.upgradeToAndCall(newImpl, "");
@@ -86,9 +84,7 @@ contract UpgradeEntrypointTest is Test {
     }
 
     function testUpgradeEntrypoint_testUpgradeability() public {
-        address newImpl = address(
-            new MockUpgradeEntryPointV2()
-        );
+        address newImpl = address(new MockUpgradeEntryPointV2());
         // Network shall allow the owner to upgrade the contract.
         vm.prank(admin);
         upgradeEntrypoint.upgradeToAndCall(newImpl, "");

--- a/contracts/test/utils/Mocks.sol
+++ b/contracts/test/utils/Mocks.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0
 // OpenZeppelin Contracts (last updated v5.0.0) (utils/ReentrancyGuard.sol)
-
+// solhint-disable max-states-count
 pragma solidity ^0.8.23;
 
 import { IPTokenSlashing } from "../../src/protocol/IPTokenSlashing.sol";
 import { IPTokenStaking } from "../../src/protocol/IPTokenStaking.sol";
 import { UpgradeEntrypoint } from "../../src/protocol/UpgradeEntrypoint.sol";
-
 
 contract MockIPTokenStakingV2 is IPTokenStaking {
     constructor(
@@ -14,12 +13,9 @@ contract MockIPTokenStakingV2 is IPTokenStaking {
         uint32 defaultCommissionRate,
         uint32 defaultMaxCommissionRate,
         uint32 defaultMaxCommissionChangeRate
-    ) IPTokenStaking(
-        stakingRounding,
-        defaultCommissionRate,
-        defaultMaxCommissionRate,
-        defaultMaxCommissionChangeRate
-    ) {}
+    )
+        IPTokenStaking(stakingRounding, defaultCommissionRate, defaultMaxCommissionRate, defaultMaxCommissionChangeRate)
+    {}
 
     function upgraded() external pure returns (bool) {
         return true;

--- a/contracts/test/utils/Mocks.sol
+++ b/contracts/test/utils/Mocks.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/ReentrancyGuard.sol)
+
+pragma solidity ^0.8.23;
+
+import { IPTokenSlashing } from "../../src/protocol/IPTokenSlashing.sol";
+import { IPTokenStaking } from "../../src/protocol/IPTokenStaking.sol";
+import { UpgradeEntrypoint } from "../../src/protocol/UpgradeEntrypoint.sol";
+
+
+contract MockIPTokenStakingV2 is IPTokenStaking {
+    constructor(
+        uint256 stakingRounding,
+        uint32 defaultCommissionRate,
+        uint32 defaultMaxCommissionRate,
+        uint32 defaultMaxCommissionChangeRate
+    ) IPTokenStaking(
+        stakingRounding,
+        defaultCommissionRate,
+        defaultMaxCommissionRate,
+        defaultMaxCommissionChangeRate
+    ) {}
+
+    function upgraded() external pure returns (bool) {
+        return true;
+    }
+}
+
+contract MockIPTokenSlashingV2 is IPTokenSlashing {
+    constructor(address ipTokenStaking) IPTokenSlashing(ipTokenStaking) {}
+
+    function upgraded() external pure returns (bool) {
+        return true;
+    }
+}
+
+contract MockUpgradeEntryPointV2 is UpgradeEntrypoint {
+    function upgraded() external pure returns (bool) {
+        return true;
+    }
+}


### PR DESCRIPTION
Current contracts would require to perform an upgrade to disable upgrading.
This PR adds a simple one time flag to disable upgradeability from an admin method, so we can make the contract non upgradeable with less moving parts.

- `UpgradeabilityFlag` contract with the logic and flag
- Every UUPSUpgradeable contract inherits and uses modifier to protect `_authorizeUpgrade()`
- Unit tests for admin transfers and upgrades.
