### PR TITLE
test(evmstaking/keeper): add test cases for staking queue

### DIFF
--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -83,6 +83,8 @@ func (s *TestSuite) SetupTest() {
 	cfg.SetBech32PrefixForAccount("story", "storypub")
 	cfg.SetBech32PrefixForValidator("storyvaloper", "storyvaloperpub")
 	cfg.SetBech32PrefixForConsensusNode("storyvalcons", "storyvalconspub")
+	// it should be called after setting the bech32 prefix correctly
+	s.addrs = simtestutil.CreateIncrementalAccounts(4)
 
 	// gomock initializations
 	ctrl := gomock.NewController(s.T())

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -83,8 +83,6 @@ func (s *TestSuite) SetupTest() {
 	cfg.SetBech32PrefixForAccount("story", "storypub")
 	cfg.SetBech32PrefixForValidator("storyvaloper", "storyvaloperpub")
 	cfg.SetBech32PrefixForConsensusNode("storyvalcons", "storyvalconspub")
-	// it should be called after setting the bech32 prefix correctly
-	s.addrs = simtestutil.CreateIncrementalAccounts(4)
 
 	// gomock initializations
 	ctrl := gomock.NewController(s.T())

--- a/client/x/evmstaking/keeper/staking_queue_test.go
+++ b/client/x/evmstaking/keeper/staking_queue_test.go
@@ -6,48 +6,11 @@ import (
 
 	"cosmossdk.io/math"
 
-	"github.com/cometbft/cometbft/crypto"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	skeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	"github.com/cosmos/cosmos-sdk/x/staking/testutil"
 	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
-	"github.com/piplabs/story/lib/k1util"
 
 	"go.uber.org/mock/gomock"
 )
-
-// setupValidatorAndDelegation creates a validator and delegation for testing.
-func (s *TestSuite) setupValidatorAndDelegation(ctx sdk.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress) {
-	require := s.Require()
-	bankKeeper, stakingKeeper, keeper := s.BankKeeper, s.StakingKeeper, s.EVMStakingKeeper
-
-	// Convert public key to cosmos format
-	valCosmosPubKey, err := k1util.PubKeyToCosmos(valPubKey)
-	require.NoError(err)
-
-	// Create and update validator
-	val := testutil.NewValidator(s.T(), valAddr, valCosmosPubKey)
-	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
-	validator, _ := val.AddTokensFromDel(valTokens)
-	bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
-	_ = skeeper.TestingUpdateValidator(stakingKeeper, ctx, validator, true)
-
-	// Create and set delegation
-	delAmt := stakingKeeper.TokensFromConsensusPower(ctx, 100).ToLegacyDec()
-	delegation := stypes.NewDelegation(delAddr.String(), valAddr.String(), delAmt)
-	require.NoError(stakingKeeper.SetDelegation(ctx, delegation))
-
-	// Map delegator to EVM address
-	delEvmAddr, err := k1util.CosmosPubkeyToEVMAddress(delPubKey.Bytes())
-	require.NoError(err)
-	require.NoError(keeper.DelegatorMap.Set(ctx, delAddr.String(), delEvmAddr.String()))
-
-	// Ensure delegation is set correctly
-	delegation, err = stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
-	require.NoError(err)
-	require.Equal(delAmt, delegation.GetShares())
-}
 
 // setupUnbonding creates unbondings for testing.
 func (s *TestSuite) setupUnbonding(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amount string) {
@@ -57,6 +20,16 @@ func (s *TestSuite) setupUnbonding(ctx context.Context, delAddr sdk.AccAddress, 
 	bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.BondedPoolName, stypes.NotBondedPoolName, gomock.Any())
 	_, _, err := stakingKeeper.Undelegate(ctx, delAddr, valAddr, math.LegacyMustNewDecFromStr(amount))
 	require.NoError(err)
+}
+
+// setupMaturedUnbonding creates matured unbondings for testing.
+func (s *TestSuite) setupMatureUnbonding(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt string, duration time.Duration) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	pastHeader := sdkCtx.BlockHeader()
+	pastHeader.Time = pastHeader.Time.Add(-duration).Add(-time.Minute)
+	pastCtx := sdkCtx.WithBlockHeader(pastHeader)
+
+	s.setupUnbonding(pastCtx, delAddr, valAddr, amt)
 }
 
 func (s *TestSuite) TestGetMatureUnbondedDelegations() {
@@ -74,12 +47,20 @@ func (s *TestSuite) TestGetMatureUnbondedDelegations() {
 	pubKeys, accAddrs, valAddrs := createAddresses(3)
 	delAddr := accAddrs[0]
 	delPubKey := pubKeys[0]
-	valPubKey := pubKeys[1]
-	valAddr := valAddrs[1]
+	valPubKey1 := pubKeys[1]
+	valAddr1 := valAddrs[1]
 	valPubKey2 := pubKeys[2]
 	valAddr2 := valAddrs[2]
-	s.setupValidatorAndDelegation(ctx, valPubKey, delPubKey, valAddr, delAddr)
+	s.setupValidatorAndDelegation(ctx, valPubKey1, delPubKey, valAddr1, delAddr)
 	s.setupValidatorAndDelegation(ctx, valPubKey2, delPubKey, valAddr2, delAddr)
+
+	// set staking module's params
+	ubdTime := time.Duration(3600) * time.Second
+	stakingParams, err := stakingKeeper.GetParams(ctx)
+	require.NoError(err)
+	stakingParams.UnbondingTime = ubdTime
+	require.NoError(err)
+	require.NoError(stakingKeeper.SetParams(ctx, stakingParams))
 
 	tcs := []struct {
 		name           string
@@ -88,27 +69,31 @@ func (s *TestSuite) TestGetMatureUnbondedDelegations() {
 		expectedError  string
 	}{
 		{
-			name:           "pass: no unbondings",
+			name: "pass: no matured unbondings",
+			setUnbondings: func(c context.Context) {
+				s.setupUnbonding(c, delAddr, valAddr1, "100")
+				s.setupUnbonding(c, delAddr, valAddr2, "100")
+			},
 			expectedResult: nil,
 		},
 		{
-			name: "pass: one unbonding",
+			name: "pass: one mautred and one not matured unbonding",
 			setUnbondings: func(c context.Context) {
-				s.setupUnbonding(c, delAddr, valAddr, "100")
+				s.setupMatureUnbonding(c, delAddr, valAddr1, "100", ubdTime)
+				s.setupUnbonding(c, delAddr, valAddr2, "100")
 			},
 			expectedResult: []stypes.DVPair{
-				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr.String()},
+				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr1.String()},
 			},
 		},
 		{
-			name: "pass: multiple unbondings",
+			name: "pass: two matured unbondings",
 			setUnbondings: func(c context.Context) {
-				// Set up multiple unbondings
-				s.setupUnbonding(c, delAddr, valAddr, "50")
-				s.setupUnbonding(c, delAddr, valAddr2, "50")
+				s.setupMatureUnbonding(c, delAddr, valAddr1, "100", ubdTime)
+				s.setupMatureUnbonding(c, delAddr, valAddr2, "100", ubdTime)
 			},
 			expectedResult: []stypes.DVPair{
-				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr.String()},
+				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr1.String()},
 				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr2.String()},
 			},
 		},
