### PR TITLE
fix(staking): fix redelegate

### DIFF
--- a/contracts/src/interfaces/IIPTokenStaking.sol
+++ b/contracts/src/interfaces/IIPTokenStaking.sol
@@ -268,7 +268,7 @@ interface IIPTokenStaking {
         bytes calldata validatorUncmpDstPubkey,
         uint256 delegationId,
         uint256 amount
-    ) external payable;
+    ) external;
 
     /// @notice Entry point for redelegating the stake to another validator on behalf of the delegator.
     /// @dev For non flexible staking, your staking period will continue as is.
@@ -284,7 +284,7 @@ interface IIPTokenStaking {
         bytes calldata validatorUncmpDstPubkey,
         uint256 delegationId,
         uint256 amount
-    ) external payable;
+    ) external;
 
     /// @notice Entry point for unstaking the previously staked token.
     /// @dev Unstake (withdrawal) will trigger native minting, so token in this contract is considered as burned.

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -417,7 +417,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         uint256 amount
     )
         external
-        payable
         verifyUncmpPubkeyWithExpectedAddress(delegatorUncmpPubkey, msg.sender)
         verifyUncmpPubkey(validatorUncmpSrcPubkey)
         verifyUncmpPubkey(validatorUncmpDstPubkey)
@@ -441,7 +440,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         uint256 amount
     )
         external
-        payable
         verifyUncmpPubkey(delegatorUncmpPubkey)
         verifyUncmpPubkey(validatorUncmpSrcPubkey)
         verifyUncmpPubkey(validatorUncmpDstPubkey)
@@ -460,7 +458,7 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
             keccak256(validatorUncmpSrcPubkey) != keccak256(validatorUncmpDstPubkey),
             "IPTokenStaking: Redelegating to same validator"
         );
-        (uint256 stakeAmount, ) = roundedStakeAmount(msg.value);
+        (uint256 stakeAmount, ) = roundedStakeAmount(amount);
         require(stakeAmount >= minStakeAmount, "IPTokenStaking: Stake amount under min");
         require(delegationId <= _delegationIdCounter, "IPTokenStaking: Invalid delegation id");
 
@@ -470,7 +468,7 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
             validatorUncmpDstPubkey,
             delegationId,
             msg.sender,
-            amount
+            stakeAmount
         );
     }
 

--- a/contracts/test/stake/IPTokenStaking.t.sol
+++ b/contracts/test/stake/IPTokenStaking.t.sol
@@ -378,7 +378,7 @@ contract IPTokenStakingTest is Test {
         );
         vm.deal(delegatorAddr, stakeAmount);
         vm.prank(delegatorAddr);
