### PR TITLE
test(evmstaking/types): add test cases for withdraw

### DIFF
--- a/client/x/evmstaking/types/withdraw_test.go
+++ b/client/x/evmstaking/types/withdraw_test.go
@@ -1,0 +1,146 @@
+package types
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type WithdrawTestSuite struct {
+	suite.Suite
+	encConf testutil.TestEncodingConfig
+	delAddr string
+	valAddr string
+	evmAddr common.Address
+}
+
+func (suite *WithdrawTestSuite) SetupTest() {
+	suite.encConf = testutil.MakeTestEncodingConfig()
+	// set dummy addresses
+	suite.delAddr = "story1hmjw3pvkjtndpg8wqppwdn8udd835qpan4hm0y"
+	suite.valAddr = "storyvaloper1hmjw3pvkjtndpg8wqppwdn8udd835qpaa6r6y0"
+	suite.evmAddr = common.HexToAddress("0x131D25EDE18178BAc9275b312001a63C081722d2")
+}
+
+func (suite *WithdrawTestSuite) TestString() {
+	suite.T().Parallel()
+
+	// Define the test cases
+	testCases := []struct {
+		name           string
+		withdrawal     Withdrawal
+		expectedString string
+	}{
+		{
+			name:           "Normal values",
+			withdrawal:     NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 100),
+			expectedString: fmt.Sprintf("creation_height:1 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" amount:100 ", suite.delAddr, suite.valAddr, suite.evmAddr.String()),
+		},
+		{
+			name:           "Empty addresses",
+			withdrawal:     NewWithdrawal(1, "", "", "", 1),
+			expectedString: "creation_height:1 amount:1 ",
+		},
+		{
+			name:           "Large amount",
+			withdrawal:     NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), math.MaxUint64),
+			expectedString: fmt.Sprintf("creation_height:1 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" amount:%s ", suite.delAddr, suite.valAddr, suite.evmAddr.String(), new(big.Int).SetUint64(math.MaxUint64).String()),
+		},
+		{
+			name:           "Zero amount",
+			withdrawal:     NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 0),
+			expectedString: fmt.Sprintf("creation_height:1 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" ", suite.delAddr, suite.valAddr, suite.evmAddr.String()),
+		},
+	}
+
+	// Iterate over test cases
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			result := tc.withdrawal.String()
+			suite.Equal(tc.expectedString, result)
+		})
+	}
+}
+
+func (suite *WithdrawTestSuite) TestWithdrawalsString() {
+	suite.T().Parallel()
+	ws := Withdrawals{
+		Withdrawals: []Withdrawal{
+			NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
+			NewWithdrawal(2, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 2),
+		},
+	}
+
+	expectedString := fmt.Sprintf(
+		`creation_height:1 delegator_address:"%s" validator_address:"%s" execution_address:"%s" amount:1 
+creation_height:2 delegator_address:"%s" validator_address:"%s" execution_address:"%s" amount:2`,
+		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
+		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
+	)
+	suite.Equal(expectedString, ws.String())
+}
+
+func (suite *WithdrawTestSuite) TestWithdrawalsLen() {
+	suite.T().Parallel()
+	ws := Withdrawals{
+		Withdrawals: []Withdrawal{
+			NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
+			NewWithdrawal(2, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 2),
+		},
+	}
+
+	suite.Equal(2, ws.Len())
+}
+
+func (suite *WithdrawTestSuite) TestNewWithdrawalFromMsg() {
+	suite.T().Parallel()
+	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	msgAddwithdrawal := MsgAddWithdrawal{
+		Authority:  "gov",
+		Withdrawal: &withdrawal,
+	}
+	w := NewWithdrawalFromMsg(&msgAddwithdrawal)
+	suite.Equal(withdrawal, w, "NewWithdrawalFromMsg should return the same withdrawal")
+}
+
+func (suite *WithdrawTestSuite) TestMustMarshalWithdraw() {
+	suite.T().Parallel()
+	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	suite.NotPanics(func() {
+		marshaled := MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal)
+		suite.NotNil(marshaled, "MarshalWithdrawal should not return nil")
+	})
+}
+
+func (suite *WithdrawTestSuite) TestUnmarshalWithdraw() {
+	suite.T().Parallel()
+	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	marshaled := MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal)
+
+	w, err := UnmarshalWithdrawal(suite.encConf.Codec, marshaled)
+	suite.NoError(err)
+	suite.Equal(withdrawal, w, "UnmarshalWithdrawal should return the same withdrawal")
+}
+
+func (suite *WithdrawTestSuite) TestMustUnmarshalWithdraw() {
+	suite.T().Parallel()
+	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	suite.NotPanics(func() {
+		w := MustUnmarshalWithdrawal(
+			suite.encConf.Codec,
+			MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal),
+		)
+		require.Equal(suite.T(), withdrawal, w)
+	})
+}
+
+func TestTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(WithdrawTestSuite))
+}

