### PR TITLE
test(evmstaking/keeper): add test cases for redelegation

### DIFF
--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -197,6 +197,8 @@ func (s *TestSuite) TestProcessStakingEvents() {
 	gwei, exp := big.NewInt(10), big.NewInt(9)
 	gwei.Exp(gwei, exp, nil)
 	delAmtGwei := new(big.Int).Mul(gwei, new(big.Int).SetUint64(delCoin.Amount.Uint64()))
+	// self delegation amount
+	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
 
 	tcs := []struct {
 		name           string
@@ -495,7 +497,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				return evmEvents, nil
 			},
 			setup: func(c context.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey1, delPubKey, valAddr1, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey1, delPubKey, valAddr1, delAddr, valTokens)
 				accountKeeper.EXPECT().HasAccount(c, delAddr).Return(true)
 				bankKeeper.EXPECT().MintCoins(c, types.ModuleName, sdk.NewCoins(delCoin))
 				bankKeeper.EXPECT().SendCoinsFromModuleToAccount(c, types.ModuleName, delAddr, sdk.NewCoins(delCoin))
@@ -534,8 +536,8 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				return evmEvents, nil
 			},
 			setup: func(c context.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey1, delPubKey, valAddr1, delAddr)
-				s.setupValidatorAndDelegation(c, valPubKey2, delPubKey, valAddr2, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey1, delPubKey, valAddr1, delAddr, valTokens)
+				s.setupValidatorAndDelegation(c, valPubKey2, delPubKey, valAddr2, delAddr, valTokens)
 			},
 			stateCheck: func(c context.Context) {
 				_, err = stakingKeeper.GetRedelegation(c, delAddr, valAddr1, valAddr2)
@@ -568,7 +570,7 @@ func (s *TestSuite) TestProcessStakingEvents() {
 				return evmEvents, nil
 			},
 			setup: func(c context.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey1, delPubKey, valAddr1, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey1, delPubKey, valAddr1, delAddr, valTokens)
 				accountKeeper.EXPECT().HasAccount(c, delAddr).Return(true)
 				bankKeeper.EXPECT().SendCoinsFromModuleToModule(c, stypes.BondedPoolName, stypes.NotBondedPoolName, gomock.Any())
 			},
@@ -637,7 +639,8 @@ func TestTestSuite(t *testing.T) {
 }
 
 // setupValidatorAndDelegation creates a validator and delegation for testing.
