### PR TITLE
test(evmstaking/keeper): add test cases for params

### DIFF
--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -139,6 +139,7 @@ func (s *TestSuite) SetupTest() {
 		ethCl,
 		address.NewBech32Codec("storyvaloper"),
 	)
+	s.Require().NoError(evmstakingKeeper.SetParams(s.Ctx, types.DefaultParams()))
 	s.EVMStakingKeeper = evmstakingKeeper
 	s.msgServer = keeper.NewMsgServerImpl(evmstakingKeeper)
 }

--- a/client/x/evmstaking/keeper/params_test.go
+++ b/client/x/evmstaking/keeper/params_test.go
@@ -1,0 +1,107 @@
+package keeper_test
+
+import "github.com/piplabs/story/client/x/evmstaking/types"
+
+func (s *TestSuite) TestGetParams() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+	params, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	require.Equal(types.DefaultParams(), params)
+}
+
+func (s *TestSuite) TestSetParams() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+	newMaxWithdrawalPerBlock := uint32(10)
+	newMaxSweepPerBlock := uint32(100)
+	newMinPartialWithdrawalAmount := uint64(100_000)
+
+	params, err := keeper.GetParams(ctx)
+	require.NoError(err)
+
+	// check existing params are not equal to new params
+	require.NotEqual(newMaxWithdrawalPerBlock, params.MaxWithdrawalPerBlock)
+	require.NotEqual(newMaxSweepPerBlock, params.MaxSweepPerBlock)
+	require.NotEqual(newMinPartialWithdrawalAmount, params.MinPartialWithdrawalAmount)
+
+	newParams := params
+	// set new params
+	newParams.MaxWithdrawalPerBlock = newMaxWithdrawalPerBlock
+	newParams.MaxSweepPerBlock = newMaxSweepPerBlock
+	newParams.MinPartialWithdrawalAmount = newMinPartialWithdrawalAmount
+	require.NoError(keeper.SetParams(ctx, newParams))
+
+	// check new params are set correctly
+	params, err = keeper.GetParams(ctx)
+	require.NoError(err)
+	require.Equal(newParams, params)
+}
+
+func (s *TestSuite) TestMaxWithdrawalPerBlock() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+
+	// params are set default during TestSuite.SetupTest
+	params, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	require.Equal(types.DefaultMaxWithdrawalPerBlock, params.MaxWithdrawalPerBlock)
+}
+
+func (s *TestSuite) TestMaxSweepPerBlock() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+
+	// params are set default during TestSuite.SetupTest
+	params, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	require.Equal(types.DefaultMaxSweepPerBlock, params.MaxSweepPerBlock)
+}
+
+func (s *TestSuite) TestMinPartialWithdrawalAmount() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+
+	// params are set default during TestSuite.SetupTest
+	params, err := keeper.GetParams(ctx)
+	require.NoError(err)
+	require.Equal(types.DefaultMinPartialWithdrawalAmount, params.MinPartialWithdrawalAmount)
+}
+
+func (s *TestSuite) TestSetValidatorSweepIndex() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+	existingNextValIndex, existingNextValDelIndex, err := keeper.GetValidatorSweepIndex(ctx)
+	require.NoError(err)
+
+	// set new sweep index
+	newNextValIndex := uint64(10)
+	newNextValDelIndex := uint64(100)
+	// make sure new value is different from existing value
+	require.NotEqual(existingNextValIndex, newNextValIndex)
+	require.NotEqual(existingNextValDelIndex, newNextValDelIndex)
+	require.NoError(keeper.SetValidatorSweepIndex(ctx, newNextValIndex, newNextValDelIndex))
+
+	// check new sweep index is set correctly
+	nextValIndex, nextValDelIndex, err := keeper.GetValidatorSweepIndex(ctx)
+	require.NoError(err)
+	require.Equal(newNextValIndex, nextValIndex)
+	require.Equal(newNextValDelIndex, nextValDelIndex)
+}
+
+func (s *TestSuite) TestGetValidatorSweepIndex() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+	nextValIndex, nextValDelIndex, err := keeper.GetValidatorSweepIndex(ctx)
+	require.NoError(err)
+	require.Equal(uint64(0), nextValIndex)
+	require.Equal(uint64(0), nextValDelIndex)
+}
+
+func (s *TestSuite) TestGetOldValidatorSweepIndex() {
+	require := s.Require()
+	ctx, keeper := s.Ctx, s.EVMStakingKeeper
+	nextValIndex, err := keeper.GetOldValidatorSweepIndex(ctx)
+	require.NoError(err)
+	require.Equal(uint64(0), nextValIndex)
+}


### PR DESCRIPTION
increased test coverage to 70%

**not covered**
- marshaling error
- sdk store error
- old validator sweep existing case

issue: #64 