### PR TITLE
fix(evmengine): get next proposer via comet algo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,14 @@ linters-settings:
   nolintlint:
     require-explanation: true
     require-specific: true
+  paralleltest:
+    # Ignore missing calls to `t.Parallel()` and only report incorrect uses of it.
+    # Default: false
+    ignore-missing: true
+    # Ignore missing calls to `t.Parallel()` in subtests. Top-level tests are
+    # still required to have `t.Parallel`, but subtests are allowed to skip it.
+    # Default: false
+    ignore-missing-subtests: true
   revive:
     enable-all-rules: true
     severity: warning

--- a/client/app/start.go
+++ b/client/app/start.go
@@ -136,7 +136,7 @@ func Start(ctx context.Context, cfg Config) (func(context.Context) error, error)
 	}
 
 	rpcClient := rpclocal.New(cmtNode)
-	cmtAPI := comet.NewAPI(rpcClient)
+	cmtAPI := comet.NewAPI(rpcClient, app.ChainID())
 	app.SetCometAPI(cmtAPI)
 
 	log.Info(ctx, "Starting CometBFT", "listeners", cmtNode.Listeners())

--- a/client/comet/comet.go
+++ b/client/comet/comet.go
@@ -3,118 +3,53 @@ package comet
 import (
 	"context"
 
+	lightprovider "github.com/cometbft/cometbft/light/provider"
+	lighthttp "github.com/cometbft/cometbft/light/provider/http"
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	cmttypes "github.com/cometbft/cometbft/types"
-	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/piplabs/story/lib/errors"
-	"github.com/piplabs/story/lib/k1util"
 	"github.com/piplabs/story/lib/tracer"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
-const perPageConst = 100
-
 var _ API = adapter{}
 
 type API interface {
-	// Validators returns the cometBFT validators at the given height or false if not
-	// available (probably due to snapshot sync after height).
-	Validators(ctx context.Context, height int64) (*cmttypes.ValidatorSet, bool, error)
-
-	// IsValidator returns true if the given address is a validator at the latest height.
-	// It is best-effort, so returns false on any error.
-	IsValidator(ctx context.Context, valAddress common.Address) bool
+	// Validators returns the cometBFT validators at the given height.
+	Validators(ctx context.Context, height int64) (*cmttypes.ValidatorSet, error)
 }
 
-func NewAPI(cl rpcclient.Client) API {
-	return adapter{cl: cl}
+func NewAPI(cl rpcclient.Client, chainID string) API {
+	return adapter{
+		cl: lighthttp.NewWithClient(chainID, remoteCl{cl}),
+	}
 }
 
 type adapter struct {
-	cl rpcclient.Client
+	cl lightprovider.Provider
 }
 
-// IsValidator returns true if the given address is a validator at the latest height.
-// It is best-effort, so returns false on any error.
-func (a adapter) IsValidator(ctx context.Context, valAddress common.Address) bool {
-	ctx, span := tracer.Start(ctx, "comet/is_validator")
-	defer span.End()
-
-	status, err := a.cl.Status(ctx)
-	if err != nil || status.SyncInfo.CatchingUp {
-		return false // Best effort
-	}
-
-	valset, ok, err := a.Validators(ctx, status.SyncInfo.LatestBlockHeight)
-	if !ok || err != nil {
-		return false // Best effort
-	}
-
-	for _, val := range valset.Validators {
-		addr, err := k1util.PubKeyToAddress(val.PubKey)
-		if err != nil {
-			continue // Best effort
-		}
-
-		if addr == valAddress {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Validators returns the cometBFT validators at the given height or false if not
-// available (probably due to snapshot sync after height).
-func (a adapter) Validators(ctx context.Context, height int64) (*cmttypes.ValidatorSet, bool, error) {
+// Validators returns the cometBFT validators at the given height.
+func (a adapter) Validators(ctx context.Context, height int64) (*cmttypes.ValidatorSet, error) {
 	ctx, span := tracer.Start(ctx, "comet/validators", trace.WithAttributes(attribute.Int64("height", height)))
 	defer span.End()
 
-	perPage := perPageConst // Can't take a pointer to a const directly.
-
-	var vals []*cmttypes.Validator
-	for page := 1; ; page++ { // Pages are 1-indexed.
-		if page > 10 { // Sanity check.
-			return nil, false, errors.New("too many validators [BUG]")
-		}
-
-		status, err := a.cl.Status(ctx)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "fetch status")
-		} else if height < status.SyncInfo.EarliestBlockHeight {
-			// This can happen if height is before snapshot restore.
-			return nil, false, nil
-		}
-
-		valResp, err := a.cl.Validators(ctx, &height, &page, &perPage)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "fetch validators")
-		}
-
-		for _, v := range valResp.Validators {
-			vals = append(vals, cmttypes.NewValidator(v.PubKey, v.VotingPower))
-		}
-
-		if len(vals) == valResp.Total {
-			break
-		}
+	block, err := a.cl.LightBlock(ctx, height) // LightBlock does all the heavy lifting to query the validator set.
+	if err != nil {
+		return nil, errors.Wrap(err, "fetch light block")
 	}
 
-	// cmttypes.NewValidatorSet() panics on error, so manually construct it for proper error handling.
-	valset := new(cmttypes.ValidatorSet)
-	if err := valset.UpdateWithChangeSet(vals); err != nil {
-		return nil, false, errors.Wrap(err, "update with change set")
-	}
-	if len(vals) > 0 {
-		valset.IncrementProposerPriority(1) // See cmttypes.NewValidatorSet
-	}
+	return block.ValidatorSet, nil
+}
 
-	if err := valset.ValidateBasic(); err != nil {
-		return nil, false, errors.Wrap(err, "validate basic")
-	}
+// remoteCl is a wrapper around rpcclient.Client to implement rpcclient.RemoteClient.
+type remoteCl struct {
+	rpcclient.Client
+}
 
-	return valset, true, nil
+func (remoteCl) Remote() string {
+	return ""
 }

--- a/client/x/evmengine/keeper/abci.go
+++ b/client/x/evmengine/keeper/abci.go
@@ -93,6 +93,7 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 			return nil, err
 		}
 		triggeredAt = time.Now()
+		log.Debug(ctx, "Started non-optimistic payload", "height", req.Height, "payload", payloadID.String())
 	} else {
 		log.Info(ctx, "Using optimistic payload", "height", height, "payload", payloadID.String())
 	}
@@ -183,12 +184,11 @@ func (k *Keeper) PostFinalize(ctx sdk.Context) error {
 
 	// Extract context values
 	height := ctx.BlockHeight()
-	proposer := ctx.BlockHeader().ProposerAddress
 	timestamp := ctx.BlockTime()
 	appHash := common.BytesToHash(ctx.BlockHeader().AppHash) // This is the app hash after the block is finalized.
 
 	// Maybe start building the next block if we are the next proposer.
-	isNext, err := k.isNextProposer(ctx, proposer, height)
+	isNext, err := k.isNextProposer(ctx, height)
 	if err != nil {
 		// IsNextProposer does non-deterministic cometBFT queries, don't stall node due to errors.
 		log.Warn(ctx, "Next proposer failed, skipping optimistic EVM payload build", err)

--- a/client/x/evmengine/keeper/abci_internal_test.go
+++ b/client/x/evmengine/keeper/abci_internal_test.go
@@ -316,7 +316,6 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 	})
 }
 
