### PR TITLE
chore(cmd/flags): add moniker as init flag

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         platform:
           [linux-amd64, linux-arm64, darwin-amd64, darwin-arm64]
-          
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.5

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -51,6 +51,7 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 	flags.StringVar(&cfg.Seeds, "seeds", "", "Override the P2P seeds (comma-separated)")
 	flags.BoolVar(&cfg.SeedMode, "seed-mode", false, "Enable seed mode")
 	flags.StringVar(&cfg.PersistentPeers, "persistent-peers", "", "Override the persistent peers (comma-separated)")
+	flags.StringVar(&cfg.Moniker, "moniker", "", "Declare a custom moniker for your node")
 }
 
 func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {


### PR DESCRIPTION
adds moniker as an init flag to override default node naming

issue: none
