### PR TITLE
test(evmstaking/keeper): add test cases for keeper

### DIFF
--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -571,7 +571,6 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				s.setupValidatorAndDelegation(c, valPubKey1, delPubKey, valAddr1, delAddr)
 				accountKeeper.EXPECT().HasAccount(c, delAddr).Return(true)
 				bankKeeper.EXPECT().SendCoinsFromModuleToModule(c, stypes.BondedPoolName, stypes.NotBondedPoolName, gomock.Any())
-
 			},
 			stateCheck: func(c context.Context) {
 				_, err = stakingKeeper.GetUnbondingDelegation(c, delAddr, valAddr1)

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -183,6 +183,20 @@ func (s *TestSuite) TestProcessStakingEvents() {
 		setup         func(c context.Context)
 		expectedError string
 	}{
+		{
+			name: "fail: invalid evm event",
+			evmEvents: func() ([]*evmenginetypes.EVMEvent, error) {
+				logs := []ethtypes.Log{{Topics: []common.Hash{types.SetWithdrawalAddress.ID, dummyHash}}}
+				evmEvents, err := ethLogsToEvmEvents(logs)
+				if err != nil {
+					return nil, err
+				}
+				evmEvents[0].Address = nil
+
+				return evmEvents, nil
+			},
+			expectedError: "verify log [BUG]",
+		},
 		// INVALID LOGS but PASS Cases because currently we are handling it as a continued
 		{
 			name: "pass(continue): invalid SetWithdrawalEvent log",

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -206,6 +206,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -217,6 +218,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -228,6 +230,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -239,6 +242,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -250,6 +254,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -261,6 +266,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -281,6 +287,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -302,6 +309,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -320,6 +328,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -338,6 +347,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -355,6 +365,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},
@@ -369,6 +380,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				if err != nil {
 					return nil, err
 				}
+
 				return evmEvents, nil
 			},
 		},


### PR DESCRIPTION
increased coverage from 11.4% to 94.3%

covered:
- almost every code paths of `ProcessStakingEvents`
- previous not-covered methods (= `Logger`, `Keeper.GetAuthority`, `Keeper.ValidatorAddressCodec`)

not covered:
- panic cases during NewKeeper (e.g. binding contracts fails, address codec broken, etc...) 

changes:
- move common test helper function `createCorruptedPubKey` to from `withdraw_test` to `keeper_test`

issue: #64 