--- a/client/x/evmstaking/types/withdraw_test.go
+++ b/client/x/evmstaking/types/withdraw_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
@@ -84,6 +85,11 @@ func (suite *WithdrawTestSuite) TestWithdrawalsString() {
 		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
 	)
 	require.Equal(expectedString, ws.String())
+
+	// Test with spaces, it should trim the spaces
+	stringWithSpaces := " " + ws.String() + " " // add leading and trailing spaces
+	trimmedString := strings.TrimSpace(stringWithSpaces)
+	require.Equal(expectedString, trimmedString, "Withdrawals.String() should trim spaces")
 }
 
 func (suite *WithdrawTestSuite) TestWithdrawalsLen() {

--- a/client/x/evmstaking/types/withdraw_test.go
+++ b/client/x/evmstaking/types/withdraw_test.go
@@ -1,4 +1,4 @@
-package types
+package types_test
 
 import (
 	"fmt"
@@ -9,6 +9,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/piplabs/story/client/x/evmstaking/types"
 )
 
 type WithdrawTestSuite struct {
@@ -28,30 +30,31 @@ func (suite *WithdrawTestSuite) SetupTest() {
 }
 
 func (suite *WithdrawTestSuite) TestString() {
+	require := suite.Require()
 	// Define the test cases
 	testCases := []struct {
 		name           string
-		withdrawal     Withdrawal
+		withdrawal     types.Withdrawal
 		expectedString string
 	}{
 		{
 			name:           "Normal values",
-			withdrawal:     NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 100),
+			withdrawal:     types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 100),
 			expectedString: fmt.Sprintf("creation_height:1 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" amount:100 ", suite.delAddr, suite.valAddr, suite.evmAddr.String()),
 		},
 		{
 			name:           "Empty addresses",
-			withdrawal:     NewWithdrawal(1, "", "", "", 1),
+			withdrawal:     types.NewWithdrawal(1, "", "", "", 1),
 			expectedString: "creation_height:1 amount:1 ",
 		},
 		{
 			name:           "Large amount",
-			withdrawal:     NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), math.MaxUint64),
+			withdrawal:     types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), math.MaxUint64),
 			expectedString: fmt.Sprintf("creation_height:1 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" amount:%s ", suite.delAddr, suite.valAddr, suite.evmAddr.String(), new(big.Int).SetUint64(math.MaxUint64).String()),
 		},
 		{
 			name:           "Zero amount",
-			withdrawal:     NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 0),
+			withdrawal:     types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 0),
 			expectedString: fmt.Sprintf("creation_height:1 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" ", suite.delAddr, suite.valAddr, suite.evmAddr.String()),
 		},
 	}
