### PR TITLE
fix(cmd): change to use create validator

### DIFF
--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -464,7 +464,7 @@ func createValidator(ctx context.Context, cfg createValidatorConfig) error {
 	_, err = prepareAndExecuteTransaction(
 		ctx,
 		&cfg.baseConfig,
-		"createValidatorOnBehalf",
+		"createValidator",
 		stakeAmount,
 		uncompressedPubKeyBytes,
 		cfg.Moniker,


### PR DESCRIPTION
Fix create validator command to use `createValidator` instead of `createValidatorOnBehalf`.

issue: #429 
