### PR TITLE
feat(cmd): add persistent peers init override

### DIFF
--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -50,6 +50,7 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 	flags.StringVar(&cfg.ExternalAddress, "external-address", "", "Override the P2P external address")
 	flags.StringVar(&cfg.Seeds, "seeds", "", "Override the P2P seeds (comma-separated)")
 	flags.BoolVar(&cfg.SeedMode, "seed-mode", false, "Enable seed mode")
+	flags.StringVar(&cfg.PersistentPeers, "persistent-peers", "", "Override the persistent peers (comma-separated)")
 }
 
 func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {

--- a/client/cmd/init.go
+++ b/client/cmd/init.go
@@ -38,6 +38,7 @@ type InitConfig struct {
 	Seeds           string
 	SeedMode        bool
 	Moniker         string
+	PersistentPeers string
 }
 
 // newInitCmd returns a new cobra command that initializes the files and folders required by story.
@@ -165,6 +166,12 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 		// Otherwise, use the network's default seeds
 		comet.P2P.Seeds = strings.Join(networkSeeds, ",")
 		log.Info(ctx, "Using network's default P2P seeds", "seeds", comet.P2P.Seeds)
+	}
+
+	if initCfg.PersistentPeers != "" {
+		persistentPeers := SplitAndTrim(initCfg.PersistentPeers)
+		comet.P2P.PersistentPeers = strings.Join(persistentPeers, ",")
+		log.Info(ctx, "Overriding P2P persistent peers", "persistent-peers", comet.P2P.PersistentPeers)
 	}
 
 	if initCfg.SeedMode {


### PR DESCRIPTION
allows overriding the persistent peers setting on initialization

issue: none