@@ -60,16 +63,17 @@ func (suite *WithdrawTestSuite) TestString() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			result := tc.withdrawal.String()
-			suite.Equal(tc.expectedString, result)
+			require.Equal(tc.expectedString, result)
 		})
 	}
 }
 
 func (suite *WithdrawTestSuite) TestWithdrawalsString() {
-	ws := Withdrawals{
-		Withdrawals: []Withdrawal{
-			NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
-			NewWithdrawal(2, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 2),
+	require := suite.Require()
+	ws := types.Withdrawals{
+		Withdrawals: []types.Withdrawal{
+			types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
+			types.NewWithdrawal(2, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 2),
 		},
 	}
 
@@ -79,57 +83,61 @@ creation_height:2 delegator_address:"%s" validator_address:"%s" execution_addres
 		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
 		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
 	)
-	suite.Equal(expectedString, ws.String())
+	require.Equal(expectedString, ws.String())
 }
 
 func (suite *WithdrawTestSuite) TestWithdrawalsLen() {
-	ws := Withdrawals{
-		Withdrawals: []Withdrawal{
-			NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
-			NewWithdrawal(2, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 2),
+	require := suite.Require()
+	ws := types.Withdrawals{
+		Withdrawals: []types.Withdrawal{
+			types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
+			types.NewWithdrawal(2, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 2),
 		},
 	}
 
-	suite.Equal(2, ws.Len())
+	require.Equal(2, ws.Len())
 }
 
 func (suite *WithdrawTestSuite) TestNewWithdrawalFromMsg() {
-	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
-	msgAddwithdrawal := MsgAddWithdrawal{
+	require := suite.Require()
+	withdrawal := types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	msgAddwithdrawal := types.MsgAddWithdrawal{
 		Authority:  "gov",
 		Withdrawal: &withdrawal,
 	}
-	w := NewWithdrawalFromMsg(&msgAddwithdrawal)
-	suite.Equal(withdrawal, w, "NewWithdrawalFromMsg should return the same withdrawal")
+	w := types.NewWithdrawalFromMsg(&msgAddwithdrawal)
+	require.Equal(withdrawal, w, "NewWithdrawalFromMsg should return the same withdrawal")
 }
 
 func (suite *WithdrawTestSuite) TestMustMarshalWithdraw() {
-	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
-	suite.NotPanics(func() {
-		marshaled := MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal)
-		suite.NotNil(marshaled, "MarshalWithdrawal should not return nil")
+	require := suite.Require()
+	withdrawal := types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	require.NotPanics(func() {
+		marshaled := types.MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal)
+		require.NotNil(marshaled, "MarshalWithdrawal should not return nil")
 	})
 }
 
 func (suite *WithdrawTestSuite) TestUnmarshalWithdraw() {
-	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	require := suite.Require()
+	withdrawal := types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
 
 	testCases := []struct {
 		name           string
 		input          []byte
-		expectedResult Withdrawal
+		expectedResult types.Withdrawal
 		expectError    bool
 	}{
 		{
 			name:           "Unmarshal valid withdrawal bytes",
-			input:          MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal),
-			expectedResult: NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
+			input:          types.MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal),
+			expectedResult: types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
 			expectError:    false,
 		},
 		{
 			name:           "Unmarshal invalid withdrawal bytes",
 			input:          []byte{1},
-			expectedResult: Withdrawal{}, // Expecting an empty struct since it will fail
+			expectedResult: types.Withdrawal{}, // Expecting an empty struct since it will fail
 			expectError:    true,
 		},
 	}
@@ -137,30 +145,31 @@ func (suite *WithdrawTestSuite) TestUnmarshalWithdraw() {
 	// Iterate over test cases
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			result, err := UnmarshalWithdrawal(suite.encConf.Codec, tc.input)
+			result, err := types.UnmarshalWithdrawal(suite.encConf.Codec, tc.input)
 			if tc.expectError {
-				suite.Error(err)
+				require.Error(err)
 			} else {
-				suite.NoError(err)
-				suite.Equal(tc.expectedResult, result, "UnmarshalWithdrawal should return the correct withdrawal")
+				require.NoError(err)
+				require.Equal(tc.expectedResult, result, "UnmarshalWithdrawal should return the correct withdrawal")
 			}
 		})
 	}
 }
 
 func (suite *WithdrawTestSuite) TestMustUnmarshalWithdraw() {
-	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
+	require := suite.Require()
+	withdrawal := types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
 
 	testCases := []struct {
 		name        string
 		input       []byte
-		expected    Withdrawal
+		expected    types.Withdrawal
 		expectPanic bool
 	}{
 		{
 			name:        "Unmarshal valid withdrawal bytes",
-			input:       MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal),
-			expected:    NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
+			input:       types.MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal),
+			expected:    types.NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
 			expectPanic: false,
 		},
 		{
@@ -174,13 +183,13 @@ func (suite *WithdrawTestSuite) TestMustUnmarshalWithdraw() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			if tc.expectPanic {
-				suite.Panics(func() {
-					MustUnmarshalWithdrawal(suite.encConf.Codec, tc.input)
+				require.Panics(func() {
+					types.MustUnmarshalWithdrawal(suite.encConf.Codec, tc.input)
 				})
 			} else {
-				suite.NotPanics(func() {
-					result := MustUnmarshalWithdrawal(suite.encConf.Codec, tc.input)
-					suite.Equal(tc.expected, result, "MustUnmarshalWithdrawal should return the correct withdrawal")
+				require.NotPanics(func() {
+					result := types.MustUnmarshalWithdrawal(suite.encConf.Codec, tc.input)
+					require.Equal(tc.expected, result, "MustUnmarshalWithdrawal should return the correct withdrawal")
 				})
 			}
 		})

--- a/client/x/evmstaking/types/withdraw_test.go
+++ b/client/x/evmstaking/types/withdraw_test.go
@@ -28,8 +28,6 @@ func (suite *WithdrawTestSuite) SetupTest() {
 }
 
 func (suite *WithdrawTestSuite) TestString() {
-	suite.T().Parallel()
-
 	// Define the test cases
 	testCases := []struct {
 		name           string
@@ -68,7 +66,6 @@ func (suite *WithdrawTestSuite) TestString() {
 }
 
 func (suite *WithdrawTestSuite) TestWithdrawalsString() {
-	suite.T().Parallel()
 	ws := Withdrawals{
 		Withdrawals: []Withdrawal{
 			NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
@@ -86,7 +83,6 @@ creation_height:2 delegator_address:"%s" validator_address:"%s" execution_addres
 }
 
 func (suite *WithdrawTestSuite) TestWithdrawalsLen() {
-	suite.T().Parallel()
 	ws := Withdrawals{
 		Withdrawals: []Withdrawal{
 			NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1),
@@ -98,7 +94,6 @@ func (suite *WithdrawTestSuite) TestWithdrawalsLen() {
 }
 
 func (suite *WithdrawTestSuite) TestNewWithdrawalFromMsg() {
-	suite.T().Parallel()
 	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
 	msgAddwithdrawal := MsgAddWithdrawal{
 		Authority:  "gov",
@@ -109,7 +104,6 @@ func (suite *WithdrawTestSuite) TestNewWithdrawalFromMsg() {
 }
 
 func (suite *WithdrawTestSuite) TestMustMarshalWithdraw() {
-	suite.T().Parallel()
 	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
 	suite.NotPanics(func() {
 		marshaled := MustMarshalWithdrawal(suite.encConf.Codec, &withdrawal)
@@ -118,8 +112,6 @@ func (suite *WithdrawTestSuite) TestMustMarshalWithdraw() {
 }
 
 func (suite *WithdrawTestSuite) TestUnmarshalWithdraw() {
-	suite.T().Parallel()
-
 	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
 
 	testCases := []struct {
@@ -157,8 +149,6 @@ func (suite *WithdrawTestSuite) TestUnmarshalWithdraw() {
 }
 
 func (suite *WithdrawTestSuite) TestMustUnmarshalWithdraw() {
-	suite.T().Parallel()
-
 	withdrawal := NewWithdrawal(1, suite.delAddr, suite.valAddr, suite.evmAddr.String(), 1)
 
 	testCases := []struct {

--- a/client/x/evmstaking/types/withdraw_test.go
+++ b/client/x/evmstaking/types/withdraw_test.go
@@ -78,8 +78,8 @@ func (suite *WithdrawTestSuite) TestWithdrawalsString() {
 	}
 
 	expectedString := fmt.Sprintf(
-		`creation_height:1 delegator_address:"%s" validator_address:"%s" execution_address:"%s" amount:1 
-creation_height:2 delegator_address:"%s" validator_address:"%s" execution_address:"%s" amount:2`,
+		"creation_height:1 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" amount:1 \n"+
+			"creation_height:2 delegator_address:\"%s\" validator_address:\"%s\" execution_address:\"%s\" amount:2",
 		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
 		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
 	)

--- a/client/x/evmstaking/types/withdraw_test.go
+++ b/client/x/evmstaking/types/withdraw_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"strings"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
@@ -85,11 +84,6 @@ func (suite *WithdrawTestSuite) TestWithdrawalsString() {
 		suite.delAddr, suite.valAddr, suite.evmAddr.String(),
 	)
 	require.Equal(expectedString, ws.String())
-
-	// Test with spaces, it should trim the spaces
-	stringWithSpaces := " " + ws.String() + " " // add leading and trailing spaces
-	trimmedString := strings.TrimSpace(stringWithSpaces)
-	require.Equal(expectedString, trimmedString, "Withdrawals.String() should trim spaces")
 }
 
 func (suite *WithdrawTestSuite) TestWithdrawalsLen() {


### PR DESCRIPTION
This PR increased test coverage of [client/x/evmstaking/types/withdraw.go](https://github.com/piplabs/story/blob/main/client/x/evmstaking/types/withdraw.go) from 0% to 100%.

issue: #64 