### PR TITLE
fix(client/validator): use correct secp256k1 key uncompression

### DIFF
--- a/client/cmd/key_utils.go
+++ b/client/cmd/key_utils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/decred/dcrd/dcrec/secp256k1"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/piplabs/story/lib/errors"
@@ -30,17 +31,16 @@ func decodeAndUncompressPubKey(compressedPubKeyBase64 string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to decode base64 public key")
 	}
-	if len(compressedPubKeyBytes) != 33 {
+	if len(compressedPubKeyBytes) != secp256k1.PubKeyBytesLenCompressed {
 		return "", fmt.Errorf("invalid compressed public key length: %d", len(compressedPubKeyBytes))
 	}
 
-	curve := elliptic.P256()
-	x, y := elliptic.UnmarshalCompressed(curve, compressedPubKeyBytes)
-	if x == nil || y == nil {
-		return "", errors.New("failed to unmarshal compressed public key")
+	pubKey, err := secp256k1.ParsePubKey(compressedPubKeyBytes)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse compressed public key")
 	}
 
-	uncompressedPubKeyBytes := elliptic.Marshal(curve, x, y)
+	uncompressedPubKeyBytes := pubKey.SerializeUncompressed()
 	uncompressedPubKeyHex := hex.EncodeToString(uncompressedPubKeyBytes)
 
 	return uncompressedPubKeyHex, nil

--- a/go.mod
+++ b/go.mod
@@ -252,6 +252,7 @@ require (
 
 require (
 	cosmossdk.io/x/upgrade v0.1.4
+	github.com/decred/dcrd/dcrec/secp256k1 v1.0.4
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/joho/godotenv v1.5.1
 )
@@ -264,6 +265,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.224 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 // indirect
 	github.com/ethereum/go-verkle v0.1.1-0.20240306133620-7d920df305f0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,15 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
 github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyLRN07EO0cNBV6DGU=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/dcrec/secp256k1 v1.0.4 h1:0XErmfJBiVbl0NvyclGn4jr+1hIylDf5beFi9W0o7Fc=
+github.com/decred/dcrd/dcrec/secp256k1 v1.0.4/go.mod h1:00z7mJdugt+GBAzPN1QrDRGCXxyKUiexEHu6ukxEw3k=
+github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 h1:3GIJYXQDAKpLEFriGFN8SbSffak10UXHGdIcFaMPykY=
+github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0/go.mod h1:3s92l0paYkZoIHuj4X93Teg/HB7eGM9x/zokGw+u4mY=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=


### PR DESCRIPTION
fixes secp256k1 key uncompression bug in the validator CLI

issue: fixes #50 
