### PR TITLE
feat(evmstaking): handle claimed reward in account

### DIFF
--- a/client/x/evmstaking/keeper/withdraw.go
+++ b/client/x/evmstaking/keeper/withdraw.go
@@ -294,7 +294,7 @@ func (k Keeper) EnqueueEligibleRewardWithdrawal(ctx context.Context, rewardWithd
 			delRewards = delRewards.Add(rewardCoins)
 		}
 
-		totalWithdrawalAmount := delRewards.AmountOf(sdk.DefaultBondDenom).Uint64()
+		delRewardUint64 := delRewards.AmountOf(sdk.DefaultBondDenom).Uint64()
 		log.Debug(
 			ctx, "Withdraw delegator rewards",
 			"validator_addr", rewardWithdrawals[i].ValidatorAddress,
@@ -302,7 +302,7 @@ func (k Keeper) EnqueueEligibleRewardWithdrawal(ctx context.Context, rewardWithd
 			"delegator_addr", rewardWithdrawals[i].DelegatorAddress,
 			"amount_calculate", rewardWithdrawals[i].WithdrawalEntry.Amount,
 			"amount_deposited", rewardWithdrawals[i].RemainedBalance,
-			"amount_total_withdrawal", totalWithdrawalAmount,
+			"amount_total_withdrawal", delRewardUint64,
 		)
 
 		// Burn tokens from the delegator
@@ -319,7 +319,7 @@ func (k Keeper) EnqueueEligibleRewardWithdrawal(ctx context.Context, rewardWithd
 		if err := k.AddRewardWithdrawalToQueue(ctx, types.NewWithdrawal(
 			uint64(sdk.UnwrapSDKContext(ctx).BlockHeight()),
 			rewardWithdrawals[i].WithdrawalEntry.ExecutionAddress,
-			totalWithdrawalAmount,
+			delRewardUint64,
 		)); err != nil {
 			return err
 		}


### PR DESCRIPTION
When a delegator delegates token multiple times, the accumulated reward token is transferred to the cosmos account. 
In this case, we need to cover this as well in reward withdrawal.

issue: none