-func (s *TestSuite) setupValidatorAndDelegation(ctx sdk.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress, valTokens sdkmath.Int) {
+func (s *TestSuite) setupValidatorAndDelegation(ctx context.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress, valTokens sdkmath.Int) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	require := s.Require()
 	stakingKeeper := s.StakingKeeper
 	keeper := s.EVMStakingKeeper
@@ -650,7 +653,7 @@ func (s *TestSuite) setupValidatorAndDelegation(ctx sdk.Context, valPubKey, delP
 	val := testutil.NewValidator(s.T(), valAddr, valCosmosPubKey)
 	validator, _ := val.AddTokensFromDel(valTokens)
 	s.BankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
-	_ = skeeper.TestingUpdateValidator(stakingKeeper, ctx, validator, true)
+	_ = skeeper.TestingUpdateValidator(stakingKeeper, sdkCtx, validator, true)
 
 	// Create and set delegation
 	delAmt := stakingKeeper.TokensFromConsensusPower(ctx, 100).ToLegacyDec()

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -637,10 +637,10 @@ func TestTestSuite(t *testing.T) {
 }
 
 // setupValidatorAndDelegation creates a validator and delegation for testing.
-func (s *TestSuite) setupValidatorAndDelegation(ctx context.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress) {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
+func (s *TestSuite) setupValidatorAndDelegation(ctx sdk.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress, valTokens sdkmath.Int) {
 	require := s.Require()
-	bankKeeper, stakingKeeper, keeper := s.BankKeeper, s.StakingKeeper, s.EVMStakingKeeper
+	stakingKeeper := s.StakingKeeper
+	keeper := s.EVMStakingKeeper
 
 	// Convert public key to cosmos format
 	valCosmosPubKey, err := k1util.PubKeyToCosmos(valPubKey)
@@ -648,10 +648,9 @@ func (s *TestSuite) setupValidatorAndDelegation(ctx context.Context, valPubKey, 
 
 	// Create and update validator
 	val := testutil.NewValidator(s.T(), valAddr, valCosmosPubKey)
-	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
 	validator, _ := val.AddTokensFromDel(valTokens)
-	bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
-	_ = skeeper.TestingUpdateValidator(stakingKeeper, sdkCtx, validator, true)
+	s.BankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
+	_ = skeeper.TestingUpdateValidator(stakingKeeper, ctx, validator, true)
 
 	// Create and set delegation
 	delAmt := stakingKeeper.TokensFromConsensusPower(ctx, 100).ToLegacyDec()

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -642,8 +642,7 @@ func TestTestSuite(t *testing.T) {
 func (s *TestSuite) setupValidatorAndDelegation(ctx context.Context, valPubKey, delPubKey crypto.PubKey, valAddr sdk.ValAddress, delAddr sdk.AccAddress, valTokens sdkmath.Int) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	require := s.Require()
-	stakingKeeper := s.StakingKeeper
-	keeper := s.EVMStakingKeeper
+	bankKeeper, stakingKeeper, keeper := s.BankKeeper, s.StakingKeeper, s.EVMStakingKeeper
 
 	// Convert public key to cosmos format
 	valCosmosPubKey, err := k1util.PubKeyToCosmos(valPubKey)
@@ -652,7 +651,7 @@ func (s *TestSuite) setupValidatorAndDelegation(ctx context.Context, valPubKey, 
 	// Create and update validator
 	val := testutil.NewValidator(s.T(), valAddr, valCosmosPubKey)
 	validator, _ := val.AddTokensFromDel(valTokens)
-	s.BankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
+	bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
 	_ = skeeper.TestingUpdateValidator(stakingKeeper, sdkCtx, validator, true)
 
 	// Create and set delegation

--- a/client/x/evmstaking/keeper/msg_server_test.go
+++ b/client/x/evmstaking/keeper/msg_server_test.go
@@ -18,6 +18,9 @@ func (s *TestSuite) TestAddWithdrawal() {
 	valAddr := valAddrs[1]
 	valPubKey := pubKeys[1]
 
+	// self delegation
+	valTokens := s.StakingKeeper.TokensFromConsensusPower(ctx, 10)
+
 	tcs := []struct {
 		name          string
 		preRun        func(c context.Context)
@@ -71,7 +74,7 @@ func (s *TestSuite) TestAddWithdrawal() {
 		{
 			name: "fail: jailed validator",
 			preRun: func(c context.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey, delPubKey, valAddr, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey, delPubKey, valAddr, delAddr, valTokens)
 				validator, err := s.StakingKeeper.GetValidator(c, valAddr)
 				require.NoError(err)
 				validator.Jailed = true
@@ -89,7 +92,7 @@ func (s *TestSuite) TestAddWithdrawal() {
 		{
 			name: "fail: unbonded validator",
 			preRun: func(c context.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey, delPubKey, valAddr, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey, delPubKey, valAddr, delAddr, valTokens)
 				validator, err := s.StakingKeeper.GetValidator(c, valAddr)
 				require.NoError(err)
 				validator.Status = stypes.Unbonded
@@ -107,7 +110,7 @@ func (s *TestSuite) TestAddWithdrawal() {
 		{
 			name: "pass",
 			preRun: func(c context.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey, delPubKey, valAddr, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey, delPubKey, valAddr, delAddr, valTokens)
 			},
 			msg: &types.MsgAddWithdrawal{
 				Withdrawal: &types.Withdrawal{

--- a/client/x/evmstaking/keeper/redelegation_test.go
+++ b/client/x/evmstaking/keeper/redelegation_test.go
@@ -1,20 +1,17 @@
 package keeper_test
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/cometbft/cometbft/crypto"
 	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	skeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	"github.com/cosmos/cosmos-sdk/x/staking/testutil"
-	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/piplabs/story/client/x/evmstaking/types"
 	"github.com/piplabs/story/contracts/bindings"
-	"github.com/piplabs/story/lib/k1util"
-
-	"go.uber.org/mock/gomock"
 )
 
 func createAddresses(count int) ([]crypto.PubKey, []sdk.AccAddress, []sdk.ValAddress) {
@@ -40,33 +37,15 @@ func (s *TestSuite) TestRedelegation() {
 	// create addresses
 	pubKeys, accAddrs, valAddrs := createAddresses(3)
 	delAddr := accAddrs[0]
+	delPubKey := pubKeys[0]
+	valSrcPubKey := pubKeys[1]
 	valSrcAddr := valAddrs[1]
+	valDstPubKey := pubKeys[2]
 	valDstAddr := valAddrs[2]
 
-	// create a validator (src)
-	validatorSrc := testutil.NewValidator(s.T(), valSrcAddr, PKs[1])
-	require.NoError(stakingKeeper.SetValidatorByConsAddr(ctx, validatorSrc))
-
-	// delegate to the validator
 	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
-	validator, issuedShares := validatorSrc.AddTokensFromDel(valTokens)
-	require.Equal(valTokens, issuedShares.RoundInt())
-	s.BankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
-	_ = skeeper.TestingUpdateValidator(stakingKeeper, ctx, validator, true)
-	delegation := stypes.NewDelegation(delAddr.String(), valSrcAddr.String(), issuedShares)
-	require.NoError(stakingKeeper.SetDelegation(ctx, delegation))
-	delEvmAddr, err := k1util.CosmosPubkeyToEVMAddress(pubKeys[0].Bytes())
-	require.NoError(err)
-	require.NoError(keeper.DelegatorMap.Set(ctx, delAddr.String(), delEvmAddr.String()))
-
-	// create a second validator(dst) and delegate the same amount of token
-	validatorDst := testutil.NewValidator(s.T(), valDstAddr, PKs[1])
-	validatorDst, issuedShares = validatorDst.AddTokensFromDel(valTokens)
-	require.Equal(valTokens, issuedShares.RoundInt())
-	s.BankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stypes.NotBondedPoolName, stypes.BondedPoolName, gomock.Any())
-	_ = skeeper.TestingUpdateValidator(stakingKeeper, ctx, validatorDst, true)
-	delegation = stypes.NewDelegation(delAddr.String(), valDstAddr.String(), issuedShares)
-	require.NoError(stakingKeeper.SetDelegation(ctx, delegation))
+	s.setupValidatorAndDelegation(ctx, valSrcPubKey, delPubKey, valSrcAddr, delAddr, valTokens)
+	s.setupValidatorAndDelegation(ctx, valDstPubKey, delPubKey, valDstAddr, delAddr, valTokens)
 
 	// check the amount of delegated tokens
 	delSrc, err := stakingKeeper.GetDelegatorValidator(ctx, delAddr, valSrcAddr)
@@ -82,39 +61,172 @@ func (s *TestSuite) TestRedelegation() {
 	require.NoError(err)
 	require.False(has)
 
-	redelTokens := stakingKeeper.TokensFromConsensusPower(ctx, 5)
+	redelTokens := stakingKeeper.TokensFromConsensusPower(ctx, 5) // multiply power reduction of 1000000
+	validInput := &bindings.IPTokenStakingRedelegate{
+		DelegatorCmpPubkey: delPubKey.Bytes(),
+		ValidatorSrcPubkey: valSrcPubKey.Bytes(),
+		ValidatorDstPubkey: valDstPubKey.Bytes(),
+		Amount:             big.NewInt(redelTokens.Int64()),
+	}
+	checkStateAfterRedelegation := func(c context.Context) {
+		// check the amount of delegated tokens after redelegation
+		delSrc, err = stakingKeeper.GetDelegatorValidator(c, delAddr, valSrcAddr)
+		require.NoError(err)
+		require.True(delSrc.Tokens.Equal(valTokens.Sub(redelTokens)))
 
-	ipTokenRedelegate := &bindings.IPTokenStakingRedelegate{
-		DelegatorCmpPubkey: pubKeys[0].Bytes(),
-		ValidatorSrcPubkey: pubKeys[1].Bytes(),
-		ValidatorDstPubkey: pubKeys[2].Bytes(),
-		Amount:             big.NewInt(redelTokens.Int64()), // multiply power reduction of 1000000
-		Raw:                gethtypes.Log{},
+		delDst, err = stakingKeeper.GetDelegatorValidator(c, delAddr, valDstAddr)
+		require.NoError(err)
+		require.True(delDst.Tokens.Equal(valTokens.Add(redelTokens)))
+
+		// params
+		params, err := s.StakingKeeper.GetParams(c)
+		require.NoError(err)
+
+		redelegation, err := stakingKeeper.GetRedelegation(c, delAddr, valSrcAddr, valDstAddr)
+		require.NoError(err)
+		require.Equal(delAddr.String(), redelegation.DelegatorAddress)
+		require.Equal(valSrcAddr.String(), redelegation.ValidatorSrcAddress)
+		require.Equal(valDstAddr.String(), redelegation.ValidatorDstAddress)
+		require.Equal(redelTokens, redelegation.Entries[0].InitialBalance)
+		sdkCtx := sdk.UnwrapSDKContext(c)
+		require.Equal(sdkCtx.BlockTime().Add(params.UnbondingTime), redelegation.Entries[0].CompletionTime)
 	}
 
-	// redelegation
-	require.NoError(keeper.ProcessRedelegate(ctx, ipTokenRedelegate))
+	tcs := []struct {
+		name          string
+		input         func() bindings.IPTokenStakingRedelegate
+		expectedError string
+		// postCheck checks the state is changed after the successful operation
+		postCheck func(c context.Context)
+	}{
+		{
+			name: "pass: valid redelegation",
+			input: func() bindings.IPTokenStakingRedelegate {
+				return *validInput
+			},
+			postCheck: checkStateAfterRedelegation,
+		},
+		{
+			name: "fail: zero amount",
+			input: func() bindings.IPTokenStakingRedelegate {
+				inputCpy := *validInput
+				inputCpy.Amount = big.NewInt(0)
 
-	// check the amount of delegated tokens after redelegation
-	delSrc, err = stakingKeeper.GetDelegatorValidator(ctx, delAddr, valSrcAddr)
-	require.NoError(err)
-	require.True(delSrc.Tokens.Equal(valTokens.Sub(redelTokens)))
+				return inputCpy
+			},
+			expectedError: "invalid shares amount",
+		},
+		{
+			name: "fail: invalid delegator pubkey",
+			input: func() bindings.IPTokenStakingRedelegate {
+				inputCpy := *validInput
+				inputCpy.DelegatorCmpPubkey = delPubKey.Bytes()[1:]
 
-	delDst, err = stakingKeeper.GetDelegatorValidator(ctx, delAddr, valDstAddr)
-	require.NoError(err)
-	require.True(delDst.Tokens.Equal(valTokens.Add(redelTokens)))
+				return inputCpy
+			},
+			expectedError: "depositor pubkey to cosmos",
+		},
+		{
+			name: "fail: invalid src validator pubkey",
+			input: func() bindings.IPTokenStakingRedelegate {
+				inputCpy := *validInput
+				inputCpy.ValidatorSrcPubkey = valSrcPubKey.Bytes()[1:]
 
-	// params
-	params, err := s.StakingKeeper.GetParams(ctx)
-	require.NoError(err)
+				return inputCpy
+			},
+			expectedError: "src validator pubkey to cosmos",
+		},
+		{
+			name: "fail: invalid dst validator pubkey",
+			input: func() bindings.IPTokenStakingRedelegate {
+				inputCpy := *validInput
+				inputCpy.ValidatorDstPubkey = valDstPubKey.Bytes()[1:]
 
-	redelegation, err := stakingKeeper.GetRedelegation(ctx, delAddr, valSrcAddr, valDstAddr)
-	require.NoError(err)
-	require.Equal(delAddr.String(), redelegation.DelegatorAddress)
-	require.Equal(valSrcAddr.String(), redelegation.ValidatorSrcAddress)
-	require.Equal(valDstAddr.String(), redelegation.ValidatorDstAddress)
-	require.Equal(redelTokens, redelegation.Entries[0].InitialBalance)
-	require.Equal(ctx.BlockTime().Add(params.UnbondingTime), redelegation.Entries[0].CompletionTime)
+				return inputCpy
+			},
+			expectedError: "dst validator pubkey to cosmos",
+		},
+		{
+			name: "fail: corrupted delegator pubkey",
+			input: func() bindings.IPTokenStakingRedelegate {
+				inputCpy := *validInput
+				inputCpy.DelegatorCmpPubkey = createCorruptedPubKey(delPubKey.Bytes())
 
-	// TODO: test EndBlock
+				return inputCpy
+
+			},
+			expectedError: "deledator pubkey to evm address",
+		},
+		{
+			name: "fail: corrupted src validator pubkey",
+			input: func() bindings.IPTokenStakingRedelegate {
+				inputCpy := *validInput
+				inputCpy.ValidatorSrcPubkey = createCorruptedPubKey(valSrcPubKey.Bytes())
+
+				return inputCpy
+			},
+			expectedError: "src validator pubkey to evm address",
+		},
+		{
+			name: "fail: corrupted dst validator pubkey",
+			input: func() bindings.IPTokenStakingRedelegate {
+				inputCpy := *validInput
+				inputCpy.ValidatorDstPubkey = createCorruptedPubKey(valDstPubKey.Bytes())
+
+				return inputCpy
+			},
+			expectedError: "dst validator pubkey to evm address",
+		},
+	}
+
+	for _, tc := range tcs {
+		s.Run(tc.name, func() {
+			cachedCtx, _ := ctx.CacheContext()
+			input := tc.input()
+			err := keeper.ProcessRedelegate(cachedCtx, &input)
+			if tc.expectedError != "" {
+				require.ErrorContains(err, tc.expectedError)
+			} else {
+				require.NoError(err, tc.expectedError)
+				tc.postCheck(cachedCtx)
+			}
+		})
+	}
+}
+
+func (s *TestSuite) TestParseRedelegationLog() {
+	require := s.Require()
+	keeper := s.EVMStakingKeeper
+
+	testCases := []struct {
+		name      string
+		log       gethtypes.Log
+		expectErr bool
+	}{
+		{
+			name: "Unknown Topic",
+			log: gethtypes.Log{
+				Topics: []common.Hash{common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Valid Topic",
+			log: gethtypes.Log{
+				Topics: []common.Hash{types.RedelegateEvent.ID},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			_, err := keeper.ParseRedelegateLog(tc.log)
+			if tc.expectErr {
+				require.Error(err, "should return error for %s", tc.name)
+			} else {
+				require.NoError(err, "should not return error for %s", tc.name)
+			}
+		})
+	}
 }

--- a/client/x/evmstaking/keeper/redelegation_test.go
+++ b/client/x/evmstaking/keeper/redelegation_test.go
@@ -153,7 +153,6 @@ func (s *TestSuite) TestRedelegation() {
 				inputCpy.DelegatorCmpPubkey = createCorruptedPubKey(delPubKey.Bytes())
 
 				return inputCpy
-
 			},
 			expectedError: "deledator pubkey to evm address",
 		},

--- a/client/x/evmstaking/keeper/staking_queue_test.go
+++ b/client/x/evmstaking/keeper/staking_queue_test.go
@@ -51,8 +51,10 @@ func (s *TestSuite) TestGetMatureUnbondedDelegations() {
 	valAddr1 := valAddrs[1]
 	valPubKey2 := pubKeys[2]
 	valAddr2 := valAddrs[2]
-	s.setupValidatorAndDelegation(ctx, valPubKey1, delPubKey, valAddr1, delAddr)
-	s.setupValidatorAndDelegation(ctx, valPubKey2, delPubKey, valAddr2, delAddr)
+	// self delegation
+	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
+	s.setupValidatorAndDelegation(ctx, valPubKey1, delPubKey, valAddr1, delAddr, valTokens)
+	s.setupValidatorAndDelegation(ctx, valPubKey2, delPubKey, valAddr2, delAddr, valTokens)
 
 	// set staking module's params
 	ubdTime := time.Duration(3600) * time.Second

--- a/client/x/evmstaking/keeper/withdraw_test.go
+++ b/client/x/evmstaking/keeper/withdraw_test.go
@@ -36,7 +36,8 @@ func (s *TestSuite) TestExpectedPartialWithdrawals() {
 	valPubKey2 := pubKeys[2]
 	valAddr2 := valAddrs[2]
 
-	s.setupValidatorAndDelegation(ctx, valPubKey, delPubKey, valAddr, delAddr)
+	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
+	s.setupValidatorAndDelegation(ctx, valPubKey, delPubKey, valAddr, delAddr, valTokens)
 	// set params as default
 	params := types.DefaultParams()
 	require.NoError(keeper.SetParams(ctx, params))
@@ -103,7 +104,7 @@ func (s *TestSuite) TestExpectedPartialWithdrawals() {
 		{
 			name: "pass: multiple validators",
 			preRun: func(c sdk.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey2, delPubKey, valAddr2, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey2, delPubKey, valAddr2, delAddr, valTokens)
 				distrKeeper.EXPECT().GetValidatorAccumulatedCommission(gomock.Any(), gomock.Any()).Return(dtypes.ValidatorAccumulatedCommission{}, nil).Times(2)
 				distrKeeper.EXPECT().IncrementValidatorPeriod(gomock.Any(), gomock.Any()).Return(uint64(0), nil).Times(2)
 				distrKeeper.EXPECT().CalculateDelegationRewards(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(delRewards, nil).Times(2)
@@ -126,7 +127,7 @@ func (s *TestSuite) TestExpectedPartialWithdrawals() {
 		{
 			name: "pass: skip jailed validator",
 			preRun: func(c sdk.Context) {
-				s.setupValidatorAndDelegation(c, valPubKey2, delPubKey, valAddr2, delAddr)
+				s.setupValidatorAndDelegation(c, valPubKey2, delPubKey, valAddr2, delAddr, valTokens)
 				val, err := stakingKeeper.GetValidator(c, valAddr2)
 				require.NoError(err)
 				val.Jailed = true
@@ -290,7 +291,7 @@ func (s *TestSuite) TestEnqueueEligiblePartialWithdrawal() {
 
 func (s *TestSuite) TestProcessWithdraw() {
 	require := s.Require()
-	ctx, keeper, accountKeeper, bankKeeper := s.Ctx, s.EVMStakingKeeper, s.AccountKeeper, s.BankKeeper
+	ctx, keeper, accountKeeper, bankKeeper, stakingKeeper := s.Ctx, s.EVMStakingKeeper, s.AccountKeeper, s.BankKeeper, s.StakingKeeper
 
 	pubKeys, accAddrs, valAddrs := createAddresses(4)
 	// delegator-1
@@ -302,7 +303,8 @@ func (s *TestSuite) TestProcessWithdraw() {
 	// unknown pubkey
 	unknownPubKey := pubKeys[3]
 
-	s.setupValidatorAndDelegation(ctx, valPubKey, delPubKey1, valAddr, delAddr1)
+	valTokens := stakingKeeper.TokensFromConsensusPower(ctx, 10)
+	s.setupValidatorAndDelegation(ctx, valPubKey, delPubKey1, valAddr, delAddr1, valTokens)
 
 	tcs := []struct {
 		name        string


### PR DESCRIPTION
increased coverage from 72.4% to 100%
**changes**
- added test cases for existing redelegation test code
- updated and moved common test helper function `setupValidatorAndDelegation` to `keeper_test.go`

issue: #64 
