### PR TITLE
fix(contracts): more audit issues

### DIFF
--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -309,6 +309,7 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         external
         payable
         verifyUncmpPubkeyWithExpectedAddress(delegatorUncmpPubkey, msg.sender)
+        verifyUncmpPubkey(validatorUncmpPubkey)
         nonReentrant
         returns (uint256 delegationId)
     {
@@ -330,7 +331,14 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         bytes calldata validatorUncmpPubkey,
         IIPTokenStaking.StakingPeriod stakingPeriod,
         bytes calldata data
-    ) external payable verifyUncmpPubkey(delegatorUncmpPubkey) nonReentrant returns (uint256 delegationId) {
+    )
+        external
+        payable
+        verifyUncmpPubkey(delegatorUncmpPubkey)
+        verifyUncmpPubkey(validatorUncmpPubkey)
+        nonReentrant
+        returns (uint256 delegationId)
+    {
         return _stake(delegatorUncmpPubkey, validatorUncmpPubkey, stakingPeriod, data);
     }
 

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -511,6 +511,7 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
     ) private {
         require(delegationId <= _delegationIdCounter, "IPTokenStaking: Invalid delegation id");
         require(amount >= minUnstakeAmount, "IPTokenStaking: Unstake amount under min");
+        require(amount % STAKE_ROUNDING == 0, "IPTokenStaking: Amount must be rounded to STAKE_ROUNDING");
         emit Withdraw(delegatorUncmpPubkey, validatorUncmpPubkey, amount, delegationId, msg.sender, data);
     }
 

--- a/contracts/test/stake/IPTokenStaking.t.sol
+++ b/contracts/test/stake/IPTokenStaking.t.sol
@@ -366,6 +366,19 @@ contract IPTokenStakingTest is Test {
             ""
         );
         vm.stopPrank();
+
+        // Revert if amount is not rounded to STAKE_ROUNDING
+        uint256 unroundedAmount = ipTokenStaking.minUnstakeAmount() + ipTokenStaking.STAKE_ROUNDING() + 1;
+        vm.deal(delegatorAddr, feeAmount);
+        vm.prank(delegatorAddr);
+        vm.expectRevert("IPTokenStaking: Amount must be rounded to STAKE_ROUNDING");
+        ipTokenStaking.unstake{ value: feeAmount }(
+            delegatorUncmpPubkey,
+            validatorPubkey,
+            delegationId,
+            unroundedAmount,
+            ""
+        );
     }
 
     function testIPTokenStaking_Redelegation() public {

--- a/contracts/test/stake/IPTokenStaking.t.sol
+++ b/contracts/test/stake/IPTokenStaking.t.sol
@@ -242,6 +242,28 @@ contract IPTokenStakingTest is Test {
             ""
         );
         assertEq(delegationId, expectedDelegationId);
+
+        // Test revert for malformed validator pubkey
+        vm.deal(delegatorAddr, stakeAmount);
+        vm.prank(delegatorAddr);
+        vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
+        ipTokenStaking.stake{ value: stakeAmount }(
+            delegatorUncmpPubkey,
+            hex"04e38d15ae6cc5d41cce27a2307903cb", // Malformed validator pubkey
+            IIPTokenStaking.StakingPeriod.FLEXIBLE,
+            ""
+        );
+
+        // Test revert for malformed delegator pubkey
+        vm.deal(delegatorAddr, stakeAmount);
+        vm.prank(delegatorAddr);
+        vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
+        ipTokenStaking.stake{ value: stakeAmount }(
+            hex"04e38d15ae6cc5d41cce27a2307903cb", // Malformed delegator pubkey
+            validatorPubkey,
+            IIPTokenStaking.StakingPeriod.FLEXIBLE,
+            ""
+        );
     }
 
     function testIPTokenStaking_stake_remainder() public {

--- a/contracts/test/stake/IPTokenStaking.t.sol
+++ b/contracts/test/stake/IPTokenStaking.t.sol
@@ -249,7 +249,7 @@ contract IPTokenStakingTest is Test {
         vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
         ipTokenStaking.stake{ value: stakeAmount }(
             delegatorUncmpPubkey,
-            hex"04e38d15ae6cc5d41cce27a2307903cb", // Malformed validator pubkey
+            hex"04e38d15ae6cc5d41cce27a2307903cb", // pragma: allowlist-secret
             IIPTokenStaking.StakingPeriod.FLEXIBLE,
             ""
         );
@@ -259,7 +259,7 @@ contract IPTokenStakingTest is Test {
         vm.prank(delegatorAddr);
         vm.expectRevert("PubKeyVerifier: Invalid pubkey length");
         ipTokenStaking.stake{ value: stakeAmount }(
-            hex"04e38d15ae6cc5d41cce27a2307903cb", // Malformed delegator pubkey
+            hex"04e38d15ae6cc5d41cce27a2307903cb", // pragma: allowlist-secret
             validatorPubkey,
             IIPTokenStaking.StakingPeriod.FLEXIBLE,
             ""


### PR DESCRIPTION
- TRST-R-5: Apply rounding mechanism to IPTokenStaking._unstake()
- TRST-R-3: IPTokenStaking stake() and stakeOnBehalf() do not check validator key to be valid

issue: none
