### PR TITLE
test(evmstaking/types): add test cases for params

### DIFF
--- a/client/x/evmstaking/types/params.go
+++ b/client/x/evmstaking/types/params.go
@@ -55,12 +55,7 @@ func UnmarshalParams(cdc *codec.LegacyAmino, value []byte) (params Params, err e
 	return params, nil
 }
 
-func ValidateMaxWithdrawalPerBlock(i any) error {
-	v, ok := i.(uint32)
-	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", i)
-	}
-
+func ValidateMaxWithdrawalPerBlock(v uint32) error {
 	if v == 0 {
 		return fmt.Errorf("max withdrawal per block must be positive: %d", v)
 	}
@@ -68,29 +63,19 @@ func ValidateMaxWithdrawalPerBlock(i any) error {
 	return nil
 }
 
-func ValidateMaxSweepPerBlock(i any, maxWithdrawalPerBlock uint32) error {
-	v, ok := i.(uint32)
-	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", i)
+func ValidateMaxSweepPerBlock(maxSweepPerBlock uint32, maxWithdrawalPerBlock uint32) error {
+	if maxSweepPerBlock == 0 {
+		return fmt.Errorf("max sweep per block must be positive: %d", maxSweepPerBlock)
 	}
 
-	if v == 0 {
-		return fmt.Errorf("max sweep per block must be positive: %d", v)
-	}
-
-	if v < maxWithdrawalPerBlock {
-		return fmt.Errorf("max sweep per block must be greater than or equal to max withdrawal per block: %d < %d", v, maxWithdrawalPerBlock)
+	if maxSweepPerBlock < maxWithdrawalPerBlock {
+		return fmt.Errorf("max sweep per block must be greater than or equal to max withdrawal per block: %d < %d", maxSweepPerBlock, maxWithdrawalPerBlock)
 	}
 
 	return nil
 }
 
-func ValidateMinPartialWithdrawalAmount(i any) error {
-	v, ok := i.(uint64)
-	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", i)
-	}
-
+func ValidateMinPartialWithdrawalAmount(v uint64) error {
 	if v == 0 {
 		return fmt.Errorf("min partial withdrawal amount must be positive: %d", v)
 	}

--- a/client/x/evmstaking/types/params_test.go
+++ b/client/x/evmstaking/types/params_test.go
@@ -1,0 +1,235 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/piplabs/story/client/x/evmstaking/types"
+)
+
+type ParamsTestSuite struct {
+	suite.Suite
+	encConf testutil.TestEncodingConfig
+}
+
+func (suite *ParamsTestSuite) SetupTest() {
+	suite.encConf = testutil.MakeTestEncodingConfig()
+}
+
+func (suite *ParamsTestSuite) TestNewParams() {
+	require := suite.Require()
+	maxWithdrawalPerBlock, maxSweepPerBlock, minPartialWithdrawalAmount := uint32(1), uint32(2), uint64(3)
+	params := types.NewParams(maxWithdrawalPerBlock, maxSweepPerBlock, minPartialWithdrawalAmount)
+	// check values are set correctly
+	require.Equal(maxWithdrawalPerBlock, params.MaxWithdrawalPerBlock)
+	require.Equal(maxSweepPerBlock, params.MaxSweepPerBlock)
+	require.Equal(minPartialWithdrawalAmount, params.MinPartialWithdrawalAmount)
+}
+
+func (suite *ParamsTestSuite) TestDefaultParams() {
+	require := suite.Require()
+	params := types.DefaultParams()
+	// check values are set correctly
+	require.Equal(types.DefaultMaxWithdrawalPerBlock, params.MaxWithdrawalPerBlock)
+	require.Equal(types.DefaultMaxSweepPerBlock, params.MaxSweepPerBlock)
+	require.Equal(types.DefaultMinPartialWithdrawalAmount, params.MinPartialWithdrawalAmount)
+}
+
+func (suite *ParamsTestSuite) TestMustUnmarshalParams() {
+	require := suite.Require()
+	maxWithdrawalPerBlock, maxSweepPerBlock, minPartialWithdrawalAmount := uint32(1), uint32(2), uint64(3)
+	params := types.NewParams(maxWithdrawalPerBlock, maxSweepPerBlock, minPartialWithdrawalAmount)
+
+	tcs := []struct {
+		name        string
+		input       []byte
+		expected    types.Params
+		expectPanic bool
+	}{
+		{
+			name:  "Unmarshal valid params bytes",
+			input: suite.encConf.Codec.MustMarshal(&params),
+			expected: types.Params{
+				MaxWithdrawalPerBlock:      maxWithdrawalPerBlock,
+				MaxSweepPerBlock:           maxSweepPerBlock,
+				MinPartialWithdrawalAmount: minPartialWithdrawalAmount,
+			},
+		},
+		{
+			name:        "Unmarshal invalid params bytes",
+			input:       []byte{0x1, 0x2, 0x3},
+			expectPanic: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		suite.Run(tc.name, func() {
+			if tc.expectPanic {
+				require.Panics(func() {
+					types.MustUnmarshalParams(suite.encConf.Amino, tc.input)
+				})
+			} else {
+				params := types.MustUnmarshalParams(suite.encConf.Amino, tc.input)
+				require.Equal(tc.expected, params)
+			}
+		})
+	}
+}
+
+func (suite *ParamsTestSuite) TestUnmarshalParams() {
+	require := suite.Require()
+	maxWithdrawalPerBlock, maxSweepPerBlock, minPartialWithdrawalAmount := uint32(1), uint32(2), uint64(3)
+	params := types.NewParams(maxWithdrawalPerBlock, maxSweepPerBlock, minPartialWithdrawalAmount)
+
+	tcs := []struct {
+		name          string
+		input         []byte
+		expected      types.Params
+		expectedError string
+	}{
+		{
+			name:  "Unmarshal valid params bytes",
+			input: suite.encConf.Codec.MustMarshal(&params),
+			expected: types.Params{
+				MaxWithdrawalPerBlock:      maxWithdrawalPerBlock,
+				MaxSweepPerBlock:           maxSweepPerBlock,
+				MinPartialWithdrawalAmount: minPartialWithdrawalAmount,
+			},
+		},
+		{
+			name:          "Unmarshal invalid params bytes",
+			input:         []byte{0x1, 0x2, 0x3},
+			expectedError: "unmarshal params",
+		},
+	}
+
+	for _, tc := range tcs {
+		suite.Run(tc.name, func() {
+			params, err := types.UnmarshalParams(suite.encConf.Amino, tc.input)
+			if tc.expectedError != "" {
+				require.Error(err)
+				require.Contains(err.Error(), tc.expectedError)
+			} else {
+				require.NoError(err)
+				require.Equal(tc.expected, params)
+			}
+		})
+	}
+}
+
+func (suite *ParamsTestSuite) TestValidateMaxWithdrawalPerBlock() {
+	require := suite.Require()
+
+	tcs := []struct {
+		name        string
+		input       uint32
+		expectedErr string
+	}{
+		{
+			name:  "valid value",
+			input: 1,
+		},
+		{
+			name:        "invalid value",
+			input:       0,
+			expectedErr: "max withdrawal per block must be positive: 0",
+		},
+	}
+
+	for _, tc := range tcs {
+		suite.Run(tc.name, func() {
+			err := types.ValidateMaxWithdrawalPerBlock(tc.input)
+			if tc.expectedErr == "" {
+				require.NoError(err)
+			} else {
+				require.Error(err)
+				require.Contains(err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}
+
+func (suite *ParamsTestSuite) TestValidateMaxSweepPerBlock() {
+	require := suite.Require()
+
+	tcs := []struct {
+		name                  string
+		maxSweepPerBlock      uint32
+		maxWithdrawalPerBlock uint32
+		expectedErr           string
+	}{
+		{
+			name:                  "valid value",
+			maxSweepPerBlock:      2,
+			maxWithdrawalPerBlock: 1,
+		},
+		{
+			name:                  "valid value",
+			maxSweepPerBlock:      1,
+			maxWithdrawalPerBlock: 1,
+		},
+		{
+			name:                  "invalid value",
+			maxSweepPerBlock:      0,
+			maxWithdrawalPerBlock: 2,
+			expectedErr:           "max sweep per block must be positive: 0",
+		},
+		{
+			name:                  "invalid value",
+			maxSweepPerBlock:      1,
+			maxWithdrawalPerBlock: 2,
+			expectedErr:           "max sweep per block must be greater than or equal to max withdrawal per block",
+		},
+	}
+
+	for _, tc := range tcs {
+		suite.Run(tc.name, func() {
+			err := types.ValidateMaxSweepPerBlock(tc.maxSweepPerBlock, tc.maxWithdrawalPerBlock)
+			if tc.expectedErr == "" {
+				require.NoError(err)
+			} else {
+				require.Error(err)
+				require.Contains(err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}
+
+func (suite *ParamsTestSuite) TestValidateMinPartialWithdrawatAmount() {
+	require := suite.Require()
+
+	tcs := []struct {
+		name        string
+		input       uint64
+		expectedErr string
+	}{
+		{
+			name:  "valid value",
+			input: 1,
+		},
+		{
+			name:        "invalid value",
+			input:       0,
+			expectedErr: "min partial withdrawal amount must be positive: 0",
+		},
+	}
+
+	for _, tc := range tcs {
+		suite.Run(tc.name, func() {
+			err := types.ValidateMinPartialWithdrawalAmount(tc.input)
+			if tc.expectedErr == "" {
+				require.NoError(err)
+			} else {
+				require.Error(err)
+				require.Contains(err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestParamsTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(ParamsTestSuite))
+}

--- a/client/x/evmstaking/types/withdraw_test.go
+++ b/client/x/evmstaking/types/withdraw_test.go
@@ -196,7 +196,7 @@ func (suite *WithdrawTestSuite) TestMustUnmarshalWithdraw() {
 	}
 }
 
-func TestTestSuite(t *testing.T) {
+func TestWithdrawalTestSuite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, new(WithdrawTestSuite))
 }


### PR DESCRIPTION
increased test coverage to 100% 

**changes**
- Updated the input types of validation functions to use concrete types instead of any, as there doesn’t appear to be a specific reason for using any. (Please let me know if there’s a reason for it)
- Renamed the withdrawal test suite to avoid naming conflicts with the parameter test suite.

issue: #64