-
 func TestKeeper_PostFinalize(t *testing.T) {
 	payloadID := eengine.PayloadID{0x1}
 	payloadFailedToSet := func(k *Keeper) {

--- a/client/x/evmengine/keeper/abci_internal_test.go
+++ b/client/x/evmengine/keeper/abci_internal_test.go
@@ -476,7 +476,7 @@ func TestKeeper_PostFinalize(t *testing.T) {
 			if tt.isNextProposer {
 				nxtAddr, err = k1util.PubKeyToAddress(cmtAPI.validatorSet.CopyIncrementProposerPriority(1).Proposer.PubKey)
 			} else {
-				nxtAddr, err = k1util.PubKeyToAddress(cmtAPI.validatorSet.CopyIncrementProposerPriority(2).Proposer.PubKey)
+				nxtAddr = common.HexToAddress("0x0000000000000000000000000000000000000000")
 			}
 			require.NoError(t, err)
 

--- a/client/x/evmengine/keeper/keeper.go
+++ b/client/x/evmengine/keeper/keeper.go
@@ -193,7 +193,7 @@ func (k *Keeper) isNextProposer(ctx context.Context, currentHeight int64) (bool,
 	}
 
 	nextProposer := valset.CopyIncrementProposerPriority(1).Proposer
-	nextAddr, err := k1util.PubKeyToAddress(nextProposer.PubKey)
+	nextAddr, err := k1util.PubKeyToAddress(nextProposer.PubKey) // Convert to EVM address
 	if err != nil {
 		return false, err
 	}

--- a/client/x/evmengine/keeper/keeper.go
+++ b/client/x/evmengine/keeper/keeper.go
@@ -177,31 +177,22 @@ func (k *Keeper) parseAndVerifyProposedPayload(ctx context.Context, msg *types.M
 	return payload, nil
 }
 
-// isNextProposer returns true if the local node is the proposer
-// for the next block. It also returns the next block height.
+// isNextProposer returns true if the local node is the proposer for the next block
 //
 // Note that the validator set can change, so this is an optimistic check.
-func (k *Keeper) isNextProposer(ctx context.Context, currentProposer []byte, currentHeight int64) (bool, error) {
+func (k *Keeper) isNextProposer(ctx context.Context, currentHeight int64) (bool, error) {
 	// PostFinalize can be called during block replay (performed in newCometNode),
 	// but cmtAPI is set only after newCometNode completes (see app.SetCometAPI), so a nil check is necessary.
 	if k.cmtAPI == nil {
 		return false, nil
 	}
 
-	valset, ok, err := k.cmtAPI.Validators(ctx, currentHeight)
+	valset, err := k.cmtAPI.Validators(ctx, currentHeight)
 	if err != nil {
 		return false, err
-	} else if !ok || len(valset.Validators) == 0 {
-		return false, errors.New("validators not available")
 	}
 
-	idx, _ := valset.GetByAddress(currentProposer)
-	if idx < 0 {
-		return false, errors.New("proposer not in validator set")
-	}
-
-	nextIdx := int(idx+1) % len(valset.Validators)
-	nextProposer := valset.Validators[nextIdx]
+	nextProposer := valset.CopyIncrementProposerPriority(1).Proposer
 	nextAddr, err := k1util.PubKeyToAddress(nextProposer.PubKey)
 	if err != nil {
 		return false, err

--- a/client/x/evmengine/keeper/msg_server_internal_test.go
+++ b/client/x/evmengine/keeper/msg_server_internal_test.go
@@ -46,7 +46,7 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 	// set the header and proposer so we have the correct next proposer
 	header := cmtproto.Header{Height: 1, AppHash: tutil.RandomHash().Bytes()}
 	header.ProposerAddress = cmtAPI.validatorSet.Validators[0].Address
-	nxtAddr, err := k1util.PubKeyToAddress(cmtAPI.validatorSet.Validators[1].PubKey)
+	nxtAddr, err := k1util.PubKeyToAddress(cmtAPI.validatorSet.CopyIncrementProposerPriority(1).Proposer.PubKey)
 	require.NoError(t, err)
 
 	ctx, storeKey, storeService := setupCtxStore(t, &header)

--- a/client/x/evmengine/keeper/upgrades_internal_test.go
+++ b/client/x/evmengine/keeper/upgrades_internal_test.go
@@ -278,7 +278,7 @@ func setupTestEnvironment(t *testing.T) (*Keeper, sdk.Context, *gomock.Controlle
 	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk, dk)
 	require.NoError(t, err)
 	keeper.SetCometAPI(cmtAPI)
-	nxtAddr, err := k1util.PubKeyToAddress(cmtAPI.validatorSet.Validators[1].PubKey)
+	nxtAddr, err := k1util.PubKeyToAddress(cmtAPI.validatorSet.CopyIncrementProposerPriority(1).Proposer.PubKey)
 	require.NoError(t, err)
 	keeper.SetValidatorAddress(nxtAddr)
 	populateGenesisHead(ctx, t, keeper)

--- a/client/x/mint/keeper/genesis_test.go
+++ b/client/x/mint/keeper/genesis_test.go
@@ -1,4 +1,3 @@
-//nolint:paralleltest // just for testing
 package keeper_test
 
 import (

--- a/client/x/mint/keeper/grpc_query_test.go
+++ b/client/x/mint/keeper/grpc_query_test.go
@@ -1,4 +1,3 @@
-//nolint:paralleltest // just for testing
 package keeper_test
 
 import (

--- a/client/x/mint/keeper/keeper_test.go
+++ b/client/x/mint/keeper/keeper_test.go
@@ -1,4 +1,3 @@
-//nolint:paralleltest // just for testing
 package keeper_test
 
 import (

--- a/lib/expbackoff/expbackoff_test.go
+++ b/lib/expbackoff/expbackoff_test.go
@@ -1,4 +1,3 @@
-//nolint:paralleltest // Parallel tests not supported since test-alias globals are used.
 package expbackoff_test
 
 import (


### PR DESCRIPTION
use comet's exposed validators functions to check if the local node is the next (predicted) proposer

issue: closes #388 
