### PR TITLE
fix(staking): removing period values from staking contract

### DIFF
--- a/contracts/script/GenerateAlloc.s.sol
+++ b/contracts/script/GenerateAlloc.s.sol
@@ -166,18 +166,8 @@ contract GenerateAlloc is Script {
             minStakeAmount: 1024 ether,
             minUnstakeAmount: 1024 ether,
             minCommissionRate: 5_00, // 5% in basis points
-            shortStakingPeriod: 1 days, // TBD
-            mediumStakingPeriod: 2 days, // TBD
-            longStakingPeriod: 3 days, // TBD
             fee: 1 ether // 1 IP
         });
-
-        // Devnet timing values
-        if (block.chainid == 1315) {
-            args.shortStakingPeriod = 60 seconds;
-            args.mediumStakingPeriod = 120 seconds;
-            args.longStakingPeriod = 180 seconds;
-        }
 
         IPTokenStaking(Predeploys.Staking).initialize(args);
 

--- a/contracts/src/interfaces/IIPTokenStaking.sol
+++ b/contracts/src/interfaces/IIPTokenStaking.sol
@@ -20,26 +20,14 @@ interface IIPTokenStaking {
     /// @param minStakeAmount Global minimum amount required to stake
     /// @param minUnstakeAmount Global minimum amount required to unstake
     /// @param minCommissionRate Global minimum commission rate for validators
-    /// @param shortStakingPeriod The staking duration for short staking, in seconds
-    /// @param mediumStakingPeriod The staking duration for medium staking, in seconds
-    /// @param longStakingPeriod The staking duration for long staking, in seconds
     /// @param fee The fee charged for adding to CL storage
     struct InitializerArgs {
         address owner;
         uint256 minStakeAmount;
         uint256 minUnstakeAmount;
         uint256 minCommissionRate;
-        uint32 shortStakingPeriod;
-        uint32 mediumStakingPeriod;
-        uint32 longStakingPeriod;
         uint256 fee;
     }
-
-    /// @notice Emitted when the staking periods are updated
-    /// @param short The new staking duration for short staking, in seconds
-    /// @param medium The new staking duration for medium staking, in seconds
-    /// @param long The new staking duration for long staking, in seconds
-    event StakingPeriodsChanged(uint32 short, uint32 medium, uint32 long);
 
     /// @notice Emitted when the fee charged for adding to CL storage is updated
     /// @param newFee The new fee
@@ -86,7 +74,7 @@ interface IIPTokenStaking {
     /// @param delegatorUncmpPubkey Delegator's 65 bytes uncompressed secp256k1 public key.
     /// @param validatorUnCmpPubkey Validator's 65 bytes uncompressed secp256k1 public key.
     /// @param stakeAmount Token deposited.
-    /// @param stakingPeriod The staking period of the deposit in seconds, 0 if flexible
+    /// @param stakingPeriod of the deposit 
     /// @param delegationId The ID of the delegation
     /// @param operatorAddress The caller's address
     /// @param data Additional data for the deposit

--- a/contracts/src/interfaces/IIPTokenStaking.sol
+++ b/contracts/src/interfaces/IIPTokenStaking.sol
@@ -74,7 +74,7 @@ interface IIPTokenStaking {
     /// @param delegatorUncmpPubkey Delegator's 65 bytes uncompressed secp256k1 public key.
     /// @param validatorUnCmpPubkey Validator's 65 bytes uncompressed secp256k1 public key.
     /// @param stakeAmount Token deposited.
-    /// @param stakingPeriod of the deposit 
+    /// @param stakingPeriod of the deposit
     /// @param delegationId The ID of the delegation
     /// @param operatorAddress The caller's address
     /// @param data Additional data for the deposit

--- a/contracts/src/libraries/Errors.sol
+++ b/contracts/src/libraries/Errors.sol
@@ -21,10 +21,6 @@ library Errors {
     error IPTokenStaking__ZeroMinUnstakeAmount();
     error IPTokenStaking__ZeroMinCommissionRate();
 
-    error IPTokenStaking__ZeroShortPeriodDuration();
-    error IPTokenStaking__ShortPeriodLongerThanMedium();
-    error IPTokenStaking__MediumLongerThanLong();
-
     error IPTokenStaking__StakeAmountUnderMin();
     error IPTokenStaking__LowUnstakeAmount();
     error IPTokenStaking__RedelegatingToSameValidator();

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -125,7 +125,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         _setMinUnstakeAmount(newMinUnstakeAmount);
     }
 
-
     /// @notice Sets the fee charged for adding to CL storage.
     /// @param newFee The new fee
     function setFee(uint256 newFee) external onlyOwner {
@@ -141,7 +140,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
     /*//////////////////////////////////////////////////////////////////////////
     //                            Internal setters                            //
     //////////////////////////////////////////////////////////////////////////*/
-
 
     /// @dev Sets the fee charged for adding to CL storage.
     function _setFee(uint256 newFee) private {
@@ -432,7 +430,15 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         if (stakingPeriod != IIPTokenStaking.StakingPeriod.FLEXIBLE) {
             delegationId = ++_delegationIdCounter;
         }
-        emit Deposit(delegatorUncmpPubkey, validatorUncmpPubkey, stakeAmount, uint8(stakingPeriod), delegationId, msg.sender, data);
+        emit Deposit(
+            delegatorUncmpPubkey,
+            validatorUncmpPubkey,
+            stakeAmount,
+            uint8(stakingPeriod),
+            delegationId,
+            msg.sender,
+            data
+        );
         // We burn staked tokens
         payable(address(0)).transfer(stakeAmount);
 

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -422,6 +422,8 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         IIPTokenStaking.StakingPeriod stakingPeriod,
         bytes calldata data
     ) internal returns (uint256) {
+        // This can't be tested from Foundry (Solidity), but can be triggered from js/rpc
+        require(stakingPeriod <= IIPTokenStaking.StakingPeriod.LONG, "IPTokenStaking: Invalid staking period");
         (uint256 stakeAmount, uint256 remainder) = roundedStakeAmount(msg.value);
         if (stakeAmount < minStakeAmount) {
             revert Errors.IPTokenStaking__StakeAmountUnderMin();

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -50,9 +50,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
     /// @notice The fee paid to update a validator (unjail, commission update, etc.)
     uint256 public fee;
 
-    /// @notice Staking periods and their corresponding durations
-    mapping(IIPTokenStaking.StakingPeriod period => uint32 duration) public stakingDurations;
-
     /// @notice Verifies that the syntax of the given public key is a 65 byte uncompressed secp256k1 public key.
     modifier verifyUncmpPubkey(bytes calldata uncmpPubkey) {
         if (uncmpPubkey.length != 65) {
@@ -109,7 +106,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         _setMinStakeAmount(args.minStakeAmount);
         _setMinUnstakeAmount(args.minUnstakeAmount);
         _setMinCommissionRate(args.minCommissionRate);
-        _setStakingPeriods(args.shortStakingPeriod, args.mediumStakingPeriod, args.longStakingPeriod);
         _setFee(args.fee);
     }
 
@@ -129,13 +125,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         _setMinUnstakeAmount(newMinUnstakeAmount);
     }
 
-    /// @dev Sets the staking periods and their corresponding durations.
-    /// @param short The duration of the short staking period.
-    /// @param medium The duration of the medium staking period.
-    /// @param long The duration of the long staking period.
-    function setStakingPeriods(uint32 short, uint32 medium, uint32 long) external onlyOwner {
-        _setStakingPeriods(short, medium, long);
-    }
 
     /// @notice Sets the fee charged for adding to CL storage.
     /// @param newFee The new fee
@@ -153,22 +142,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
     //                            Internal setters                            //
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Sets the staking periods and their corresponding durations.
-    function _setStakingPeriods(uint32 short, uint32 medium, uint32 long) private {
-        if (short == 0) {
-            revert Errors.IPTokenStaking__ZeroShortPeriodDuration();
-        }
-        if (short >= medium) {
-            revert Errors.IPTokenStaking__ShortPeriodLongerThanMedium();
-        }
-        if (medium >= long) {
-            revert Errors.IPTokenStaking__MediumLongerThanLong();
-        }
-        stakingDurations[IIPTokenStaking.StakingPeriod.SHORT] = short;
-        stakingDurations[IIPTokenStaking.StakingPeriod.MEDIUM] = medium;
-        stakingDurations[IIPTokenStaking.StakingPeriod.LONG] = long;
-        emit StakingPeriodsChanged(short, medium, long);
-    }
 
     /// @dev Sets the fee charged for adding to CL storage.
     function _setFee(uint256 newFee) private {
@@ -455,13 +428,11 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         if (stakeAmount < minStakeAmount) {
             revert Errors.IPTokenStaking__StakeAmountUnderMin();
         }
-        uint32 duration = 0;
         uint256 delegationId = 0;
         if (stakingPeriod != IIPTokenStaking.StakingPeriod.FLEXIBLE) {
             delegationId = ++_delegationIdCounter;
-            duration = stakingDurations[stakingPeriod];
         }
-        emit Deposit(delegatorUncmpPubkey, validatorUncmpPubkey, stakeAmount, duration, delegationId, msg.sender, data);
+        emit Deposit(delegatorUncmpPubkey, validatorUncmpPubkey, stakeAmount, uint8(stakingPeriod), delegationId, msg.sender, data);
         // We burn staked tokens
         payable(address(0)).transfer(stakeAmount);
 


### PR DESCRIPTION
Removes period durations from smart contract so it's not duplicated in EL ad CL.

issue: none
