### PR TITLE
test(evmengine): add test cases for genesis

### DIFF
--- a/client/x/evmengine/keeper/db_internal_test.go
+++ b/client/x/evmengine/keeper/db_internal_test.go
@@ -3,38 +3,10 @@ package keeper
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-
-	moduletestutil "github.com/piplabs/story/client/x/evmengine/testutil"
-	"github.com/piplabs/story/lib/ethclient/mock"
-
-	"go.uber.org/mock/gomock"
 )
-
-func createTestKeeper(t *testing.T) (sdk.Context, *Keeper) {
-	t.Helper()
-	cdc := getCodec(t)
-	txConfig := authtx.NewTxConfig(cdc, nil)
-
-	mockEngine, err := newMockEngineAPI(0)
-	require.NoError(t, err)
-
-	ctrl := gomock.NewController(t)
-	mockClient := mock.NewMockClient(ctrl)
-	ak := moduletestutil.NewMockAccountKeeper(ctrl)
-	esk := moduletestutil.NewMockEvmStakingKeeper(ctrl)
-	uk := moduletestutil.NewMockUpgradeKeeper(ctrl)
-	ctx, storeService := setupCtxStore(t, nil)
-	ctx = ctx.WithExecMode(sdk.ExecModeFinalize)
-	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk)
-	require.NoError(t, err)
-
-	return ctx, keeper
-}
 
 func TestKeeper_InsertGenesisHead(t *testing.T) {
 	t.Parallel()

--- a/client/x/evmengine/keeper/genesis_internal_test.go
+++ b/client/x/evmengine/keeper/genesis_internal_test.go
@@ -105,7 +105,7 @@ func TestKeeper_InitGenesis(t *testing.T) {
 			}
 			if tc.requirePanic {
 				require.PanicsWithError(t, tc.expectedError, func() {
-					keeper.InitGenesis(ctx, tc.gs())
+					_ = keeper.InitGenesis(ctx, tc.gs())
 				})
 			} else {
 				err := keeper.InitGenesis(ctx, tc.gs())

--- a/client/x/evmengine/keeper/genesis_internal_test.go
+++ b/client/x/evmengine/keeper/genesis_internal_test.go
@@ -4,44 +4,12 @@ import (
 	"context"
 	"testing"
 
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
-	moduletestutil "github.com/piplabs/story/client/x/evmengine/testutil"
 	"github.com/piplabs/story/client/x/evmengine/types"
-	"github.com/piplabs/story/lib/ethclient/mock"
-
-	"go.uber.org/mock/gomock"
 )
-
-func createTestKeeper(t *testing.T) (context.Context, *Keeper) {
-	t.Helper()
-
-	cdc := getCodec(t)
-	txConfig := authtx.NewTxConfig(cdc, nil)
-	mockEngine, err := newMockEngineAPI(0)
-	require.NoError(t, err)
-
-	cmtAPI := newMockCometAPI(t, nil)
-	header := cmtproto.Header{Height: 1}
-
-	ctrl := gomock.NewController(t)
-	mockClient := mock.NewMockClient(ctrl)
-	ak := moduletestutil.NewMockAccountKeeper(ctrl)
-	esk := moduletestutil.NewMockEvmStakingKeeper(ctrl)
-	uk := moduletestutil.NewMockUpgradeKeeper(ctrl)
-
-	ctx, storeService := setupCtxStore(t, &header)
-
-	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk)
-	require.NoError(t, err)
-	keeper.SetCometAPI(cmtAPI)
-
-	return ctx, keeper
-}
 
 func TestKeeper_InitGenesis(t *testing.T) {
 	t.Parallel()

--- a/client/x/evmengine/keeper/genesis_internal_test.go
+++ b/client/x/evmengine/keeper/genesis_internal_test.go
@@ -1,0 +1,163 @@
+package keeper
+
+import (
+	"context"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	moduletestutil "github.com/piplabs/story/client/x/evmengine/testutil"
+	"github.com/piplabs/story/client/x/evmengine/types"
+	"github.com/piplabs/story/lib/ethclient/mock"
+
+	"go.uber.org/mock/gomock"
+)
+
+func createTestKeeper(t *testing.T) (context.Context, *Keeper) {
+	t.Helper()
+
+	cdc := getCodec(t)
+	txConfig := authtx.NewTxConfig(cdc, nil)
+	mockEngine, err := newMockEngineAPI(0)
+	require.NoError(t, err)
+
+	cmtAPI := newMockCometAPI(t, nil)
+	header := cmtproto.Header{Height: 1}
+
+	ctrl := gomock.NewController(t)
+	mockClient := mock.NewMockClient(ctrl)
+	ak := moduletestutil.NewMockAccountKeeper(ctrl)
+	esk := moduletestutil.NewMockEvmStakingKeeper(ctrl)
+	uk := moduletestutil.NewMockUpgradeKeeper(ctrl)
+
+	ctx, storeService := setupCtxStore(t, &header)
+
+	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk)
+	require.NoError(t, err)
+	keeper.SetCometAPI(cmtAPI)
+
+	return ctx, keeper
+}
+
+func TestKeeper_InitGenesis(t *testing.T) {
+	t.Parallel()
+	dummyExecutionHead := common.HexToHash("0x047e24c3455107d87c68dffa307b3b7fa1877f3e9d7f30c7ee359f2eff3a75d9")
+	validParams := types.NewParams(dummyExecutionHead.Bytes())
+
+	tcs := []struct {
+		name           string
+		gs             func() *types.GenesisState
+		setup          func(c context.Context, k *Keeper)
+		postStateCheck func(c context.Context, k *Keeper)
+		expectedError  string
+		requirePanic   bool
+	}{
+		{
+			name: "pass",
+			gs: func() *types.GenesisState {
+				return &types.GenesisState{
+					Params: validParams,
+				}
+			},
+			postStateCheck: func(c context.Context, k *Keeper) {
+				params, err := k.GetParams(c)
+				require.NoError(t, err)
+				require.Equal(t, validParams, params)
+			},
+		},
+		{
+			name: "fail: invalid execution block hash",
+			gs: func() *types.GenesisState {
+				invalidParams := validParams
+				invalidParams.ExecutionBlockHash = []byte("invalid")
+
+				return &types.GenesisState{
+					Params: invalidParams,
+				}
+			},
+			expectedError: "invalid execution block hash length",
+		},
+		{
+			name: "panic: execution head already exists",
+			setup: func(c context.Context, k *Keeper) {
+				require.NoError(t, k.InsertGenesisHead(c, dummyExecutionHead.Bytes()))
+			},
+			gs: func() *types.GenesisState {
+				return &types.GenesisState{
+					Params: validParams,
+				}
+			},
+			expectedError: "insert genesis head: unexpected genesis head id",
+			requirePanic:  true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, keeper := createTestKeeper(t)
+			if tc.setup != nil {
+				tc.setup(ctx, keeper)
+			}
+			if tc.requirePanic {
+				require.PanicsWithError(t, tc.expectedError, func() {
+					keeper.InitGenesis(ctx, tc.gs())
+				})
+			} else {
+				err := keeper.InitGenesis(ctx, tc.gs())
+				if tc.expectedError != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tc.expectedError)
+				} else {
+					require.NoError(t, err)
+					tc.postStateCheck(ctx, keeper)
+				}
+			}
+		})
+	}
+}
+
+func TestKeeper_ExportGenesis(t *testing.T) {
+	t.Parallel()
+	dummyExecutionHead := common.HexToHash("0x047e24c3455107d87c68dffa307b3b7fa1877f3e9d7f30c7ee359f2eff3a75d9")
+	validParams := types.NewParams(dummyExecutionHead.Bytes())
+
+	tcs := []struct {
+		name           string
+		setup          func(c context.Context, k *Keeper)
+		postStateCheck func(c context.Context, k *Keeper)
+	}{
+		{
+			name: "pass",
+			setup: func(c context.Context, k *Keeper) {
+				require.NoError(t, k.SetParams(c, validParams))
+			},
+			postStateCheck: func(c context.Context, k *Keeper) {
+				gs := k.ExportGenesis(sdk.UnwrapSDKContext(c))
+				require.Equal(t, validParams, gs.Params)
+			},
+		},
+		{
+			name: "pass: default params",
+			postStateCheck: func(c context.Context, k *Keeper) {
+				gs := k.ExportGenesis(sdk.UnwrapSDKContext(c))
+				require.Equal(t, types.DefaultParams(), gs.Params)
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, keeper := createTestKeeper(t)
+			if tc.setup != nil {
+				tc.setup(ctx, keeper)
+			}
+			tc.postStateCheck(ctx, keeper)
+		})
+	}
+}


### PR DESCRIPTION
increase coverage to 83.3%
not covered part is sdk's store related errors (e.g. failed to get params from store)

issue: #81 