### PR TITLE
feat(genesis): add singularity height to slashing module

### DIFF
--- a/client/x/evmstaking/types/params.go
+++ b/client/x/evmstaking/types/params.go
@@ -12,7 +12,7 @@ const (
 
 	DefaultMinPartialWithdrawalAmount uint64 = 600_000
 
-	DefaultSingularityHeight uint64 = 1209600 // 42 days with 35 seconds block time
+	DefaultSingularityHeight uint64 = 1209600 // 42 days with 3 seconds block time
 )
 
 // NewParams creates a new Params instance.

--- a/client/x/mint/keeper/abci.go
+++ b/client/x/mint/keeper/abci.go
@@ -22,7 +22,7 @@ func (k Keeper) BeginBlocker(ctx context.Context, ic types.InflationCalculationF
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	if sdkCtx.BlockHeight() <= int64(params.SingularityHeight) {
+	if sdkCtx.BlockHeight() < int64(params.SingularityHeight) {
 		log.Debug(ctx, "Skip minting during singularity")
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -295,7 +295,7 @@ replace (
 	cosmossdk.io/core v0.12.0 => cosmossdk.io/core v0.11.0
 
 	// Direct cosmos-sdk branch link: https://github.com/piplabs/cosmos-sdk/tree/piplabs/v0.50.7, current branch: piplabs/v0.50.7
-	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.14
+	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.8-0.20241020215712-ca039d442878
 
 	// See https://github.com/cosmos/cosmos-sdk/pull/14952
 	// Also https://github.com/cosmos/cosmos-db/blob/main/go.mod#L11-L12

--- a/go.sum
+++ b/go.sum
@@ -1032,8 +1032,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.14 h1:Ks4P6BZOAHs4Nhr3hX5uMhcK8KitVUajAr1RVXvz448=
-github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.14/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
+github.com/piplabs/cosmos-sdk v0.50.8-0.20241020215712-ca039d442878 h1:a49PS8MHEtZKtO/UoolwXEQl2QwKC+hZkVbmOFMPMaI=
+github.com/piplabs/cosmos-sdk v0.50.8-0.20241020215712-ca039d442878/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/lib/netconf/local/genesis.json
+++ b/lib/netconf/local/genesis.json
@@ -148,7 +148,8 @@
         "min_signed_per_window": "0.050000000000000000",
         "downtime_jail_duration": "60s",
         "slash_fraction_double_sign": "0.050000000000000000",
-        "slash_fraction_downtime": "0.010000000000000000"
+        "slash_fraction_downtime": "0.010000000000000000",
+        "singularity_height": "30"
       },
       "signing_infos": [],
       "missed_blocks": []

--- a/lib/netconf/odyssey/genesis.json
+++ b/lib/netconf/odyssey/genesis.json
@@ -609,7 +609,8 @@
         "min_signed_per_window": "0.050000000000000000",
         "downtime_jail_duration": "600s",
         "slash_fraction_double_sign": "0.050000000000000000",
-        "slash_fraction_downtime": "0.000200000000000000"
+        "slash_fraction_downtime": "0.000200000000000000",
+        "singularity_height": "1209600"
       },
       "signing_infos": [],
       "missed_blocks": []


### PR DESCRIPTION
With disabling the slash within singularity (https://github.com/piplabs/cosmos-sdk/pull/17), I added genesis param to our genesis.json file. The version of cosmos-sdk for replacement should be updated after merging the PR and release. 

issue: none
