### PR TITLE
fix(evmengine): graceful post finalize errors

### DIFF
--- a/client/x/evmengine/keeper/abci.go
+++ b/client/x/evmengine/keeper/abci.go
@@ -188,7 +188,10 @@ func (k *Keeper) PostFinalize(ctx sdk.Context) error {
 	// Maybe start building the next block if we are the next proposer.
 	isNext, err := k.isNextProposer(ctx, proposer, height)
 	if err != nil {
-		return errors.Wrap(err, "next proposer")
+		// IsNextProposer does non-deterministic cometBFT queries, don't stall node due to errors.
+		log.Warn(ctx, "Next proposer failed, skipping optimistic EVM payload build", err)
+
+		return nil
 	} else if !isNext {
 		return nil // Nothing to do if we are not next proposer.
 	}


### PR DESCRIPTION
This PR is the commit from Omni to handle errors in PostFinalize gracefully (https://github.com/omni-network/omni/pull/2508). When non-deterministic response received from CometBFT, skip optimistic build.

issue: none
