### PR TITLE
test(evmstaking/keeper): add test cases for set address

### DIFF
--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -78,8 +78,6 @@ func (s *TestSuite) SetupTest() {
 	cfg.SetBech32PrefixForAccount("story", "storypub")
 	cfg.SetBech32PrefixForValidator("storyvaloper", "storyvaloperpub")
 	cfg.SetBech32PrefixForConsensusNode("storyvalcons", "storyvalconspub")
-	// it should be called after setting the bech32 prefix correctly
-	s.addrs = simtestutil.CreateIncrementalAccounts(4)
 
 	// gomock initializations
 	ctrl := gomock.NewController(s.T())

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -78,6 +78,8 @@ func (s *TestSuite) SetupTest() {
 	cfg.SetBech32PrefixForAccount("story", "storypub")
 	cfg.SetBech32PrefixForValidator("storyvaloper", "storyvaloperpub")
 	cfg.SetBech32PrefixForConsensusNode("storyvalcons", "storyvalconspub")
+	// it should be called after setting the bech32 prefix correctly
+	s.addrs = simtestutil.CreateIncrementalAccounts(4)
 
 	// gomock initializations
 	ctrl := gomock.NewController(s.T())

--- a/client/x/evmstaking/keeper/set_address_test.go
+++ b/client/x/evmstaking/keeper/set_address_test.go
@@ -67,7 +67,6 @@ func (s *TestSuite) TestProcessSetWithdrawalAddress() {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		s.Run(tc.name, func() {
 			evmAddr := execAddr
 			if !tc.sameAddr {

--- a/client/x/evmstaking/keeper/set_address_test.go
+++ b/client/x/evmstaking/keeper/set_address_test.go
@@ -1,0 +1,94 @@
+package keeper_test
+
+import (
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/piplabs/story/contracts/bindings"
+	"github.com/piplabs/story/lib/k1util"
+)
+
+func (s *TestSuite) TestProcessSetWithdrawalAddress() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+
+	pubKeys, accAddrs, _ := createAddresses(2)
+	delAddr := accAddrs[0]
+	delPubKey := pubKeys[0]
+	corruptedPubKey := delPubKey.Bytes()[0:20]
+
+	execAddr, err := k1util.CosmosPubkeyToEVMAddress(delPubKey.Bytes())
+	require.NoError(err)
+	anotherExecAddr, err := k1util.CosmosPubkeyToEVMAddress(pubKeys[1].Bytes())
+	require.NoError(err)
+
+	tcs := []struct {
+		name          string
+		sameAddr      bool
+		input         func(execAddr common.Address, pubKey crypto.PubKey) *bindings.IPTokenStakingSetWithdrawalAddress
+		expectedError string
+	}{
+		{
+			name:     "pass: same delegator and execution address",
+			sameAddr: true,
+			input: func(execAddr common.Address, pubKey crypto.PubKey) *bindings.IPTokenStakingSetWithdrawalAddress {
+				paddedExecAddr := common.LeftPadBytes(execAddr.Bytes(), 32)
+				return &bindings.IPTokenStakingSetWithdrawalAddress{
+					DelegatorCmpPubkey: pubKey.Bytes(),
+					ExecutionAddress:   [32]byte(paddedExecAddr),
+				}
+			},
+			expectedError: "",
+		},
+		{
+			name:     "pass: same delegator and different execution address",
+			sameAddr: false,
+			input: func(execAddr common.Address, pubKey crypto.PubKey) *bindings.IPTokenStakingSetWithdrawalAddress {
+				paddedExecAddr := common.LeftPadBytes(execAddr.Bytes(), 32)
+				return &bindings.IPTokenStakingSetWithdrawalAddress{
+					DelegatorCmpPubkey: pubKey.Bytes(),
+					ExecutionAddress:   [32]byte(paddedExecAddr),
+				}
+			},
+			expectedError: "",
+		},
+		{
+			name:     "fail: delegator key is corrupted",
+			sameAddr: false,
+			input: func(execAddr common.Address, pubKey crypto.PubKey) *bindings.IPTokenStakingSetWithdrawalAddress {
+				paddedExecAddr := common.LeftPadBytes(execAddr.Bytes(), 32)
+				return &bindings.IPTokenStakingSetWithdrawalAddress{
+					DelegatorCmpPubkey: corruptedPubKey,
+					ExecutionAddress:   [32]byte(paddedExecAddr),
+				}
+			},
+			expectedError: "depositor pubkey to cosmos",
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		s.Run(tc.name, func() {
+			var ev *bindings.IPTokenStakingSetWithdrawalAddress
+			evmAddr := execAddr
+			if !tc.sameAddr {
+			} else {
+				evmAddr = anotherExecAddr
+			}
+			ev = tc.input(evmAddr, pubKeys[0])
+
+			// Process the event
+			err := keeper.ProcessSetWithdrawalAddress(ctx, ev)
+			if tc.expectedError != "" {
+				require.Error(err)
+				require.Contains(err.Error(), tc.expectedError)
+			} else {
+				require.NoError(err)
+				// check result
+				addr, err := keeper.DelegatorMap.Get(ctx, delAddr.String())
+				require.NoError(err)
+				require.Equal(evmAddr.String(), addr)
+			}
+		})
+	}
+}

--- a/client/x/evmstaking/keeper/set_address_test.go
+++ b/client/x/evmstaking/keeper/set_address_test.go
@@ -70,7 +70,7 @@ func (s *TestSuite) TestProcessSetWithdrawalAddress() {
 		tc := tc
 		s.Run(tc.name, func() {
 			evmAddr := execAddr
-			if tc.sameAddr {
+			if !tc.sameAddr {
 				evmAddr = anotherExecAddr
 			}
 			ev := tc.input(evmAddr, pubKeys[0])

--- a/client/x/evmstaking/keeper/set_address_test.go
+++ b/client/x/evmstaking/keeper/set_address_test.go
@@ -15,7 +15,7 @@ func (s *TestSuite) TestProcessSetWithdrawalAddress() {
 	pubKeys, accAddrs, _ := createAddresses(2)
 	delAddr := accAddrs[0]
 	delPubKey := pubKeys[0]
-	corruptedPubKey := delPubKey.Bytes()[0:20]
+	invalidPubKey := delPubKey.Bytes()[0:20]
 
 	execAddr, err := k1util.CosmosPubkeyToEVMAddress(delPubKey.Bytes())
 	require.NoError(err)
@@ -58,7 +58,7 @@ func (s *TestSuite) TestProcessSetWithdrawalAddress() {
 			input: func(execAddr common.Address, pubKey crypto.PubKey) *bindings.IPTokenStakingSetWithdrawalAddress {
 				paddedExecAddr := common.LeftPadBytes(execAddr.Bytes(), 32)
 				return &bindings.IPTokenStakingSetWithdrawalAddress{
-					DelegatorCmpPubkey: corruptedPubKey,
+					DelegatorCmpPubkey: invalidPubKey,
 					ExecutionAddress:   [32]byte(paddedExecAddr),
 				}
 			},


### PR DESCRIPTION
Increased test coverage from 0% to 87.5%
- **What's Covered**
  - Most application logics written on the Story side, excluding SDK.
- **What’s Not Covered (Edge Cases Related to the SDK)**
  - Failed to set of map (= collections)

issue: #64 