### PR TITLE
feat(*): support mainnet with network flag

### DIFF
--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -54,10 +54,10 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 }
 
 func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
-	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://storyrpc.io", "RPC URL to connect to the testnet")
+	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://storyrpc.io", "RPC URL to connect to the network")
 	cmd.Flags().StringVar(&cfg.PrivateKey, "private-key", "", "Private key used for the transaction")
 	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
-	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1516, "Chain ID to use for the transaction")
+	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1415, "Chain ID to use for the transaction")
 }
 
 func bindValidatorCreateFlags(cmd *cobra.Command, cfg *createValidatorConfig) {

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -54,9 +54,9 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 }
 
 func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
-	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://odyssey.storyrpc.io", "RPC URL to connect to the testnet")
+	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://storyrpc.io", "RPC URL to connect to the testnet")
 	cmd.Flags().StringVar(&cfg.PrivateKey, "private-key", "", "Private key used for the transaction")
-	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://odyssey.storyscan.xyz", "URL of the blockchain explorer")
+	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1516, "Chain ID to use for the transaction")
 }
 

--- a/client/cmd/init.go
+++ b/client/cmd/init.go
@@ -111,6 +111,8 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 		cfg = storycfg.IliadConfig
 	case network == netconf.Odyssey:
 		cfg = storycfg.OdysseyConfig
+	case network == netconf.Mainnet:
+		cfg = storycfg.MainnetConfig
 	case network == netconf.Local:
 		cfg = storycfg.LocalConfig
 	default:

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -81,6 +81,25 @@ var (
 		Seeds:              "",
 		SeedMode:           false,
 	}