-        ipTokenStaking.redelegate{ value: stakeAmount }(
+        ipTokenStaking.redelegate(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpDstPubkey,
@@ -390,7 +390,7 @@ contract IPTokenStakingTest is Test {
         vm.deal(address(0x4545), stakeAmount);
         vm.prank(address(0x4545));
         vm.expectRevert("PubKeyVerifier: Invalid pubkey derived address");
-        ipTokenStaking.redelegate{ value: stakeAmount }(
+        ipTokenStaking.redelegate(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpDstPubkey,
@@ -402,7 +402,7 @@ contract IPTokenStakingTest is Test {
         vm.deal(delegatorAddr, stakeAmount);
         vm.prank(delegatorAddr);
         vm.expectRevert("IPTokenStaking: Redelegating to same validator");
-        ipTokenStaking.redelegate{ value: stakeAmount }(
+        ipTokenStaking.redelegate(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpSrcPubkey,
@@ -413,7 +413,7 @@ contract IPTokenStakingTest is Test {
         vm.deal(delegatorAddr, stakeAmount);
         vm.prank(delegatorAddr);
         vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
-        ipTokenStaking.redelegate{ value: stakeAmount }(
+        ipTokenStaking.redelegate(
             delegatorUncmpPubkey,
             hex"04e38d15ae6cc5d41cce27a2307903cb", // pragma: allowlist secret
             validatorUncmpDstPubkey,
@@ -424,7 +424,7 @@ contract IPTokenStakingTest is Test {
         vm.deal(delegatorAddr, stakeAmount);
         vm.prank(delegatorAddr);
         vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
-        ipTokenStaking.redelegate{ value: stakeAmount }(
+        ipTokenStaking.redelegate(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             hex"04e38d15ae6cc5d41cce27a2307903cb", // pragma: allowlist secret
@@ -435,19 +435,19 @@ contract IPTokenStakingTest is Test {
         vm.deal(delegatorAddr, stakeAmount);
         vm.prank(delegatorAddr);
         vm.expectRevert("IPTokenStaking: Stake amount under min");
-        ipTokenStaking.redelegate{ value: stakeAmount - 1 }(
+        ipTokenStaking.redelegate(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpDstPubkey,
             delegationId,
-            stakeAmount + 100
+            stakeAmount - 1
         );
 
         // Revert if delegationId is invalid
         delegationId++;
         vm.prank(delegatorAddr);
         vm.expectRevert("IPTokenStaking: Invalid delegation id");
-        ipTokenStaking.redelegate{ value: stakeAmount }(
+        ipTokenStaking.redelegate(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpDstPubkey,
@@ -483,7 +483,7 @@ contract IPTokenStakingTest is Test {
         );
         vm.deal(operator, stakeAmount);
         vm.prank(operator);
-        ipTokenStaking.redelegateOnBehalf{ value: stakeAmount }(
+        ipTokenStaking.redelegateOnBehalf(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpDstPubkey,
@@ -495,7 +495,7 @@ contract IPTokenStakingTest is Test {
         vm.deal(operator, stakeAmount);
         vm.prank(operator);
         vm.expectRevert("IPTokenStaking: Redelegating to same validator");
-        ipTokenStaking.redelegateOnBehalf{ value: stakeAmount }(
+        ipTokenStaking.redelegateOnBehalf(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpSrcPubkey,
@@ -506,7 +506,7 @@ contract IPTokenStakingTest is Test {
         vm.deal(operator, stakeAmount);
         vm.prank(operator);
         vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
-        ipTokenStaking.redelegateOnBehalf{ value: stakeAmount }(
+        ipTokenStaking.redelegateOnBehalf(
             delegatorUncmpPubkey,
             hex"04e38d15ae6cc5d41cce27a2307903cb", // pragma: allowlist secret
             validatorUncmpDstPubkey,
@@ -517,7 +517,7 @@ contract IPTokenStakingTest is Test {
         vm.deal(operator, stakeAmount);
         vm.prank(operator);
         vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
-        ipTokenStaking.redelegateOnBehalf{ value: stakeAmount }(
+        ipTokenStaking.redelegateOnBehalf(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             hex"04e38d15ae6cc5d41cce27a2307903cb", // pragma: allowlist secret
@@ -528,19 +528,19 @@ contract IPTokenStakingTest is Test {
         vm.deal(operator, stakeAmount);
         vm.prank(operator);
         vm.expectRevert("IPTokenStaking: Stake amount under min");
-        ipTokenStaking.redelegateOnBehalf{ value: stakeAmount - 1 }(
+        ipTokenStaking.redelegateOnBehalf(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpDstPubkey,
             delegationId,
-            stakeAmount + 100
+            stakeAmount - 1
         );
 
         // Revert if delegationId is invalid
         delegationId++;
         vm.prank(operator);
         vm.expectRevert("IPTokenStaking: Invalid delegation id");
-        ipTokenStaking.redelegateOnBehalf{ value: stakeAmount }(
+        ipTokenStaking.redelegateOnBehalf(
             delegatorUncmpPubkey,
             validatorUncmpSrcPubkey,
             validatorUncmpDstPubkey,


### PR DESCRIPTION
Redelegate was mistakenly `payable`. Tokens are already in CL.

issue: fixes #255