### PR TITLE
chore(comet): change template package to avoid escape

### DIFF
--- a/client/cmd/comettoml.go
+++ b/client/cmd/comettoml.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"bytes"
-	"html/template"
 	"strings"
+	"text/template"
 
 	cmtconfig "github.com/cometbft/cometbft/config"
 	cmtos "github.com/cometbft/cometbft/libs/os"


### PR DESCRIPTION
with `html/template`, the character " was escaped so that converted to &#34. Changed to `text/template` as done in [cometbft](https://github.com/cometbft/cometbft/blob/main/config/toml.go#L7).

issue: none
