### PR TITLE
feat(genesis): disable vote extension by default

### DIFF
--- a/client/genutil/defaults.go
+++ b/client/genutil/defaults.go
@@ -5,7 +5,6 @@ import "github.com/cometbft/cometbft/types"
 // DefaultConsensusParams returns the default cometBFT consensus params for story protocol.
 func DefaultConsensusParams() *types.ConsensusParams {
 	resp := types.DefaultConsensusParams()
-	resp.ABCI.VoteExtensionsEnableHeight = 1                             // Enable vote extensions from the start.
 	resp.Validator.PubKeyTypes = []string{types.ABCIPubKeyTypeSecp256k1} // Only k1 keys.
 	resp.Block.MaxBytes = -1                                             // Disable max block bytes, since we MUST include the whole EVM block, which is limited by max gas per block.
 

--- a/client/genutil/genutil_internal_test.go
+++ b/client/genutil/genutil_internal_test.go
@@ -15,7 +15,7 @@ import (
 func TestDefaultConsensusParams(t *testing.T) {
 	t.Parallel()
 	cons := defaultConsensusGenesis()
-	require.EqualValues(t, 1, cons.Params.ABCI.VoteExtensionsEnableHeight)
+	require.EqualValues(t, 0, cons.Params.ABCI.VoteExtensionsEnableHeight)
 	require.EqualValues(t, types.ABCIPubKeyTypeSecp256k1, cons.Params.Validator.PubKeyTypes[0])
 	require.EqualValues(t, -1, cons.Params.Block.MaxBytes)
 	require.EqualValues(t, -1, cons.Params.Block.MaxGas)

--- a/lib/netconf/iliad/genesis.json
+++ b/lib/netconf/iliad/genesis.json
@@ -19,7 +19,7 @@
       "app": "0"
     },
     "abci": {
-      "vote_extensions_enable_height": "1"
+      "vote_extensions_enable_height": "0"
     }
   },
   "app_hash": "",

--- a/lib/netconf/local/genesis.json
+++ b/lib/netconf/local/genesis.json
@@ -19,7 +19,7 @@
       "app": "0"
     },
     "abci": {
-      "vote_extensions_enable_height": "1"
+      "vote_extensions_enable_height": "0"
     }
   },
   "app_hash": "",

--- a/lib/tutil/testdata/genesis.json
+++ b/lib/tutil/testdata/genesis.json
@@ -19,7 +19,7 @@
 			]
 		},
 		"abci": {
-			"vote_extensions_enable_height": "1"
+			"vote_extensions_enable_height": "0"
 		},
 		"version": {}
 	},


### PR DESCRIPTION
Disable VoteExtension by default for all network. We can enable this for future by setting `vote_extensions_enable_height`.

issue: #172 
