### PR TITLE
fix(cli): add converting delegator pubkey from cmp to uncmp

### DIFF
--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -105,7 +105,7 @@ func bindValidatorStakeOnBehalfFlags(cmd *cobra.Command, cfg *stakeConfig) {
 func bindValidatorUnstakeFlags(cmd *cobra.Command, cfg *unstakeConfig) {
 	bindValidatorBaseFlags(cmd, &cfg.baseConfig)
 	cmd.Flags().StringVar(&cfg.ValidatorPubKey, "validator-pubkey", "", "Validator's hex-encoded compressed 33-byte secp256k1 public key")
-	cmd.Flags().StringVar(&cfg.StakeAmount, "stake", "", "Amount for the validator to self-delegate in wei")
+	cmd.Flags().StringVar(&cfg.StakeAmount, "unstake", "", "Amount to unstake in wei")
 	cmd.Flags().Uint32Var(&cfg.DelegationID, "delegation-id", 0, "The delegation ID (0 for flexible staking)")
 }
 
@@ -113,7 +113,7 @@ func bindValidatorUnstakeOnBehalfFlags(cmd *cobra.Command, cfg *unstakeConfig) {
 	bindValidatorBaseFlags(cmd, &cfg.baseConfig)
 	cmd.Flags().StringVar(&cfg.ValidatorPubKey, "validator-pubkey", "", "Validator's hex-encoded compressed 33-byte secp256k1 public key")
 	cmd.Flags().StringVar(&cfg.DelegatorPubKey, "delegator-pubkey", "", "Delegator's hex-encoded compressed 33-byte secp256k1 public key")
-	cmd.Flags().StringVar(&cfg.StakeAmount, "stake", "", "Amount for the validator to self-delegate in wei")
+	cmd.Flags().StringVar(&cfg.StakeAmount, "unstake", "", "Amount to unstake in wei")
 	cmd.Flags().Uint32Var(&cfg.DelegationID, "delegation-id", 0, "The delegation ID (0 for flexible staking)")
 }
 
@@ -209,7 +209,7 @@ func validateValidatorStakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command
 }
 
 func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg *unstakeConfig) error {
-	if err := validateFlags(cmd, []string{"validator-pubkey", "stake"}); err != nil {
+	if err := validateFlags(cmd, []string{"validator-pubkey", "unstake"}); err != nil {
 		return errors.Wrap(err, "failed to validate unstake flags")
 	}
 
@@ -217,7 +217,7 @@ func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg 
 }
 
 func validateValidatorUnstakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command, cfg *unstakeConfig) error {
-	if err := validateFlags(cmd, []string{"validator-pubkey", "delegator-pubkey", "stake"}); err != nil {
+	if err := validateFlags(cmd, []string{"validator-pubkey", "delegator-pubkey", "unstake"}); err != nil {
 		return errors.Wrap(err, "failed to validate unstake-on-behalf flags")
 	}
 

--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -668,9 +668,14 @@ func unstake(ctx context.Context, cfg unstakeConfig) error {
 }
 
 func unstakeOnBehalf(ctx context.Context, cfg unstakeConfig) error {
-	uncompressedDelegatorPubKeyBytes, err := hex.DecodeString(cfg.DelegatorPubKey)
+	delegatorPubKeyBytes, err := hex.DecodeString(cfg.DelegatorPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded delegator pub key")
+	}
+
+	uncompressedDelegatorPubKeyBytes, err := cmpPubKeyToUncmpPubKey(delegatorPubKeyBytes)
+	if err != nil {
+		return errors.Wrap(err, "failed to uncompress delegator public key")
 	}
 
 	validatorPubKeyBytes, err := hex.DecodeString(cfg.ValidatorPubKey)


### PR DESCRIPTION
Fix unstake command
- converting delegator's compressed pubkey to uncompressed pubkey
- changing name of flag for unstake amount

issue: #351
