### PR TITLE
chore(*): bump cosmos ver for singularity slashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -299,7 +299,7 @@ replace (
 	cosmossdk.io/x/evidence => github.com/piplabs/cosmos-sdk/x/evidence v0.1.1-piplabs-v0.1
 
 	// Direct cosmos-sdk branch link: https://github.com/piplabs/cosmos-sdk/tree/piplabs/v0.50.7, current branch: piplabs/v0.50.7
-	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.19
+	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.20
 
 	// See https://github.com/cosmos/cosmos-sdk/pull/14952
 	// Also https://github.com/cosmos/cosmos-db/blob/main/go.mod#L11-L12

--- a/go.sum
+++ b/go.sum
@@ -1032,8 +1032,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.19 h1:BFNCafIt0Fud4FUo7UZ8GHdf+/kx8ASknGYyKDsHJXg=
-github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.19/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
+github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.20 h1:052Y1aCYhJ7khJv5JkkEXKyUDuYTruzgkFUp8p+s8qE=
+github.com/piplabs/cosmos-sdk v0.50.7-piplabs-v0.20/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
 github.com/piplabs/cosmos-sdk/x/evidence v0.1.1-piplabs-v0.1 h1:8NMQQNIwwETASsk2uPc9zNwWI5g8bQnpINdzmGTfvsM=
 github.com/piplabs/cosmos-sdk/x/evidence v0.1.1-piplabs-v0.1/go.mod h1:l9M6k8sqBTVuP+uLgPOk31FnRskMoUeiO5jG265l6XY=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
As described in #336, validator is jailed right after the singularity. It was due to that the skipping logic for downtime slashing was placed incorrectly. Fixed in [this PR](https://github.com/piplabs/cosmos-sdk/pull/25) and bump up the cosmos-sdk version accordingly.

issue: #336 
