### PR TITLE
fix: update default blockchain explorer URL in story validator create command

### DIFF
--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -57,7 +57,7 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
 	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://odyssey.storyrpc.io", "RPC URL to connect to the testnet")
 	cmd.Flags().StringVar(&cfg.PrivateKey, "private-key", "", "Private key used for the transaction")
-	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://odyssey.storyscan.xyz", "URL of the blockchain explorer")
+	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://odyssey-testnet-explorer.storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1516, "Chain ID to use for the transaction")
 }
 


### PR DESCRIPTION
### Summary
This commit updates the default blockchain explorer URL in the `story validator create` command. The previous URL was incorrect, so it's now set to https://odyssey-testnet-explorer.storyscan.xyz to direct users to the correct explorer.
