### PR TITLE
test(evmengine): add test cases for params

### DIFF
--- a/client/x/evmengine/keeper/params_internal_test.go
+++ b/client/x/evmengine/keeper/params_internal_test.go
@@ -1,46 +1,13 @@
 package keeper
 
 import (
-	"context"
 	"testing"
 
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
-	moduletestutil "github.com/piplabs/story/client/x/evmengine/testutil"
 	"github.com/piplabs/story/client/x/evmengine/types"
-	"github.com/piplabs/story/lib/ethclient/mock"
-
-	"go.uber.org/mock/gomock"
 )
-
-func createTestKeeper(t *testing.T) (context.Context, *Keeper) {
-	t.Helper()
-
-	cdc := getCodec(t)
-	txConfig := authtx.NewTxConfig(cdc, nil)
-	mockEngine, err := newMockEngineAPI(0)
-	require.NoError(t, err)
-
-	cmtAPI := newMockCometAPI(t, nil)
-	header := cmtproto.Header{Height: 1}
-
-	ctrl := gomock.NewController(t)
-	mockClient := mock.NewMockClient(ctrl)
-	ak := moduletestutil.NewMockAccountKeeper(ctrl)
-	esk := moduletestutil.NewMockEvmStakingKeeper(ctrl)
-	uk := moduletestutil.NewMockUpgradeKeeper(ctrl)
-
-	ctx, storeService := setupCtxStore(t, &header)
-
-	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk)
-	require.NoError(t, err)
-	keeper.SetCometAPI(cmtAPI)
-
-	return ctx, keeper
-}
 
 func TestKeeper_ExecutionBlockHash(t *testing.T) {
 	t.Parallel()

--- a/client/x/evmengine/keeper/params_internal_test.go
+++ b/client/x/evmengine/keeper/params_internal_test.go
@@ -1,0 +1,79 @@
+package keeper
+
+import (
+	"context"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	moduletestutil "github.com/piplabs/story/client/x/evmengine/testutil"
+	"github.com/piplabs/story/client/x/evmengine/types"
+	"github.com/piplabs/story/lib/ethclient/mock"
+
+	"go.uber.org/mock/gomock"
+)
+
+func createTestKeeper(t *testing.T) (context.Context, *Keeper) {
+	t.Helper()
+
+	cdc := getCodec(t)
+	txConfig := authtx.NewTxConfig(cdc, nil)
+	mockEngine, err := newMockEngineAPI(0)
+	require.NoError(t, err)
+
+	cmtAPI := newMockCometAPI(t, nil)
+	header := cmtproto.Header{Height: 1}
+
+	ctrl := gomock.NewController(t)
+	mockClient := mock.NewMockClient(ctrl)
+	ak := moduletestutil.NewMockAccountKeeper(ctrl)
+	esk := moduletestutil.NewMockEvmStakingKeeper(ctrl)
+	uk := moduletestutil.NewMockUpgradeKeeper(ctrl)
+
+	ctx, storeService := setupCtxStore(t, &header)
+
+	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk)
+	require.NoError(t, err)
+	keeper.SetCometAPI(cmtAPI)
+
+	return ctx, keeper
+}
+
+func TestKeeper_ExecutionBlockHash(t *testing.T) {
+	ctx, keeper := createTestKeeper(t)
+
+	// check existing execution block hash
+	execHash, err := keeper.ExecutionBlockHash(ctx)
+	require.NoError(t, err)
+	require.Nil(t, execHash, "execution block hash should be nil because it is not set yet")
+
+	// set execution block hash
+	dummyHash := common.HexToHash("0x047e24c3455107d87c68dffa307b3b7fa1877f3e9d7f30c7ee359f2eff3a75d9")
+	require.NoError(t, keeper.SetParams(ctx, types.Params{ExecutionBlockHash: dummyHash.Bytes()}))
+
+	// check execution block hash whether it is set correctly
+	execHash, err = keeper.ExecutionBlockHash(ctx)
+	require.NoError(t, err)
+	require.Equal(t, dummyHash.Bytes(), execHash, "execution block hash should be equal to the dummy hash")
+}
+
+func TestKeeper_GetSetParams(t *testing.T) {
+	ctx, keeper := createTestKeeper(t)
+
+	// check existing params
+	params, err := keeper.GetParams(ctx)
+	require.NoError(t, err)
+	require.Equal(t, types.DefaultParams(), params, "params should be equal to the default params")
+
+	// set execution block hash
+	dummyHash := common.HexToHash("0x047e24c3455107d87c68dffa307b3b7fa1877f3e9d7f30c7ee359f2eff3a75d9")
+	require.NoError(t, keeper.SetParams(ctx, types.Params{ExecutionBlockHash: dummyHash.Bytes()}))
+
+	// check params whether it is set correctly
+	params, err = keeper.GetParams(ctx)
+	require.NoError(t, err)
+	require.Equal(t, types.Params{ExecutionBlockHash: dummyHash.Bytes()}, params)
+}

--- a/client/x/evmengine/keeper/params_internal_test.go
+++ b/client/x/evmengine/keeper/params_internal_test.go
@@ -43,6 +43,7 @@ func createTestKeeper(t *testing.T) (context.Context, *Keeper) {
 }
 
 func TestKeeper_ExecutionBlockHash(t *testing.T) {
+	t.Parallel()
 	ctx, keeper := createTestKeeper(t)
 
 	// check existing execution block hash
@@ -61,6 +62,7 @@ func TestKeeper_ExecutionBlockHash(t *testing.T) {
 }
 
 func TestKeeper_GetSetParams(t *testing.T) {
+	t.Parallel()
 	ctx, keeper := createTestKeeper(t)
 
 	// check existing params


### PR DESCRIPTION
increased coverage to 77.3%
not covered part is sdk's store related errors (e.g. failed to get params from store)

issue: #81 