### PR TITLE
chore(workflows): fix the action to upload artifacts

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -64,5 +64,13 @@ jobs:
           tag: ${{ github.event.release.tag_name }}
           file: |
             ./client/story-${{ matrix.platform }}
+          file_glob: false
+
+      - name: Upload binaries and source code to GitHub Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.release.tag_name }}
+          file: |
             ./client/story-${{ matrix.platform }}.sha256
           file_glob: false


### PR DESCRIPTION
fixes a bug to upload the binary and its checksum to GH release page

issue: none
