### PR TITLE
fix(contracts): remove create validator on behalf

### DIFF
--- a/contracts/src/interfaces/IIPTokenStaking.sol
+++ b/contracts/src/interfaces/IIPTokenStaking.sol
@@ -201,27 +201,6 @@ interface IIPTokenStaking {
         bytes calldata data
     ) external payable;
 
-    /// @notice Entry point for creating a new validator on behalf of someone else.
-    /// WARNING: If validatorUncmpPubkey is wrong, the stake will go to an address that the sender
-    /// won't be able to control and unstake from, funds will be lost. If you want to make sure the
-    /// caller is the owner of the validator, use createValidator instead.
-    /// @param validatorUncmpPubkey 65 bytes uncompressed secp256k1 public key.
-    /// @param moniker The moniker of the validator.
-    /// @param commissionRate The commission rate of the validator.
-    /// @param maxCommissionRate The maximum commission rate of the validator.
-    /// @param maxCommissionChangeRate The maximum commission change rate of the validator.
-    /// @param supportsUnlocked Whether the validator supports unlocked staking.
-    /// @param data Additional data for the validator.
-    function createValidatorOnBehalf(
-        bytes calldata validatorUncmpPubkey,
-        string calldata moniker,
-        uint32 commissionRate,
-        uint32 maxCommissionRate,
-        uint32 maxCommissionChangeRate,
-        bool supportsUnlocked,
-        bytes calldata data
-    ) external payable;
-
     /// @notice Entry point to stake (delegate) to the given validator. The consensus client (CL) is notified of
     /// the deposit and manages the stake accounting and validator onboarding. Payer must be the delegator.
     /// @dev Staking burns tokens in Execution Layer (EL). Unstaking (withdrawal) will trigger minting through

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -231,37 +231,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         );
     }
 
-    /// @notice Entry point for creating a new validator on behalf of someone else.
-    /// WARNING: If validatorUncmpPubkey is wrong, the stake will go to an address that the sender
-    /// won't be able to control and unstake from, funds will be lost. If you want to make sure the
-    /// caller is the owner of the validator, use createValidator instead.
-    /// @param validatorUncmpPubkey 65 bytes uncompressed secp256k1 public key.
-    /// @param moniker The moniker of the validator.
-    /// @param commissionRate The commission rate of the validator.
-    /// @param maxCommissionRate The maximum commission rate of the validator.
-    /// @param maxCommissionChangeRate The maximum commission change rate of the validator.
-    /// @param supportsUnlocked Whether the validator supports unlocked staking.
-    /// @param data Additional data for the validator.
-    function createValidatorOnBehalf(
-        bytes calldata validatorUncmpPubkey,
-        string calldata moniker,
-        uint32 commissionRate,
-        uint32 maxCommissionRate,
-        uint32 maxCommissionChangeRate,
-        bool supportsUnlocked,
-        bytes calldata data
-    ) external payable verifyUncmpPubkey(validatorUncmpPubkey) nonReentrant {
-        _createValidator(
-            validatorUncmpPubkey,
-            moniker,
-            commissionRate,
-            maxCommissionRate,
-            maxCommissionChangeRate,
-            supportsUnlocked,
-            data
-        );
-    }
-
     /// @dev Validator is the delegator when creating a new validator (self-delegation).
     /// @param validatorUncmpPubkey 65 bytes uncompressed secp256k1 public key.
     /// @param moniker The moniker of the validator.

--- a/contracts/test/stake/IPTokenStaking.t.sol
+++ b/contracts/test/stake/IPTokenStaking.t.sol
@@ -100,23 +100,6 @@ contract IPTokenStakingTest is Test {
             data: ""
         });
 
-        // Network shall not allow anyone to create a new validator on behalf if the msg.value < min
-        bytes
-            memory validator1Pubkey = hex"04e38d15ae6cc5d41cce27a2307903cb12a406cbf463fe5fef215bdf8aa988ced195e9327ac89cd362eaa0397f8d7f007c02b2a75642f174e455d339e4a1000000"; // pragma: allowlist-secret
-        stakeAmount = 0.5 ether;
-        vm.deal(delegatorAddr, 1 ether);
-        vm.prank(delegatorAddr);
-        vm.expectRevert("IPTokenStaking: Stake amount under min");
-        ipTokenStaking.createValidatorOnBehalf{ value: stakeAmount }({
-            validatorUncmpPubkey: validator1Pubkey,
-            moniker: "delegator's validator",
-            commissionRate: 1000,
-            maxCommissionRate: 5000,
-            maxCommissionChangeRate: 100,
-            supportsUnlocked: false,
-            data: ""
-        });
-
         // Network shall allow anyone to create a new validator by staking validator’s own tokens (self-delegation)
         stakeAmount = ipTokenStaking.minStakeAmount();
         vm.deal(delegatorAddr, stakeAmount);
@@ -140,35 +123,6 @@ contract IPTokenStakingTest is Test {
             maxCommissionRate: 5000,
             maxCommissionChangeRate: 100,
             supportsUnlocked: true,
-            data: abi.encode("data")
-        });
-
-        // Network shall allow anyone to create a new validator on behalf of a validator.
-        // Note that the operation stakes sender’s tokens to the validator, and the delegator will still be the validator itself.
-        bytes
-            memory validator2UncmpPubkey = hex"04e38d15ae6cc5d41cce27a2307903cb12a406cbf463fe5fef215bdf8aa988ced195e9327ac89cd362eaa0397f8d7f007c02b2a75642f174e455d339e4a1efe222"; // pragma: allowlist-secret
-        stakeAmount = ipTokenStaking.minStakeAmount();
-        vm.deal(delegatorAddr, stakeAmount);
-        vm.prank(delegatorAddr);
-        vm.expectEmit(address(ipTokenStaking));
-        emit IIPTokenStaking.CreateValidator(
-            validator2UncmpPubkey,
-            "delegator's validator",
-            stakeAmount,
-            1000,
-            5000,
-            100,
-            0, // supportsUnlocked
-            delegatorAddr,
-            abi.encode("data")
-        );
-        ipTokenStaking.createValidatorOnBehalf{ value: stakeAmount }({
-            validatorUncmpPubkey: validator2UncmpPubkey,
-            moniker: "delegator's validator",
-            commissionRate: 1000,
-            maxCommissionRate: 5000,
-            maxCommissionChangeRate: 100,
-            supportsUnlocked: false,
             data: abi.encode("data")
         });
 


### PR DESCRIPTION
To avoid possible frontrunning validator creation, we are removing this method as recommended by auditors.

issue: none
