### PR TITLE
feat(epochs): add default epoch info to genesis config

### DIFF
--- a/lib/netconf/local/genesis.json
+++ b/lib/netconf/local/genesis.json
@@ -194,7 +194,34 @@
           "current_epoch": "0",
           "current_epoch_start_time": "1970-01-01T00:00:00Z",
           "epoch_counting_started": false,
-          "current_epoch_start_height": "10"
+          "current_epoch_start_height": "1"
+        },
+        {
+          "identifier": "hour",
+          "start_time": "1970-01-01T00:00:00Z",
+          "duration": "1h",
+          "current_epoch": "0",
+          "current_epoch_start_time": "1970-01-01T00:00:00Z",
+          "epoch_counting_started": false,
+          "current_epoch_start_height": "1"
+        },
+        {
+          "identifier": "day",
+          "start_time": "1970-01-01T00:00:00Z",
+          "duration": "24h",
+          "current_epoch": "0",
+          "current_epoch_start_time": "1970-01-01T00:00:00Z",
+          "epoch_counting_started": false,
+          "current_epoch_start_height": "1"
+        },
+        {
+          "identifier": "week",
+          "start_time": "1970-01-01T00:00:00Z",
+          "duration": "168h",
+          "current_epoch": "0",
+          "current_epoch_start_time": "1970-01-01T00:00:00Z",
+          "epoch_counting_started": false,
+          "current_epoch_start_height": "1"
         }
       ]
     }


### PR DESCRIPTION
Added several default epoch info by default into genesis.json. The added epochs are as below:
- minute
- hour
- day
- week

The default start time is set as `1970-01-01T00:00:00Z`, so when you start app locally the epoch would increase every block. If you want to test epoch if it is proceeded every duration, you need to modify `start_time` near the time now.

issue: none