@@ -121,10 +106,7 @@ func (s *TestSuite) TestGetMatureUnbondedDelegations() {
 				tc.setUnbondings(cachedCtx)
 			}
 
-			// Set block time to be after unbonding period
-			header := cachedCtx.BlockHeader()
-			header.Time = header.Time.Add(params.UnbondingTime).Add(24 * time.Hour)
-			result, err := keeper.GetMatureUnbondedDelegations(cachedCtx.WithBlockHeader(header))
+			result, err := keeper.GetMatureUnbondedDelegations(cachedCtx)
 
 			// Run the test
 			if tc.expectedError != "" {

--- a/client/x/evmstaking/keeper/staking_queue_test.go
+++ b/client/x/evmstaking/keeper/staking_queue_test.go
@@ -1,0 +1,136 @@
+package keeper_test
+
+import (
+	"context"
+	"time"
+
+	"cosmossdk.io/math"
+	"github.com/cometbft/cometbft/crypto"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	skeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/cosmos/cosmos-sdk/x/staking/testutil"
+	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"go.uber.org/mock/gomock"
+
+	"github.com/piplabs/story/lib/k1util"
+)
+
+// setupValidatorAndDelegation creates a validator and delegation for testing
+func (s *TestSuite) setupValidatorAndDelegation(ctx sdk.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress) {
+	require := s.Require()
+	bankKeeper, stakingKeeper, keeper := s.BankKeeper, s.StakingKeeper, s.EVMStakingKeeper
+
+	// Convert public key to cosmos format
+	valCosmosPubKey, err := k1util.PubKeyToCosmos(valPubKey)
+	require.NoError(err)
+
+	// Create and update validator
+	val := testutil.NewValidator(s.T(), valAddr, valCosmosPubKey)
+	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
+	validator, _ := val.AddTokensFromDel(valTokens)
+	bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
+	_ = skeeper.TestingUpdateValidator(stakingKeeper, ctx, validator, true)
+
+	// Create and set delegation
+	delAmt := stakingKeeper.TokensFromConsensusPower(ctx, 100).ToLegacyDec()
+	delegation := stypes.NewDelegation(delAddr.String(), valAddr.String(), delAmt)
+	require.NoError(stakingKeeper.SetDelegation(ctx, delegation))
+
+	// Map delegator to EVM address
+	delEvmAddr, err := k1util.CosmosPubkeyToEVMAddress(delPubKey.Bytes())
+	require.NoError(err)
+	require.NoError(keeper.DelegatorMap.Set(ctx, delAddr.String(), delEvmAddr.String()))
+
+	// Ensure delegation is set correctly
+	delegation, err = stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
+	require.NoError(err)
+	require.Equal(delAmt, delegation.GetShares())
+}
+
+// setupUnbonding creates unbondings for testing
+func (s *TestSuite) setupUnbonding(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amount string) {
+	require := s.Require()
+	bankKeeper, stakingKeeper := s.BankKeeper, s.StakingKeeper
+
+	bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.BondedPoolName, stypes.NotBondedPoolName, gomock.Any())
+	_, _, err := stakingKeeper.Undelegate(ctx, delAddr, valAddr, math.LegacyMustNewDecFromStr(amount))
+	require.NoError(err)
+}
+
+func (s *TestSuite) TestGetMatureUnbondedDelegations() {
+	require := s.Require()
+	ctx, keeper, stakingKeeper := s.Ctx, s.EVMStakingKeeper, s.StakingKeeper
+
+	// Setup unbonding period
+	params, err := stakingKeeper.GetParams(ctx)
+	require.NoError(err)
+	params.UnbondingTime, err = time.ParseDuration("3600s")
+	require.NoError(err)
+	require.NoError(stakingKeeper.SetParams(ctx, params))
+
+	// Setup 2 validators
+	pubKeys, accAddrs, valAddrs := createAddresses(3)
+	delAddr := accAddrs[0]
+	delPubKey := pubKeys[0]
+	valPubKey := pubKeys[1]
+	valAddr := valAddrs[1]
+	valPubKey2 := pubKeys[2]
+	valAddr2 := valAddrs[2]
+	s.setupValidatorAndDelegation(ctx, valPubKey, delPubKey, valAddr, delAddr)
+	s.setupValidatorAndDelegation(ctx, valPubKey2, delPubKey, valAddr2, delAddr)
+
+	tcs := []struct {
+		name           string
+		setUnbondings  func(c context.Context)
+		expectedResult []stypes.DVPair
+		expectedError  string
+	}{
+		{
+			name:           "pass: no unbondings",
+			expectedResult: nil,
+		},
+		{
+			name: "pass: one unbonding",
+			setUnbondings: func(c context.Context) {
+				s.setupUnbonding(c, delAddr, valAddr, "100")
+			},
+			expectedResult: []stypes.DVPair{
+				{delAddr.String(), valAddr.String()},
+			},
+		},
+		{
+			name: "pass: multiple unbondings",
+			setUnbondings: func(c context.Context) {
+				// Set up multiple unbondings
+				s.setupUnbonding(c, delAddr, valAddr, "50")
+				s.setupUnbonding(c, delAddr, valAddr2, "50")
+			},
+			expectedResult: []stypes.DVPair{
+				{delAddr.String(), valAddr.String()},
+				{delAddr.String(), valAddr2.String()},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		s.Run(tc.name, func() {
+			cachedCtx, _ := ctx.CacheContext()
+			if tc.setUnbondings != nil {
+				tc.setUnbondings(cachedCtx)
+			}
+
+			// Set block time to be after unbonding period
+			header := cachedCtx.BlockHeader()
+			header.Time = header.Time.Add(params.UnbondingTime).Add(24 * time.Hour)
+			result, err := keeper.GetMatureUnbondedDelegations(cachedCtx.WithBlockHeader(header))
+
+			// Run the test
+			if tc.expectedError != "" {
+				require.ErrorContains(err, tc.expectedError)
+			} else {
+				require.NoError(err)
+				require.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}

--- a/client/x/evmstaking/keeper/staking_queue_test.go
+++ b/client/x/evmstaking/keeper/staking_queue_test.go
@@ -5,17 +5,19 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+
 	"github.com/cometbft/cometbft/crypto"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	skeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/cosmos/cosmos-sdk/x/staking/testutil"
 	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"go.uber.org/mock/gomock"
 
 	"github.com/piplabs/story/lib/k1util"
+
+	"go.uber.org/mock/gomock"
 )
 
-// setupValidatorAndDelegation creates a validator and delegation for testing
+// setupValidatorAndDelegation creates a validator and delegation for testing.
 func (s *TestSuite) setupValidatorAndDelegation(ctx sdk.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress) {
 	require := s.Require()
 	bankKeeper, stakingKeeper, keeper := s.BankKeeper, s.StakingKeeper, s.EVMStakingKeeper

--- a/client/x/evmstaking/keeper/staking_queue_test.go
+++ b/client/x/evmstaking/keeper/staking_queue_test.go
@@ -49,7 +49,7 @@ func (s *TestSuite) setupValidatorAndDelegation(ctx sdk.Context, valPubKey, delP
 	require.Equal(delAmt, delegation.GetShares())
 }
 
-// setupUnbonding creates unbondings for testing
+// setupUnbonding creates unbondings for testing.
 func (s *TestSuite) setupUnbonding(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amount string) {
 	require := s.Require()
 	bankKeeper, stakingKeeper := s.BankKeeper, s.StakingKeeper
@@ -97,7 +97,7 @@ func (s *TestSuite) TestGetMatureUnbondedDelegations() {
 				s.setupUnbonding(c, delAddr, valAddr, "100")
 			},
 			expectedResult: []stypes.DVPair{
-				{delAddr.String(), valAddr.String()},
+				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr.String()},
 			},
 		},
 		{
@@ -108,8 +108,8 @@ func (s *TestSuite) TestGetMatureUnbondedDelegations() {
 				s.setupUnbonding(c, delAddr, valAddr2, "50")
 			},
 			expectedResult: []stypes.DVPair{
-				{delAddr.String(), valAddr.String()},
-				{delAddr.String(), valAddr2.String()},
+				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr.String()},
+				{DelegatorAddress: delAddr.String(), ValidatorAddress: valAddr2.String()},
 			},
 		},
 	}

--- a/client/x/evmstaking/keeper/staking_queue_test.go
+++ b/client/x/evmstaking/keeper/staking_queue_test.go
@@ -77,7 +77,7 @@ func (s *TestSuite) TestGetMatureUnbondedDelegations() {
 			expectedResult: nil,
 		},
 		{
-			name: "pass: one mautred and one not matured unbonding",
+			name: "pass: one matured and one not matured unbonding",
 			setUnbondings: func(c context.Context) {
 				s.setupMatureUnbonding(c, delAddr, valAddr1, "100", ubdTime)
 				s.setupUnbonding(c, delAddr, valAddr2, "100")


### PR DESCRIPTION
Increased test coverage from 0% to 84.6%
- **What's Covered**
  - Most application logics written on the Story side, excluding SDK.
- **What’s Not Covered (Edge Cases Related to the SDK)**
  - failed to get iterator
  - failed to unmarshal

issue: #64 
