### PR TITLE
chore(release): bump client to 0.9.11 stable

### DIFF
--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	VersionMajor = 0          // Major version component of the current release
-	VersionMinor = 9          // Minor version component of the current release
-	VersionPatch = 11         // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 0        // Major version component of the current release
+	VersionMinor = 9        // Minor version component of the current release
+	VersionPatch = 11       // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 
 // Version returns the version of the whole story-monorepo and all binaries built from this git commit.


### PR DESCRIPTION
bumps the story client to 0.9.11 stable

issue: none