+	MainnetConfig = Config{
+		HomeDir:            DefaultHomeDir(),
+		Network:            "mainnet",
+		EngineEndpoint:     DefaultEngineEndpoint,
+		EngineJWTFile:      DefaultJWTFile("mainnet"),
+		SnapshotInterval:   defaultSnapshotInterval,
+		SnapshotKeepRecent: defaultSnapshotKeepRecent,
+		BackendType:        string(defaultDBBackend),
+		MinRetainBlocks:    defaultMinRetainBlocks,
+		PruningOption:      pruningtypes.PruningOptionDefault,
+		EVMBuildDelay:      defaultEVMBuildDelay,
+		EVMBuildOptimistic: true,
+		API:                apisvr.DefaultConfig(),
+		Tracer:             tracer.DefaultConfig(),
+		RPCLaddr:           "tcp://127.0.0.1:26657",
+		ExternalAddress:    "",
+		Seeds:              "",
+		SeedMode:           false,
+	}
 	LocalConfig = Config{
 		HomeDir:            DefaultHomeDir(),
 		Network:            "local",

--- a/contracts/script/GenerateAlloc.s.sol
+++ b/contracts/script/GenerateAlloc.s.sol
@@ -48,7 +48,7 @@ contract GenerateAlloc is Script {
 
     string internal dumpPath = getDumpPath();
     bool public saveState = true;
-    uint256 public constant MAINNET_CHAIN_ID = 1514; // TBD
+    uint256 public constant MAINNET_CHAIN_ID = 1415; // TBD
     // Optionally allocate 10k test accounts for devnets/testnets
     bool private constant ALLOCATE_10K_TEST_ACCOUNTS = false;
     // Optionally keep the timelock admin role for testnets

--- a/lib/evmchain/evmchain.go
+++ b/lib/evmchain/evmchain.go
@@ -9,7 +9,7 @@ type Token string
 
 const (
 	// Mainnets.
-	IDStoryMainnet uint64 = 1514
+	IDStoryMainnet uint64 = 1415
 
 	// Local Testet.
 	IDLocal uint64 = 1511

--- a/lib/netconf/mainnet/genesis.json
+++ b/lib/netconf/mainnet/genesis.json
@@ -1,0 +1,687 @@
+{
+  "genesis_time": "2024-04-16T11:04:40.60280319Z",
+  "chain_id": "odyssey-0",
+  "initial_height": "1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "-1",
+      "max_gas": "-1"
+    },
+    "evidence": {
+      "max_age_num_blocks": "100000",
+      "max_age_duration": "172800000000000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "secp256k1"
+      ]
+    },
+    "version": {
+      "app": "0"
+    },
+    "abci": {
+      "vote_extensions_enable_height": "0"
+    }
+  },
+  "app_hash": "",
+  "app_state": {
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000"
+      },
+      "accounts": [
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story1kz2cgurfhgege6zqnk8vwupwzqcjry0dj99f7f",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story1wl873hxdkhhjalt86zgmyphfzlt2kl39cxp8pk",
+          "pub_key": null,
+          "account_number": "1",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story1pdj0z84lau0l7vf2jl4qs7yggv48p3av2g732g",
+          "pub_key": null,
+          "account_number": "2",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story1z0uqv8xrw2j23mlcpmzatt3jj9hzezdqpgfzvq",
+          "pub_key": null,
+          "account_number": "3",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story1qzlsuhxyggc58dakmk92420slnsares5k70h3a",
+          "pub_key": null,
+          "account_number": "4",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story12s7mczq0gsvzyav5sleje29pped8mpgc0vhygp",
+          "pub_key": null,
+          "account_number": "5",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story12s2acumq6ycr80jycpt2hzq94xqgtehvyzkxup",
+          "pub_key": null,
+          "account_number": "6",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "story1l6gpgqmucdn7yyuvdyeph74cgs2f7k66j4mkt3",
+          "pub_key": null,
+          "account_number": "7",
+          "sequence": "0"
+        }
+      ]
+    },
+    "bank": {
+      "params": {
+        "send_enabled": [
+          {
+            "denom": "stake",
+            "enabled": true
+          }
+        ],
+        "default_send_enabled": false
+      },
+      "balances": [
+        {
+          "address": "story1kz2cgurfhgege6zqnk8vwupwzqcjry0dj99f7f",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        },
+        {
+          "address": "story1wl873hxdkhhjalt86zgmyphfzlt2kl39cxp8pk",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        },
+        {
+          "address": "story1pdj0z84lau0l7vf2jl4qs7yggv48p3av2g732g",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        },
+        {
+          "address": "story1z0uqv8xrw2j23mlcpmzatt3jj9hzezdqpgfzvq",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        },
+        {
+          "address": "story1qzlsuhxyggc58dakmk92420slnsares5k70h3a",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        },
+        {
+          "address": "story12s7mczq0gsvzyav5sleje29pped8mpgc0vhygp",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        },
+        {
+          "address": "story12s2acumq6ycr80jycpt2hzq94xqgtehvyzkxup",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        },
+        {
+          "address": "story1l6gpgqmucdn7yyuvdyeph74cgs2f7k66j4mkt3",
+          "coins": [
+            {
+              "denom": "stake",
+              "amount": "1000000"
+            }
+          ]
+        }
+      ],
+      "supply": [
+        {
+          "denom": "stake",
+          "amount": "8000000"
+        }
+      ],
+      "denom_metadata": [],
+      "send_enabled": [
+        {
+          "denom": "stake",
+          "enabled": true
+        }
+      ]
+    },
+    "distribution": {
+      "params": {
+        "ubi": "0.065000000000000000",
+        "base_proposer_reward": "0.000000000000000000",
+        "bonus_proposer_reward": "0.000000000000000000",
+        "withdraw_addr_enabled": true,
+        "max_ubi": "0.200000000000000000"
+      },
+      "fee_pool": {
+        "ubi": []
+      },
+      "delegator_withdraw_infos": [],
+      "previous_proposer": "",
+      "outstanding_rewards": [],
+      "validator_accumulated_commissions": [],
+      "validator_historical_rewards": [],
+      "validator_current_rewards": [],
+      "delegator_starting_infos": [],
+      "validator_slash_events": []
+    },
+    "evmengine": {
+      "params": {
+        "execution_block_hash": "DuAKVKhgaUz2esEz/Fc1z5ZUDLeR+lXwhia6RK6z/3k="
+      }
+    },
+    "genutil": {
+      "gen_txs": [
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Story validator 1",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story1kz2cgurfhgege6zqnk8vwupwzqcjry0dj99f7f",
+                "validator_address": "storyvaloper1kz2cgurfhgege6zqnk8vwupwzqcjry0du23g4z",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "Au1YqTGauof2D+COh7wxZY3aa/15MWhnkKL/gDhG1OWc"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 0
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Story validator 2",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story1wl873hxdkhhjalt86zgmyphfzlt2kl39cxp8pk",
+                "validator_address": "storyvaloper1wl873hxdkhhjalt86zgmyphfzlt2kl39kf4x2a",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "A3/xIU9a9LZSvGw1LssSlnkc91SkJrSafEomMST3SX6Y"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 1
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Story validator 3",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story1pdj0z84lau0l7vf2jl4qs7yggv48p3av2g732g",
+                "validator_address": "storyvaloper1pdj0z84lau0l7vf2jl4qs7yggv48p3avy82spr",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "A8L3SB/SpMx9H0v/gJUI1cA/Drd7x4T6UFF3HlpEFOjA"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 0
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Story validator 4",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story1z0uqv8xrw2j23mlcpmzatt3jj9hzezdqpgfzvq",
+                "validator_address": "storyvaloper1z0uqv8xrw2j23mlcpmzatt3jj9hzezdq08ar8t",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "A2NNYUwaEmuDVwJk6ULF/qFylpYjYQ3KzdTW4FFEWMYd"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 1
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "B-Harvest validator 1",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story1qzlsuhxyggc58dakmk92420slnsares5k70h3a",
+                "validator_address": "storyvaloper1qzlsuhxyggc58dakmk92420slnsares5c3mk6k",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "AhEo8dSDDGQN0i3w8uSslGCKm/fXbvR1oxxghUXkjCA1"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 0
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "B-Harvest validator 2",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story12s7mczq0gsvzyav5sleje29pped8mpgc0vhygp",
+                "validator_address": "storyvaloper12s7mczq0gsvzyav5sleje29pped8mpgcprr9r2",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "A/Hrs9XwYiFBA/fNh4eYd7CYHFmiqZmufDZi6RkAI8Yv"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 1
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Blockdaemon validator 1",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story12s2acumq6ycr80jycpt2hzq94xqgtehvyzkxup",
+                "validator_address": "storyvaloper12s2acumq6ycr80jycpt2hzq94xqgtehv2dz8h2",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "A/JG6XepsRi5ahJYHm6Bb1c4LX3l6WT4cfGiXJd/5tTt"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 0
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        },
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "Blockdaemon validator 2",
+                  "identity": "",
+                  "website": "",
+                  "security_contact": "",
+                  "details": ""
+                },
+                "commission": {
+                  "rate": "0.070000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
+                },
+                "min_self_delegation": "1024000000000",
+                "delegator_address": "story1l6gpgqmucdn7yyuvdyeph74cgs2f7k66j4mkt3",
+                "validator_address": "storyvaloper1l6gpgqmucdn7yyuvdyeph74cgs2f7k66u60hq6",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "A3H7KJ3EfCWXSwFOBtAEJeU3jvd8CNuhV91m7T+vMm80"
+                },
+                "value": {
+                  "denom": "stake",
+                  "amount": "1000000"
+                },
+                "support_token_type": 1
+              }
+            ],
+            "memo": "",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [],
+            "fee": {
+              "amount": [],
+              "gas_limit": "0",
+              "payer": "",
+              "granter": ""
+            },
+            "tip": null
+          },
+          "signatures": []
+        }
+      ]
+    },
+    "slashing": {
+      "params": {
+        "signed_blocks_window": "28800",
+        "min_signed_per_window": "0.050000000000000000",
+        "downtime_jail_duration": "600s",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.000200000000000000"
+      },
+      "signing_infos": [],
+      "missed_blocks": []
+    },
+    "staking": {
+      "params": {
+        "unbonding_time": "1209600s",
+        "max_validators": 112,
+        "max_entries": 14,
+        "historical_entries": 10000,
+        "bond_denom": "stake",
+        "min_commission_rate": "0.050000000000000000",
+        "min_delegation": "1024000000000",
+        "flexible_period_type": 0,
+        "singularity_height": "403200",
+        "periods": [
+          {
+            "period_type": 0,
+            "duration": "0s",
+            "rewards_multiplier": "1.000000000000000000"
+          },
+          {
+            "period_type": 1,
+            "duration": "2592000s",
+            "rewards_multiplier": "1.051000000000000000"
+          },
+          {
+            "period_type": 2,
+            "duration": "10368000s",
+            "rewards_multiplier": "1.160000000000000000"
+          },
+          {
+            "period_type": 3,
+            "duration": "46656000s",
+            "rewards_multiplier": "1.340000000000000000"
+          }
+        ],
+        "locked_token_type": 0,
+        "token_types": [
+          {
+            "token_type": 0,
+            "rewards_multiplier": "0.500000000000000000"
+          },
+          {
+            "token_type": 1,
+            "rewards_multiplier": "1.000000000000000000"
+          }
+        ]
+      },
+      "last_total_power": "0",
+      "last_validator_powers": [],
+      "validators": [],
+      "delegations": [],
+      "unbonding_delegations": [],
+      "redelegations": [],
+      "exported": false
+    },
+    "evmstaking": {
+      "params": {
+        "max_withdrawal_per_block": 32,
+        "max_sweep_per_block": 128,
+        "min_partial_withdrawal_amount": 8000000000,
+        "ubi_withdraw_address": "0xcccccc0000000000000000000000000000000002"
+      }
+    },
+    "mint": {
+      "params": {
+        "mint_denom": "stake",
+        "inflations_per_year": "24625000000000000",
+        "blocks_per_year": "10368000"
+      }
+    }
+  }
+}

