### PR TITLE
fix(x/evmengine): remove sort & retry with timeout for events

### DIFF
--- a/client/x/evmengine/keeper/evmmsgs.go
+++ b/client/x/evmengine/keeper/evmmsgs.go
@@ -1,71 +1,60 @@
 package keeper
 
 import (
-	"bytes"
 	"context"
-	"slices"
-	"sort"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/piplabs/story/client/genutil/evm/predeploys"
 	"github.com/piplabs/story/client/x/evmengine/types"
 	"github.com/piplabs/story/lib/errors"
+	clog "github.com/piplabs/story/lib/log"
 )
 
 // evmEvents returns selected EVM log events from the provided block hash.
 func (k *Keeper) evmEvents(ctx context.Context, blockHash common.Hash) ([]*types.EVMEvent, error) {
-	var events []*types.EVMEvent
+	var logs []ethtypes.Log
+	err := retryForever(ctx, func(ctx context.Context) (fetched bool, err error) {
+		logs, err = k.engineCl.FilterLogs(ctx, ethereum.FilterQuery{
+			BlockHash: &blockHash,
+			Addresses: []common.Address{
+				common.HexToAddress(predeploys.IPTokenStaking),
+				common.HexToAddress(predeploys.UBIPool),
+				common.HexToAddress(predeploys.UpgradeEntrypoint),
+			},
+		})
+		if err != nil {
+			clog.Warn(ctx, "Failed fetching evm events (will retry)", err)
 
-	logs, err := k.engineCl.FilterLogs(ctx, ethereum.FilterQuery{
-		BlockHash: &blockHash,
-		// only IPTokenStaking contract
-		Addresses: []common.Address{
-			common.HexToAddress(predeploys.IPTokenStaking),
-			common.HexToAddress(predeploys.UBIPool),
-			common.HexToAddress(predeploys.UpgradeEntrypoint),
-		},
+			return false, nil // Retry
+		}
+
+		return true, nil
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "filter logs")
 	}
 
-	ll := make([]*types.EVMEvent, 0, len(logs))
+	events := make([]*types.EVMEvent, 0, len(logs))
 	for _, l := range logs {
 		topics := make([][]byte, 0, len(l.Topics))
 		for _, t := range l.Topics {
 			topics = append(topics, t.Bytes())
 		}
-		ll = append(ll, &types.EVMEvent{
+		events = append(events, &types.EVMEvent{
 			Address: l.Address.Bytes(),
 			Topics:  topics,
 			Data:    l.Data,
 		})
 	}
 
-	for _, log := range ll {
-		if err := log.Verify(); err != nil {
-			return nil, errors.Wrap(err, "verify log")
+	for _, event := range events {
+		if err := event.Verify(); err != nil {
+			return nil, errors.Wrap(err, "verify event")
 		}
 	}
-	events = append(events, ll...)
-
-	// Sort by Address > Topics > Data
-	// This avoids dependency on runtime ordering.
-	sort.Slice(events, func(i, j int) bool {
-		if cmp := bytes.Compare(events[i].Address, events[j].Address); cmp != 0 {
-			return cmp < 0
-		}
-
-		topicI := slices.Concat(events[i].Topics...)
-		topicJ := slices.Concat(events[j].Topics...)
-		if cmp := bytes.Compare(topicI, topicJ); cmp != 0 {
-			return cmp < 0
-		}
-
-		return bytes.Compare(events[i].Data, events[j].Data) < 0
-	})
 
 	return events, nil
 }

--- a/client/x/evmengine/keeper/helpers.go
+++ b/client/x/evmengine/keeper/helpers.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/expbackoff"
@@ -10,16 +11,24 @@ import (
 
 // backoffFunc aliased for testing.
 var (
+	retryTimeout  = time.Minute // Just prevent blocking forever
 	backoffFuncMu sync.RWMutex
 	backoffFunc   = expbackoff.New
 )
 
+// retryForever retries the given function forever until it returns true or an error.
+// In order for the function to be retried, it must return false and no error.
+//
+// Networking (any IO) is non-deterministic and can fail with temporary errors.
+// Keeper logic must however be deterministic, retrying forever mitigates this.
 func retryForever(ctx context.Context, fn func(ctx context.Context) (bool, error)) error {
 	backoffFuncMu.RLock()
 	backoff := backoffFunc(ctx)
 	backoffFuncMu.RUnlock()
 	for {
-		ok, err := fn(ctx)
+		innerCtx, cancel := context.WithTimeout(ctx, retryTimeout)
+		ok, err := fn(innerCtx)
+		cancel()
 		if ctx.Err() != nil {
 			return errors.Wrap(ctx.Err(), "retry canceled")
 		} else if err != nil {


### PR DESCRIPTION
remove sorting (use filtered logs indice as-is) and add retry with timeout for evm events

issue: #301
