### PR TITLE
feat(evmstaking): replace staking keeper endblocker

### DIFF
--- a/client/x/evmstaking/types/expected_keepers.go
+++ b/client/x/evmstaking/types/expected_keepers.go
@@ -64,6 +64,7 @@ type StakingKeeper interface {
 	GetUnbondingDelegationsFromValidator(ctx context.Context, valAddr sdk.ValAddress) (ubds []stakingtypes.UnbondingDelegation, err error)
 
 	EndBlocker(ctx context.Context) ([]abci.ValidatorUpdate, error)
+	EndBlockerWithUnbondedEntries(ctx context.Context) ([]abci.ValidatorUpdate, []stakingtypes.UnbondedEntry, error)
 }
 
 // SlashingKeeper defines the expected interface for the slashing module.

--- a/go.mod
+++ b/go.mod
@@ -295,7 +295,7 @@ replace (
 	cosmossdk.io/core v0.12.0 => cosmossdk.io/core v0.11.0
 
 	// Direct cosmos-sdk branch link: https://github.com/piplabs/cosmos-sdk/tree/story/v0.50.7, current branch: story/v0.50.7
-	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.3
+	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.4
 
 	// See https://github.com/cosmos/cosmos-sdk/pull/14952
 	// Also https://github.com/cosmos/cosmos-db/blob/main/go.mod#L11-L12

--- a/go.sum
+++ b/go.sum
@@ -1032,8 +1032,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.3 h1:psxK/SkuqErPFobiYxuqSgW3gPw/xhDlTWQ36X5dhaU=
-github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.3/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
+github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.4 h1:EyX4nVJm08vx0/srAuA2kfSVrTfnhNAhF0uB/gT66yE=
+github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.4/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
With [this implementation](https://github.com/piplabs/cosmos-sdk/pull/4), I replaced the EndBlocker of staking keeper. 
It now returns the array of completed unbonding, so we can use them for processing withdrawal.

issue: #197 
