### PR TITLE
fix(contracts): fix licenses from busl to gpl

### DIFF
--- a/contracts/script/GenerateAlloc.s.sol
+++ b/contracts/script/GenerateAlloc.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 /* solhint-disable max-line-length */

--- a/contracts/script/TestPrecompileUpgrades.s.sol
+++ b/contracts/script/TestPrecompileUpgrades.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 /* solhint-disable max-line-length */

--- a/contracts/src/interfaces/IIPTokenStaking.sol
+++ b/contracts/src/interfaces/IIPTokenStaking.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 
 /// @title IIPTokenStaking

--- a/contracts/src/interfaces/IUpgradeEntrypoint.sol
+++ b/contracts/src/interfaces/IUpgradeEntrypoint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 
 interface IUpgradeEntrypoint {

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/contracts/src/protocol/UpgradeEntrypoint.sol
+++ b/contracts/src/protocol/UpgradeEntrypoint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/contracts/test/deploy/Create3.t.sol
+++ b/contracts/test/deploy/Create3.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 /* solhint-disable max-line-length */

--- a/contracts/test/libraries/Secp256k1.t.sol
+++ b/contracts/test/libraries/Secp256k1.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 /* solhint-disable max-line-length */

--- a/contracts/test/script/DeployCore.t.sol
+++ b/contracts/test/script/DeployCore.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 // /* solhint-disable no-console */
 // /* solhint-disable max-line-length */

--- a/contracts/test/stake/IPTokenStaking.t.sol
+++ b/contracts/test/stake/IPTokenStaking.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 /* solhint-disable max-line-length */

--- a/contracts/test/upgrade/UpgradeEntryPoint.t.sol
+++ b/contracts/test/upgrade/UpgradeEntryPoint.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 /* solhint-disable max-line-length */

--- a/contracts/test/utils/Test.sol
+++ b/contracts/test/utils/Test.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 /* solhint-disable max-line-length */


### PR DESCRIPTION
Smart Contracts must have GPL-3.0-only, not BUSL, since we forked from Omni.

issue: none
