### PR TITLE
feat(genesis): set genesis validator not using genutils

### DIFF
--- a/client/cmd/init.go
+++ b/client/cmd/init.go
@@ -235,6 +235,7 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 		// Derive the various addresses from the public key
 		accAddr := sdk.AccAddress(pubKey.Address().Bytes()).String()
 		valAddr := sdk.ValAddress(pubKey.Address().Bytes()).String()
+		consAddr := sdk.ConsAddress(pubKey.Address().Bytes()).String()
 		pubKeyBase64 := base64.StdEncoding.EncodeToString(pubKey.Bytes())
 		fmt.Println("Base64 Encoded Public Key:", pubKeyBase64)
 
@@ -242,6 +243,7 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 		genesisJSON = strings.ReplaceAll(genesisJSON, "{{LOCAL_ACCOUNT_ADDRESS}}", accAddr)
 		genesisJSON = strings.ReplaceAll(genesisJSON, "{{LOCAL_VALIDATOR_ADDRESS}}", valAddr)
 		genesisJSON = strings.ReplaceAll(genesisJSON, "{{LOCAL_VALIDATOR_KEY}}", pubKeyBase64)
+		genesisJSON = strings.ReplaceAll(genesisJSON, "{{LOCAL_CONS_ADDRESS}}", consAddr)
 
 		err = os.WriteFile(genFile, []byte(genesisJSON), 0o644)
 

--- a/lib/netconf/local/genesis.json
+++ b/lib/netconf/local/genesis.json
@@ -49,11 +49,11 @@
       },
       "balances": [
         {
-          "address": "{{LOCAL_ACCOUNT_ADDRESS}}",
+          "address": "story1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3h6nymd",
           "coins": [
             {
               "denom": "stake",
-              "amount": "10000000000000000"
+              "amount": "1000000"
             }
           ]
         }
@@ -61,7 +61,7 @@
       "supply": [
         {
           "denom": "stake",
-          "amount": "10000000000000000"
+          "amount": "1000000"
         }
       ],
       "denom_metadata": [],
@@ -88,59 +88,11 @@
     },
     "evmengine": {
       "params": {
-				"execution_block_hash": "MtGd+Hzb4VnGm+PGTXDJhSkChm+iUjUGCX7LUS8o754="
+        "execution_block_hash": "jz/Faw3DoAnmdx2pn/c3kA2oS5rq4V0briJcyLTbvcM="
       }
     },
     "genutil": {
-      "gen_txs": [
-        {
-          "body": {
-            "messages": [
-              {
-                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
-                "description": {
-                  "moniker": "Test",
-                  "identity": "",
-                  "website": "",
-                  "security_contact": "",
-                  "details": ""
-                },
-                "commission": {
-                  "rate": "0.000000000000000000",
-                  "max_rate": "0.000000000000000000",
-                  "max_change_rate": "0.000000000000000000"
-                },
-                "min_self_delegation": "1",
-                "delegator_address": "{{LOCAL_ACCOUNT_ADDRESS}}",
-                "validator_address": "{{LOCAL_VALIDATOR_ADDRESS}}",
-                "pubkey": {
-                  "@type": "/cosmos.crypto.secp256k1.PubKey",
-                  "key": "{{LOCAL_VALIDATOR_KEY}}"
-                },
-                "value": {
-                  "denom": "stake",
-                  "amount": "1000000000000000"
-                }
-              }
-            ],
-            "memo": "",
-            "timeout_height": "0",
-            "extension_options": [],
-            "non_critical_extension_options": []
-          },
-          "auth_info": {
-            "signer_infos": [],
-            "fee": {
-              "amount": [],
-              "gas_limit": "0",
-              "payer": "",
-              "granter": ""
-            },
-            "tip": null
-          },
-          "signatures": []
-        }
-      ]
+      "gen_txs": []
     },
     "slashing": {
       "params": {
@@ -150,7 +102,19 @@
         "slash_fraction_double_sign": "0.050000000000000000",
         "slash_fraction_downtime": "0.010000000000000000"
       },
-      "signing_infos": [],
+      "signing_infos": [
+        {
+          "address": "{{LOCAL_CONS_ADDRESS}}",
+          "validator_signing_info": {
+            "address": "{{LOCAL_ACCOUNT_ADDRESS}}",
+            "index_offset": "0",
+            "jailed_until": "1970-01-01T00:00:00Z",
+            "missed_blocks_counter": "0",
+            "start_height": "0",
+            "tombstoned": false
+          }
+        }
+      ],
       "missed_blocks": []
     },
     "staking": {
@@ -199,8 +163,47 @@
       },
       "last_total_power": "0",
       "last_validator_powers": [],
-      "validators": [],
-      "delegations": [],
+      "validators": [
+        {
+          "commission": {
+            "commission_rates": {
+              "max_change_rate": "0.000000000000000000",
+              "max_rate": "0.000000000000000000",
+              "rate": "0.000000000000000000"
+            },
+            "update_time": "1970-01-01T00:00:00Z"
+          },
+          "consensus_pubkey": {
+            "@type": "/cosmos.crypto.secp256k1.PubKey",
+            "key": "{{LOCAL_VALIDATOR_KEY}}"
+          },
+          "delegator_shares": "1",
+          "description": {
+            "details": "",
+            "identity": "",
+            "moniker": "Test",
+            "security_contact": "",
+            "website": ""
+          },
+          "jailed": false,
+          "min_self_delegation": "1024000000000",
+          "operator_address": "{{LOCAL_VALIDATOR_ADDRESS}}",
+          "status": "BOND_STATUS_BONDED",
+          "tokens": "1000000",
+          "unbonding_height": "0",
+          "unbonding_time": "1970-01-01T00:00:00Z",
+          "support_token_type": "0",
+          "delegator_rewards_shares": "500000"
+        }
+      ],
+      "delegations": [
+        {
+          "delegator_address": "{{LOCAL_ACCOUNT_ADDRESS}}",
+          "shares": "1000000",
+          "validator_address": "{{LOCAL_VALIDATOR_ADDRESS}}",
+          "rewards_shares": "500000"
+        }
+      ],
       "unbonding_delegations": [],
       "redelegations": [],
       "exported": false


### PR DESCRIPTION
Set state of genesis validator in genesis.json file for local devnet, not using genutils.
The address, `story1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3h6nymd`, is the address of bonded pool. This balance should be equal to the bonded coins.

issue: none
