### PR TITLE
fix(evmengine): nil panic with optimistic build enabled

### DIFF
--- a/client/x/evmengine/keeper/keeper.go
+++ b/client/x/evmengine/keeper/keeper.go
@@ -172,6 +172,11 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 //
 // Note that the validator set can change, so this is an optimistic check.
 func (k *Keeper) isNextProposer(ctx context.Context, currentProposer []byte, currentHeight int64) (bool, error) {
+	// cometAPI is lazily set and may be nil on startup (e.g. replayBlocks).
+	if k.cmtAPI == nil {
+		return false, nil
+	}
+
 	valset, ok, err := k.cmtAPI.Validators(ctx, currentHeight)
 	if err != nil {
 		return false, err

--- a/client/x/evmengine/keeper/keeper.go
+++ b/client/x/evmengine/keeper/keeper.go
@@ -172,7 +172,8 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 //
 // Note that the validator set can change, so this is an optimistic check.
 func (k *Keeper) isNextProposer(ctx context.Context, currentProposer []byte, currentHeight int64) (bool, error) {
-	// cometAPI is lazily set and may be nil on startup (e.g. replayBlocks).
+	// PostFinalize can be called during block replay (performed in newCometNode),
+	// but cmtAPI is set only after newCometNode completes (see app.SetCometAPI), so a nil check is necessary.
 	if k.cmtAPI == nil {
 		return false, nil
 	}


### PR DESCRIPTION
cmtAPI is lazily set, so during replaying blocks it is nil.
we should add nil checking logic to avoid panic. 
this PR is non state breaking meaning code changes won't do any state changes. so the PR doesn't require hard fork.

issue: #127 