### PR TITLE
test(evmstaking/keeper): add test cases for withdrawal queue

### DIFF
--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -51,7 +51,6 @@ type TestSuite struct {
 }
 
 func (s *TestSuite) SetupTest() {
-	s.addrs = simtestutil.CreateIncrementalAccounts(4)
 	s.encCfg = moduletestutil.MakeTestEncodingConfig(module.AppModuleBasic{})
 	evmstakingKey := storetypes.NewKVStoreKey(types.StoreKey)
 	stakingKey := storetypes.NewKVStoreKey(stypes.StoreKey)
@@ -78,16 +77,18 @@ func (s *TestSuite) SetupTest() {
 	cfg.SetBech32PrefixForAccount("story", "storypub")
 	cfg.SetBech32PrefixForValidator("storyvaloper", "storyvaloperpub")
 	cfg.SetBech32PrefixForConsensusNode("storyvalcons", "storyvalconspub")
+	// it should be called after setting the bech32 prefix correctly
+	s.addrs = simtestutil.CreateIncrementalAccounts(4)
 
 	// gomock initializations
 	ctrl := gomock.NewController(s.T())
 
 	// mock keepers
 	accountKeeper := estestutil.NewMockAccountKeeper(ctrl)
-	accountKeeper.EXPECT().GetModuleAddress(types.ModuleName).Return(s.addrs[0]).AnyTimes()
-	accountKeeper.EXPECT().GetModuleAddress(stypes.ModuleName).Return(s.addrs[1]).AnyTimes()
-	accountKeeper.EXPECT().GetModuleAddress(stypes.BondedPoolName).Return(s.addrs[2]).AnyTimes()
-	accountKeeper.EXPECT().GetModuleAddress(stypes.NotBondedPoolName).Return(s.addrs[3]).AnyTimes()
+	accountKeeper.EXPECT().GetModuleAddress(types.ModuleName).Return(authtypes.NewModuleAddress(types.ModuleName)).AnyTimes()
+	accountKeeper.EXPECT().GetModuleAddress(stypes.ModuleName).Return(authtypes.NewModuleAddress(stypes.ModuleName)).AnyTimes()
+	accountKeeper.EXPECT().GetModuleAddress(stypes.BondedPoolName).Return(authtypes.NewModuleAddress(stypes.BondedPoolName)).AnyTimes()
+	accountKeeper.EXPECT().GetModuleAddress(stypes.NotBondedPoolName).Return(authtypes.NewModuleAddress(stypes.NotBondedPoolName)).AnyTimes()
 	accountKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec("story")).AnyTimes()
 	bankKeeper := estestutil.NewMockBankKeeper(ctrl)
 	s.BankKeeper = bankKeeper
@@ -102,7 +103,7 @@ func (s *TestSuite) SetupTest() {
 		bankKeeper,
 		authtypes.NewModuleAddress(stypes.ModuleName).String(),
 		address.NewBech32Codec("storyvaloper"),
-		address.NewBech32Codec("storyvaloper"),
+		address.NewBech32Codec("storyvalcons"),
 	)
 	s.StakingKeeper = stakingKeeper
 	s.Require().NoError(s.StakingKeeper.SetParams(s.Ctx, stypes.DefaultParams()))

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -42,7 +42,6 @@ type TestSuite struct {
 
 	Ctx sdk.Context
 
-	addrs            []sdk.AccAddress
 	BankKeeper       *estestutil.MockBankKeeper
 	StakingKeeper    *skeeper.Keeper
 	EVMStakingKeeper *keeper.Keeper
@@ -77,8 +76,6 @@ func (s *TestSuite) SetupTest() {
 	cfg.SetBech32PrefixForAccount("story", "storypub")
 	cfg.SetBech32PrefixForValidator("storyvaloper", "storyvaloperpub")
 	cfg.SetBech32PrefixForConsensusNode("storyvalcons", "storyvalconspub")
-	// it should be called after setting the bech32 prefix correctly
-	s.addrs = simtestutil.CreateIncrementalAccounts(4)
 
 	// gomock initializations
 	ctrl := gomock.NewController(s.T())

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -59,19 +59,19 @@ func (s *TestSuite) TestDequeueEligibleWithdrawals() {
 		expected    []types.Withdrawal
 	}{
 		{
-			name:        "Dequeue 1 withdrawal",
+			name:        "Dequeue 1 withdrawal (have: 3, cap: 1)",
 			maxDequeue:  1,
 			expectedLen: 1,
 			expected:    withdrawals[:1],
 		},
 		{
-			name:        "Dequeue 2 withdrawals",
+			name:        "Dequeue 2 withdrawals (have: 3, cap: 2)",
 			maxDequeue:  2,
 			expectedLen: 2,
 			expected:    withdrawals[:2],
 		},
 		{
-			name:        "Dequeue more than available",
+			name:        "Dequeue all withdrawals because maxDequeue is more than available",
 			maxDequeue:  10,
 			expectedLen: len(withdrawals),
 			expected:    withdrawals,
@@ -122,7 +122,6 @@ func (s *TestSuite) TestDequeueEligibleWithdrawals() {
 }
 
 func (s *TestSuite) TestPeekEligibleWithdrawals() {
-	require := s.Require()
 	tcs := []struct {
 		name        string
 		maxDequeue  uint32
@@ -164,25 +163,25 @@ func (s *TestSuite) TestPeekEligibleWithdrawals() {
 
 			// Set max dequeue parameter
 			params, err := s.EVMStakingKeeper.GetParams(s.Ctx)
-			require.NoError(err)
+			s.NoError(err)
 			params.MaxWithdrawalPerBlock = tc.maxDequeue
 			err = s.EVMStakingKeeper.SetParams(s.Ctx, params)
-			require.NoError(err)
+			s.NoError(err)
 
 			queueLen := s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx)
 
 			// Peek the withdrawals
 			result, err := s.EVMStakingKeeper.PeekEligibleWithdrawals(s.Ctx)
-			require.NoError(err)
-			require.Equal(tc.expectedLen, len(result))
+			s.NoError(err)
+			s.Equal(tc.expectedLen, len(result))
 
 			// Peek does not change the queue length
-			require.Equal(queueLen, s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+			s.Equal(queueLen, s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
 
 			// Validate the content of the dequeued withdrawals
 			for i, w := range result {
-				require.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
-				require.Equal(tc.expected[i].Amount, w.Amount)
+				s.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
+				s.Equal(tc.expected[i].Amount, w.Amount)
 			}
 		})
 	}

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -1,0 +1,245 @@
+package keeper_test
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/piplabs/story/client/x/evmstaking/types"
+)
+
+var (
+	delAddr     = "story1hmjw3pvkjtndpg8wqppwdn8udd835qpan4hm0y"
+	valAddr     = "storyvaloper1hmjw3pvkjtndpg8wqppwdn8udd835qpaa6r6y0"
+	evmAddr     = common.HexToAddress("0x131D25EDE18178BAc9275b312001a63C081722d2")
+	withdrawals = []types.Withdrawal{
+		types.NewWithdrawal(1, delAddr, valAddr, evmAddr.String(), 100),
+		types.NewWithdrawal(2, delAddr, valAddr, evmAddr.String(), 200),
+		types.NewWithdrawal(3, delAddr, valAddr, evmAddr.String(), 300),
+	}
+)
+
+func (s *TestSuite) initQueue() {
+	err := s.EVMStakingKeeper.WithdrawalQueue.Initialize(s.Ctx)
+	s.NoError(err)
+	s.Equal(uint64(0), s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+}
+
+func (s *TestSuite) addWithdrawals(withdrawals []types.Withdrawal) {
+	for _, w := range withdrawals {
+		err := s.EVMStakingKeeper.AddWithdrawalToQueue(s.Ctx, w)
+		s.NoError(err)
+	}
+}
+
+func (s *TestSuite) TestAddWithdrawalToQueue() {
+	s.initQueue()
+
+	// Add a withdrawal to the queue
+	withdrawal := types.NewWithdrawal(1, delAddr, valAddr, evmAddr.String(), 100)
+	err := s.EVMStakingKeeper.AddWithdrawalToQueue(s.Ctx, withdrawal)
+	s.NoError(err)
+
+	// Check the withdrawal is in the queue
+	s.Equal(uint64(1), s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+	elem, err := s.EVMStakingKeeper.WithdrawalQueue.Get(s.Ctx, 0)
+	s.NoError(err)
+	s.Equal(withdrawal, elem)
+}
+
+func (s *TestSuite) TestDequeueEligibleWithdrawals() {
+	tcs := []struct {
+		name        string
+		maxDequeue  uint32
+		expectedLen int
+		expected    []types.Withdrawal
+	}{
+		{
+			name:        "Dequeue 1 withdrawal",
+			maxDequeue:  1,
+			expectedLen: 1,
+			expected:    withdrawals[:1],
+		},
+		{
+			name:        "Dequeue 2 withdrawals",
+			maxDequeue:  2,
+			expectedLen: 2,
+			expected:    withdrawals[:2],
+		},
+		{
+			name:        "Dequeue more than available",
+			maxDequeue:  10,
+			expectedLen: len(withdrawals),
+			expected:    withdrawals,
+		},
+		{
+			name:        "Dequeue with empty queue",
+			maxDequeue:  3,
+			expectedLen: 0,
+			expected:    []types.Withdrawal{},
+		},
+	}
+
+	for _, tc := range tcs {
+		s.Run(tc.name, func() {
+			s.initQueue()
+
+			if tc.name != "Dequeue with empty queue" {
+				s.addWithdrawals(withdrawals)
+			}
+
+			// Set max dequeue parameter
+			params, err := s.EVMStakingKeeper.GetParams(s.Ctx)
+			s.NoError(err)
+			params.MaxWithdrawalPerBlock = tc.maxDequeue
+			err = s.EVMStakingKeeper.SetParams(s.Ctx, params)
+			s.NoError(err)
+
+			queueLen := s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx)
+
+			// Dequeue the withdrawals
+			result, err := s.EVMStakingKeeper.DequeueEligibleWithdrawals(s.Ctx)
+			s.NoError(err)
+			s.Equal(tc.expectedLen, len(result))
+
+			// Check Queue length is decreased by the number of dequeued withdrawals
+			s.Equal(
+				queueLen-uint64(tc.expectedLen),
+				s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx),
+			)
+
+			// Validate the content of the dequeued withdrawals
+			for i, w := range result {
+				s.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
+				s.Equal(tc.expected[i].Amount, w.Amount)
+			}
+		})
+	}
+}
+
+func (s *TestSuite) TestPeekEligibleWithdrawals() {
+	tcs := []struct {
+		name        string
+		maxDequeue  uint32
+		expectedLen int
+		expected    []types.Withdrawal
+	}{
+		{
+			name:        "Peek 1 withdrawal",
+			maxDequeue:  1,
+			expectedLen: 1,
+			expected:    withdrawals[:1],
+		},
+		{
+			name:        "Peek 2 withdrawals",
+			maxDequeue:  2,
+			expectedLen: 2,
+			expected:    withdrawals[:2],
+		},
+		{
+			name:        "Peek more than available",
+			maxDequeue:  10,
+			expectedLen: len(withdrawals),
+			expected:    withdrawals,
+		},
+		{
+			name:        "Peek with empty queue",
+			maxDequeue:  3,
+			expectedLen: 0,
+			expected:    []types.Withdrawal{},
+		},
+	}
+
+	for _, tc := range tcs {
+		s.Run(tc.name, func() {
+			s.initQueue()
+			if tc.name != "Peek with empty queue" {
+				s.addWithdrawals(withdrawals)
+			}
+
+			// Set max dequeue parameter
+			params, err := s.EVMStakingKeeper.GetParams(s.Ctx)
+			s.NoError(err)
+			params.MaxWithdrawalPerBlock = tc.maxDequeue
+			err = s.EVMStakingKeeper.SetParams(s.Ctx, params)
+
+			queueLen := s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx)
+
+			// Peek the withdrawals
+			result, err := s.EVMStakingKeeper.PeekEligibleWithdrawals(s.Ctx)
+			s.NoError(err)
+			s.Equal(tc.expectedLen, len(result))
+
+			// Peek does not change the queue length
+			s.Equal(queueLen, s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+
+			// Validate the content of the dequeued withdrawals
+			for i, w := range result {
+				s.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
+				s.Equal(tc.expected[i].Amount, w.Amount)
+			}
+		})
+	}
+}
+
+func (s *TestSuite) TestGetAllWithdrawals() {
+	s.initQueue()
+
+	// Add a withdrawal to the queue
+	withdrawal := types.NewWithdrawal(1, delAddr, valAddr, evmAddr.String(), 100)
+	err := s.EVMStakingKeeper.AddWithdrawalToQueue(s.Ctx, withdrawal)
+	s.NoError(err)
+
+	// Get all withdrawals
+	result, err := s.EVMStakingKeeper.GetAllWithdrawals(s.Ctx)
+	s.NoError(err)
+	s.Equal(1, len(result))
+	s.Equal(withdrawal, result[0])
+}
+
+func (s *TestSuite) TestGetWithdrawals() {
+	s.initQueue()
+	s.addWithdrawals(withdrawals)
+
+	testCases := []struct {
+		name        string
+		maxRetrieve uint32
+		expectedLen int
+	}{
+		{
+			name:        "retrieve all",
+			maxRetrieve: uint32(len(withdrawals)),
+			expectedLen: len(withdrawals),
+		},
+		{
+			name:        "retrieve 0",
+			maxRetrieve: 0,
+			expectedLen: 0,
+		},
+		{
+			name:        "retrieve 1",
+			maxRetrieve: 1,
+			expectedLen: 1,
+		},
+		{
+			name:        "retrieve 2",
+			maxRetrieve: 2,
+			expectedLen: 2,
+		},
+		{
+			name:        "retrieve more than available",
+			maxRetrieve: 10,
+			expectedLen: len(withdrawals),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			result, err := s.EVMStakingKeeper.GetWithdrawals(s.Ctx, tc.maxRetrieve)
+			s.NoError(err)
+			s.Equal(tc.expectedLen, len(result))
+			// check contents
+			for i := 0; i < tc.expectedLen; i++ {
+				s.Equal(withdrawals[i], result[i])
+			}
+		})
+	}
+}

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"context"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -88,7 +89,7 @@ func (s *TestSuite) TestDequeueEligibleWithdrawals() {
 		s.Run(tc.name, func() {
 			s.initQueue()
 
-			if tc.name != "Dequeue with empty queue" {
+			if !strings.Contains(tc.name, "Dequeue with empty queue") {
 				s.addWithdrawals(withdrawals)
 			}
 
@@ -158,7 +159,7 @@ func (s *TestSuite) TestPeekEligibleWithdrawals() {
 	for _, tc := range tcs {
 		s.Run(tc.name, func() {
 			s.initQueue()
-			if tc.name != "Peek with empty queue" {
+			if !strings.Contains(tc.name, "Peek with empty queue") {
 				s.addWithdrawals(withdrawals)
 			}
 

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -59,19 +59,19 @@ func (s *TestSuite) TestDequeueEligibleWithdrawals() {
 		expected    []types.Withdrawal
 	}{
 		{
-			name:        "Dequeue 1 withdrawal (have: 3, cap: 1)",
+			name:        "Dequeue 1 withdrawal",
 			maxDequeue:  1,
 			expectedLen: 1,
 			expected:    withdrawals[:1],
 		},
 		{
-			name:        "Dequeue 2 withdrawals (have: 3, cap: 2)",
+			name:        "Dequeue 2 withdrawals",
 			maxDequeue:  2,
 			expectedLen: 2,
 			expected:    withdrawals[:2],
 		},
 		{
-			name:        "Dequeue all withdrawals because maxDequeue is more than available",
+			name:        "Dequeue more than available",
 			maxDequeue:  10,
 			expectedLen: len(withdrawals),
 			expected:    withdrawals,
@@ -122,6 +122,7 @@ func (s *TestSuite) TestDequeueEligibleWithdrawals() {
 }
 
 func (s *TestSuite) TestPeekEligibleWithdrawals() {
+	require := s.Require()
 	tcs := []struct {
 		name        string
 		maxDequeue  uint32
@@ -163,25 +164,25 @@ func (s *TestSuite) TestPeekEligibleWithdrawals() {
 
 			// Set max dequeue parameter
 			params, err := s.EVMStakingKeeper.GetParams(s.Ctx)
-			s.NoError(err)
+			require.NoError(err)
 			params.MaxWithdrawalPerBlock = tc.maxDequeue
 			err = s.EVMStakingKeeper.SetParams(s.Ctx, params)
-			s.NoError(err)
+			require.NoError(err)
 
 			queueLen := s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx)
 
 			// Peek the withdrawals
 			result, err := s.EVMStakingKeeper.PeekEligibleWithdrawals(s.Ctx)
-			s.NoError(err)
-			s.Equal(tc.expectedLen, len(result))
+			require.NoError(err)
+			require.Equal(tc.expectedLen, len(result))
 
 			// Peek does not change the queue length
-			s.Equal(queueLen, s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+			require.Equal(queueLen, s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
 
 			// Validate the content of the dequeued withdrawals
 			for i, w := range result {
-				s.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
-				s.Equal(tc.expected[i].Amount, w.Amount)
+				require.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
+				require.Equal(tc.expected[i].Amount, w.Amount)
 			}
 		})
 	}

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -130,25 +130,25 @@ func (s *TestSuite) TestPeekEligibleWithdrawals() {
 		expected    []types.Withdrawal
 	}{
 		{
-			name:        "Peek 1 withdrawal",
+			name:        "Peek 1 withdrawal (have: 3, cap: 1)",
 			maxDequeue:  1,
 			expectedLen: 1,
 			expected:    withdrawals[:1],
 		},
 		{
-			name:        "Peek 2 withdrawals",
+			name:        "Peek 2 withdrawals (have: 3, cap: 2)",
 			maxDequeue:  2,
 			expectedLen: 2,
 			expected:    withdrawals[:2],
 		},
 		{
-			name:        "Peek more than available",
+			name:        "Peek more than available (have: 3, cap: 10)",
 			maxDequeue:  10,
 			expectedLen: len(withdrawals),
 			expected:    withdrawals,
 		},
 		{
-			name:        "Peek with empty queue",
+			name:        "Peek with empty queue (have: 0, cap: 3)",
 			maxDequeue:  3,
 			expectedLen: 0,
 			expected:    []types.Withdrawal{},

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -59,25 +59,25 @@ func (s *TestSuite) TestDequeueEligibleWithdrawals() {
 		expected    []types.Withdrawal
 	}{
 		{
-			name:        "Dequeue 1 withdrawal",
+			name:        "Dequeue 1 withdrawal (have: 3, cap: 1)",
 			maxDequeue:  1,
 			expectedLen: 1,
 			expected:    withdrawals[:1],
 		},
 		{
-			name:        "Dequeue 2 withdrawals",
+			name:        "Dequeue 2 withdrawals (have: 3, cap: 2)",
 			maxDequeue:  2,
 			expectedLen: 2,
 			expected:    withdrawals[:2],
 		},
 		{
-			name:        "Dequeue more than available",
+			name:        "Dequeue all withdrawals (have: 3, cap: 10)",
 			maxDequeue:  10,
 			expectedLen: len(withdrawals),
 			expected:    withdrawals,
 		},
 		{
-			name:        "Dequeue with empty queue",
+			name:        "Dequeue with empty queue (have: 0, cap: 3)",
 			maxDequeue:  3,
 			expectedLen: 0,
 			expected:    []types.Withdrawal{},

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -20,34 +20,38 @@ var (
 )
 
 func (s *TestSuite) initQueue() {
+	require := s.Require()
 	err := s.EVMStakingKeeper.WithdrawalQueue.Initialize(s.Ctx)
-	s.NoError(err)
-	s.Equal(uint64(0), s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+	require.NoError(err)
+	require.Equal(uint64(0), s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
 }
 
 func (s *TestSuite) addWithdrawals(withdrawals []types.Withdrawal) {
+	require := s.Require()
 	for _, w := range withdrawals {
 		err := s.EVMStakingKeeper.AddWithdrawalToQueue(s.Ctx, w)
-		s.NoError(err)
+		require.NoError(err)
 	}
 }
 
 func (s *TestSuite) TestAddWithdrawalToQueue() {
+	require := s.Require()
 	s.initQueue()
 
 	// Add a withdrawal to the queue
 	withdrawal := types.NewWithdrawal(1, delAddr, valAddr, evmAddr.String(), 100)
 	err := s.EVMStakingKeeper.AddWithdrawalToQueue(s.Ctx, withdrawal)
-	s.NoError(err)
+	require.NoError(err)
 
 	// Check the withdrawal is in the queue
-	s.Equal(uint64(1), s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+	require.Equal(uint64(1), s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
 	elem, err := s.EVMStakingKeeper.WithdrawalQueue.Get(s.Ctx, 0)
-	s.NoError(err)
-	s.Equal(withdrawal, elem)
+	require.NoError(err)
+	require.Equal(withdrawal, elem)
 }
 
 func (s *TestSuite) TestDequeueEligibleWithdrawals() {
+	require := s.Require()
 	tcs := []struct {
 		name        string
 		maxDequeue  uint32
@@ -90,34 +94,35 @@ func (s *TestSuite) TestDequeueEligibleWithdrawals() {
 
 			// Set max dequeue parameter
 			params, err := s.EVMStakingKeeper.GetParams(s.Ctx)
-			s.NoError(err)
+			require.NoError(err)
 			params.MaxWithdrawalPerBlock = tc.maxDequeue
 			err = s.EVMStakingKeeper.SetParams(s.Ctx, params)
-			s.NoError(err)
+			require.NoError(err)
 
 			queueLen := s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx)
 
 			// Dequeue the withdrawals
 			result, err := s.EVMStakingKeeper.DequeueEligibleWithdrawals(s.Ctx)
-			s.NoError(err)
-			s.Equal(tc.expectedLen, len(result))
+			require.NoError(err)
+			require.Equal(tc.expectedLen, len(result))
 
 			// Check Queue length is decreased by the number of dequeued withdrawals
-			s.Equal(
+			require.Equal(
 				queueLen-uint64(tc.expectedLen),
 				s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx),
 			)
 
 			// Validate the content of the dequeued withdrawals
 			for i, w := range result {
-				s.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
-				s.Equal(tc.expected[i].Amount, w.Amount)
+				require.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
+				require.Equal(tc.expected[i].Amount, w.Amount)
 			}
 		})
 	}
 }
 
 func (s *TestSuite) TestPeekEligibleWithdrawals() {
+	require := s.Require()
 	tcs := []struct {
 		name        string
 		maxDequeue  uint32
@@ -159,25 +164,25 @@ func (s *TestSuite) TestPeekEligibleWithdrawals() {
 
 			// Set max dequeue parameter
 			params, err := s.EVMStakingKeeper.GetParams(s.Ctx)
-			s.NoError(err)
+			require.NoError(err)
 			params.MaxWithdrawalPerBlock = tc.maxDequeue
 			err = s.EVMStakingKeeper.SetParams(s.Ctx, params)
-			s.NoError(err)
+			require.NoError(err)
 
 			queueLen := s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx)
 
 			// Peek the withdrawals
 			result, err := s.EVMStakingKeeper.PeekEligibleWithdrawals(s.Ctx)
-			s.NoError(err)
-			s.Equal(tc.expectedLen, len(result))
+			require.NoError(err)
+			require.Equal(tc.expectedLen, len(result))
 
 			// Peek does not change the queue length
-			s.Equal(queueLen, s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
+			require.Equal(queueLen, s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx))
 
 			// Validate the content of the dequeued withdrawals
 			for i, w := range result {
-				s.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
-				s.Equal(tc.expected[i].Amount, w.Amount)
+				require.Equal(tc.expected[i].ExecutionAddress, w.Address.String())
+				require.Equal(tc.expected[i].Amount, w.Amount)
 			}
 		})
 	}
@@ -233,6 +238,7 @@ func (s *TestSuite) TestGetAllWithdrawals() {
 }
 
 func (s *TestSuite) TestGetWithdrawals() {
+	require := s.Require()
 	s.initQueue()
 	s.addWithdrawals(withdrawals)
 
@@ -271,11 +277,11 @@ func (s *TestSuite) TestGetWithdrawals() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			result, err := s.EVMStakingKeeper.GetWithdrawals(s.Ctx, tc.maxRetrieve)
-			s.NoError(err)
-			s.Equal(tc.expectedLen, len(result))
+			require.NoError(err)
+			require.Equal(tc.expectedLen, len(result))
 			// check contents
 			for i := range result[:tc.expectedLen] {
-				s.Equal(withdrawals[i], result[i])
+				require.Equal(withdrawals[i], result[i])
 			}
 		})
 	}

--- a/client/x/evmstaking/keeper/withdrawal_queue_test.go
+++ b/client/x/evmstaking/keeper/withdrawal_queue_test.go
@@ -160,6 +160,7 @@ func (s *TestSuite) TestPeekEligibleWithdrawals() {
 			s.NoError(err)
 			params.MaxWithdrawalPerBlock = tc.maxDequeue
 			err = s.EVMStakingKeeper.SetParams(s.Ctx, params)
+			s.NoError(err)
 
 			queueLen := s.EVMStakingKeeper.WithdrawalQueue.Len(s.Ctx)
 
@@ -237,7 +238,7 @@ func (s *TestSuite) TestGetWithdrawals() {
 			s.NoError(err)
 			s.Equal(tc.expectedLen, len(result))
 			// check contents
-			for i := 0; i < tc.expectedLen; i++ {
+			for i := range result[:tc.expectedLen] {
 				s.Equal(withdrawals[i], result[i])
 			}
 		})


### PR DESCRIPTION
Increased test coverage of [client/x/evmstaking/keeper/withdrawal_queue.go](https://github.com/piplabs/story/blob/main/client/x/evmstaking/keeper/withdrawal_queue.go) from 0% to 78.8%
- **What's Covered**
  - All application logic written on the Story side, excluding the SDK.
- **What’s Not Covered (Edge Cases Related to the SDK)**
  - Failed to get paramstore: this could occur if the param store is broken or not initialized properly.
  - Failures related to collections: this includes potential failures during KV store iteration.

**changes:**
- `s.addrs`: create accounts should be called after setting bech32 prefix correctly, unless it has cosmos prefix.
- `accountKeeper.EXPECT().GetModuleAddress`
  - it is more natural for returning fixed module addresses instead of randomly created account's addresses.
- `codec`: consensusAddrCodec must be prefixed with `storycons`, not `storyvaloper`

issue: #64 