### PR TITLE
chore(workflows): pin release workflow version to 1.22.0

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.5
 
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
+
       - name: Display Go version
         run: go version
 


### PR DESCRIPTION
pins go version to 1.22.0 for the release workflow

issue: none