--- a/lib/netconf/network.go
+++ b/lib/netconf/network.go
@@ -35,6 +35,9 @@ const (
 
 	// Odyssey is the official Story Protocol public testnet.
 	Odyssey ID = "odyssey"
+
+	// Mainnet is the official Story Protocol public mainnet.
+	Mainnet ID = "mainnet"
 )
 
 // supported is a map of supported networks.
@@ -44,6 +47,7 @@ var supported = map[ID]bool{
 	Iliad:   true,
 	Odyssey: true,
 	Local:   true,
+	Mainnet: true,
 }
 
 // IsAny returns true if the `ID` matches any of the provided targets.

--- a/lib/netconf/static.go
+++ b/lib/netconf/static.go
@@ -71,6 +71,15 @@ var (
 	odysseyConsensusSeedsTXT []byte
 )
 
+//nolint:gochecknoglobals // Static addresses
+var (
+	//go:embed mainnet/genesis.json
+	mainnetConsensusGenesisJSON []byte
+
+	//go:embed mainnet/seeds.txt
+	mainnetConsensusSeedsTXT []byte
+)
+
 //nolint:gochecknoglobals // Static mappings.
 var statics = map[ID]Static{
 	Iliad: {
@@ -90,5 +99,11 @@ var statics = map[ID]Static{
 		StoryExecutionChainID: evmchain.IDOdyssey,
 		ConsensusGenesisJSON:  odysseyConsensusGenesisJSON,
 		ConsensusSeedTXT:      odysseyConsensusSeedsTXT,
+	},
+	Mainnet: {
+		Version:               "v0.0.1",
+		StoryExecutionChainID: evmchain.IDStoryMainnet,
+		ConsensusGenesisJSON:  mainnetConsensusGenesisJSON,
+		ConsensusSeedTXT:      mainnetConsensusSeedsTXT,
 	},
 }


### PR DESCRIPTION
Support mainnet with `--network` flag. The genesis.json and seeds.txt from Odyssey are used for now. We need to update this later. 

fyi, ref pr: #178 (which supports Odyssey)

issue: none
