### PR TITLE
feat(evidence): add evidence module with singularity

### DIFF
--- a/client/app/app.go
+++ b/client/app/app.go
@@ -29,6 +29,7 @@ import (
 	"github.com/piplabs/story/lib/ethclient"
 
 	_ "cosmossdk.io/api/cosmos/tx/config/v1"          // import for side-effects
+	_ "cosmossdk.io/x/evidence"                       // import for side-effects
 	_ "cosmossdk.io/x/upgrade"                        // import for side-effects
 	_ "github.com/cosmos/cosmos-sdk/x/auth"           // import for side-effects
 	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config" // import for side-effects
@@ -89,6 +90,7 @@ func newApp(
 		&app.Keepers.StakingKeeper,
 		&app.Keepers.SlashingKeeper,
 		&app.Keepers.DistrKeeper,
+		&app.Keepers.EvidenceKeeper,
 		&app.Keepers.ConsensusParamsKeeper,
 		&app.Keepers.GovKeeper,
 		&app.Keepers.UpgradeKeeper,

--- a/client/app/app_config.go
+++ b/client/app/app_config.go
@@ -7,6 +7,7 @@ import (
 	bankmodulev1 "cosmossdk.io/api/cosmos/bank/module/v1"
 	consensusmodulev1 "cosmossdk.io/api/cosmos/consensus/module/v1"
 	distrmodulev1 "cosmossdk.io/api/cosmos/distribution/module/v1"
+	evidencemodulev1 "cosmossdk.io/api/cosmos/evidence/module/v1"
 	genutilmodulev1 "cosmossdk.io/api/cosmos/genutil/module/v1"
 	govmodulev1 "cosmossdk.io/api/cosmos/gov/module/v1"
 	slashingmodulev1 "cosmossdk.io/api/cosmos/slashing/module/v1"
@@ -15,6 +16,7 @@ import (
 	upgrademodulev1 "cosmossdk.io/api/cosmos/upgrade/module/v1"
 	"cosmossdk.io/core/appconfig"
 	"cosmossdk.io/depinject"
+	evidencetypes "cosmossdk.io/x/evidence/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -83,6 +85,7 @@ var (
 		minttypes.ModuleName,
 		genutiltypes.ModuleName,
 		upgradetypes.ModuleName,
+		evidencetypes.ModuleName,
 		// Story modules
 		evmenginetypes.ModuleName,
 		evmstakingtypes.ModuleName,
@@ -101,6 +104,7 @@ var (
 		minttypes.ModuleName,
 		distrtypes.ModuleName, // Note: slashing happens after distr.BeginBlocker
 		slashingtypes.ModuleName,
+		evidencetypes.ModuleName,
 		stakingtypes.ModuleName,
 	}
 
@@ -191,6 +195,10 @@ var (
 			{
 				Name:   stakingtypes.ModuleName,
 				Config: appconfig.WrapAny(&stakingmodulev1.Module{}),
+			},
+			{
+				Name:   evidencetypes.ModuleName,
+				Config: appconfig.WrapAny(&evidencemodulev1.Module{}),
 			},
 			{
 				Name:   upgradetypes.ModuleName,

--- a/client/app/keepers/types.go
+++ b/client/app/keepers/types.go
@@ -5,6 +5,7 @@ package keepers
 // When performing `ignite scaffold` the keeper will be added to `app.go`. Please move them here.
 
 import (
+	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
 
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
@@ -31,6 +32,7 @@ type Keepers struct {
 	ConsensusParamsKeeper consensuskeeper.Keeper
 	GovKeeper             *govkeeper.Keeper
 	UpgradeKeeper         *upgradekeeper.Keeper
+	EvidenceKeeper        evidencekeeper.Keeper
 
 	// Story
 	EvmStakingKeeper *evmstakingkeeper.Keeper

--- a/go.mod
+++ b/go.mod
@@ -296,10 +296,10 @@ replace (
 	cosmossdk.io/core v0.12.0 => cosmossdk.io/core v0.11.0
 
 	// replace evidence module to the story's evidence module
-	cosmossdk.io/x/evidence => github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021201424-b11be3a942ed
+	cosmossdk.io/x/evidence => github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021233425-b586999d3a6a
 
 	// Direct cosmos-sdk branch link: https://github.com/piplabs/cosmos-sdk/tree/piplabs/v0.50.7, current branch: piplabs/v0.50.7
-	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.8-0.20241021201424-b11be3a942ed
+	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.16
 
 	// See https://github.com/cosmos/cosmos-sdk/pull/14952
 	// Also https://github.com/cosmos/cosmos-db/blob/main/go.mod#L11-L12

--- a/go.mod
+++ b/go.mod
@@ -251,6 +251,7 @@ require (
 )
 
 require (
+	cosmossdk.io/x/evidence v0.0.0-00010101000000-000000000000
 	cosmossdk.io/x/upgrade v0.1.4
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.4
 	github.com/go-playground/validator/v10 v10.11.1
@@ -294,8 +295,11 @@ replace (
 	// should use v0.11.0. The Cosmos build fails with types/context.go:65:29: undefined: comet.BlockInfo otherwise.
 	cosmossdk.io/core v0.12.0 => cosmossdk.io/core v0.11.0
 
+	// replace evidence module to the story's evidence module
+	cosmossdk.io/x/evidence => github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021201424-b11be3a942ed
+
 	// Direct cosmos-sdk branch link: https://github.com/piplabs/cosmos-sdk/tree/piplabs/v0.50.7, current branch: piplabs/v0.50.7
-	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.8-0.20241020215712-ca039d442878
+	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.8-0.20241021201424-b11be3a942ed
 
 	// See https://github.com/cosmos/cosmos-sdk/pull/14952
 	// Also https://github.com/cosmos/cosmos-db/blob/main/go.mod#L11-L12

--- a/go.mod
+++ b/go.mod
@@ -251,7 +251,7 @@ require (
 )
 
 require (
-	cosmossdk.io/x/evidence v0.0.0-00010101000000-000000000000
+	cosmossdk.io/x/evidence v0.1.0
 	cosmossdk.io/x/upgrade v0.1.4
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.4
 	github.com/go-playground/validator/v10 v10.11.1

--- a/go.mod
+++ b/go.mod
@@ -296,7 +296,7 @@ replace (
 	cosmossdk.io/core v0.12.0 => cosmossdk.io/core v0.11.0
 
 	// replace evidence module to the story's evidence module
-	cosmossdk.io/x/evidence => github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021233425-b586999d3a6a
+	cosmossdk.io/x/evidence => github.com/piplabs/cosmos-sdk/x/evidence v0.1.0
 
 	// Direct cosmos-sdk branch link: https://github.com/piplabs/cosmos-sdk/tree/piplabs/v0.50.7, current branch: piplabs/v0.50.7
 	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.16

--- a/go.sum
+++ b/go.sum
@@ -1032,8 +1032,10 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/piplabs/cosmos-sdk v0.50.8-0.20241020215712-ca039d442878 h1:a49PS8MHEtZKtO/UoolwXEQl2QwKC+hZkVbmOFMPMaI=
-github.com/piplabs/cosmos-sdk v0.50.8-0.20241020215712-ca039d442878/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
+github.com/piplabs/cosmos-sdk v0.50.8-0.20241021201424-b11be3a942ed h1:AWgPbmScpGdNkzOS1aJIKz+rF1akRvoYATlMrtLgfLI=
+github.com/piplabs/cosmos-sdk v0.50.8-0.20241021201424-b11be3a942ed/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
+github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021201424-b11be3a942ed h1:3SNuLrmqOqji5hPWDeyQAhrRArdWipZbXau4LQSGu/Y=
+github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021201424-b11be3a942ed/go.mod h1:3nXI6S45+w9FILC2+kfHO0XRNtDag5maRRIRAe0i9So=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -1034,8 +1034,8 @@ github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.16 h1:BSnu6Sxi1FySN8RukXJ7Hr589/G3ifMdWEPXmJMSsuA=
 github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.16/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
-github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021233425-b586999d3a6a h1:42YLUoEwUX9XGzBlhYs3ViTNhvFqZrh40maQ06+0dUQ=
-github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021233425-b586999d3a6a/go.mod h1:l9M6k8sqBTVuP+uLgPOk31FnRskMoUeiO5jG265l6XY=
+github.com/piplabs/cosmos-sdk/x/evidence v0.1.0 h1:zkP1KkXtGKKU1GT2O1ygGWRnNM+Fff/PYiEmovBWQBQ=
+github.com/piplabs/cosmos-sdk/x/evidence v0.1.0/go.mod h1:hTaiiXsoiJ3InMz1uptgF0BnGqROllAN8mwisOMMsfw=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -1032,10 +1032,10 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/piplabs/cosmos-sdk v0.50.8-0.20241021201424-b11be3a942ed h1:AWgPbmScpGdNkzOS1aJIKz+rF1akRvoYATlMrtLgfLI=
-github.com/piplabs/cosmos-sdk v0.50.8-0.20241021201424-b11be3a942ed/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
-github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021201424-b11be3a942ed h1:3SNuLrmqOqji5hPWDeyQAhrRArdWipZbXau4LQSGu/Y=
-github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021201424-b11be3a942ed/go.mod h1:3nXI6S45+w9FILC2+kfHO0XRNtDag5maRRIRAe0i9So=
+github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.16 h1:BSnu6Sxi1FySN8RukXJ7Hr589/G3ifMdWEPXmJMSsuA=
+github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.16/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
+github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021233425-b586999d3a6a h1:42YLUoEwUX9XGzBlhYs3ViTNhvFqZrh40maQ06+0dUQ=
+github.com/piplabs/cosmos-sdk/x/evidence v0.1.2-0.20241021233425-b586999d3a6a/go.mod h1:l9M6k8sqBTVuP+uLgPOk31FnRskMoUeiO5jG265l6XY=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
With [this](https://github.com/piplabs/cosmos-sdk/pull/18), slashing for double signing is also disabled during singularity.

issue: none
