### PR TITLE
feat(upgrade): change rewards multiplier for mainnet

### DIFF
--- a/client/app/upgrades/singularity/virgil/constants.go
+++ b/client/app/upgrades/singularity/virgil/constants.go
@@ -17,7 +17,7 @@ const (
 	// AeneidUpgradeHeight defines the block height at which virgil upgrade is triggered on Aeneid.
 	AeneidUpgradeHeight = 345158
 	// StoryUpgradeHeight defines the block height at which virgil upgrade is triggered on Story.
-	StoryUpgradeHeight = 677886
+	StoryUpgradeHeight = 809988
 )
 
 var Upgrade = upgrades.Upgrade{

--- a/client/app/upgrades/singularity/virgil/constants.go
+++ b/client/app/upgrades/singularity/virgil/constants.go
@@ -1,6 +1,7 @@
 package virgil
 
 import (
+	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -32,6 +33,12 @@ var Fork = upgrades.Fork{
 	BeginForkLogic: func(_ sdk.Context, _ *keepers.Keepers) {},
 }
 
+type RewardsMultipliers struct {
+	Short  math.LegacyDec
+	Medium math.LegacyDec
+	Long   math.LegacyDec
+}
+
 func GetUpgradeHeight(chainID string) (int64, bool) {
 	switch chainID {
 	case upgrades.AeneidChainID:
@@ -40,5 +47,24 @@ func GetUpgradeHeight(chainID string) (int64, bool) {
 		return StoryUpgradeHeight, true
 	default:
 		return 0, false
+	}
+}
+
+var DefaultRewardsMultiplier = RewardsMultipliers{
+	Short:  math.LegacyNewDecWithPrec(1051, 3), // 1.051
+	Medium: math.LegacyNewDecWithPrec(116, 2),  // 1.16
+	Long:   math.LegacyNewDecWithPrec(134, 2),  // 1.34
+}
+
+func GetRewardsMultipliers(chainID string) RewardsMultipliers {
+	switch chainID {
+	case upgrades.StoryChainID:
+		return RewardsMultipliers{
+			Short:  math.LegacyNewDecWithPrec(11, 1), // 1.1
+			Medium: math.LegacyNewDecWithPrec(15, 1), // 1.5
+			Long:   math.LegacyNewDecWithPrec(20, 1), // 2
+		}
+	default:
+		return DefaultRewardsMultiplier
 	}
 }

--- a/client/app/upgrades/singularity/virgil/upgrades.go
+++ b/client/app/upgrades/singularity/virgil/upgrades.go
@@ -45,6 +45,7 @@ func CreateUpgradeHandler(
 		}
 
 		log.Info(ctx, "Update staking periods...")
+		newRewardsMultiplier := GetRewardsMultipliers(chainID)
 		var oldShortPeriodDuration time.Duration
 		for i := range stakingParams.Periods {
 			if stakingParams.Periods[i].PeriodType == 1 {
@@ -52,10 +53,16 @@ func CreateUpgradeHandler(
 				log.Info(ctx, "Existing short period duration", "Time", oldShortPeriodDuration.String())
 				log.Info(ctx, "Change short period duration to 90 days (7776000 seconds)")
 				stakingParams.Periods[i].Duration = NewShortPeriodDuration
+				log.Info(ctx, "Change short period rewards multiplier", "new_multiplier", newRewardsMultiplier.Short.String())
+				stakingParams.Periods[i].RewardsMultiplier = newRewardsMultiplier.Short
 			} else if stakingParams.Periods[i].PeriodType == 2 {
 				log.Info(ctx, "Existing medium period duration", "Time", stakingParams.Periods[i].Duration.String())
+				log.Info(ctx, "Change medium period rewards multiplier", "new_multiplier", newRewardsMultiplier.Medium.String())
+				stakingParams.Periods[i].RewardsMultiplier = newRewardsMultiplier.Medium
 			} else if stakingParams.Periods[i].PeriodType == 3 {
 				log.Info(ctx, "Existing long period duration", "Time", stakingParams.Periods[i].Duration.String())
+				log.Info(ctx, "Change long period rewards multiplier", "new_multiplier", newRewardsMultiplier.Long.String())
+				stakingParams.Periods[i].RewardsMultiplier = newRewardsMultiplier.Long
 			}
 		}
 
@@ -71,15 +78,24 @@ func CreateUpgradeHandler(
 		}
 
 		for _, p := range stakingParams.Periods {
-			if p.PeriodType == 1 {
+			if p.PeriodType == 1 { //nolint:nestif // no issue
 				log.Info(ctx, "New short period duration", "Time", p.Duration.String())
 				if p.Duration != NewShortPeriodDuration {
 					return vm, errors.New("new short period duration is not correct")
 				}
+				if !p.RewardsMultiplier.Equal(newRewardsMultiplier.Short) {
+					return vm, errors.New("new short period rewards multiplier is not correct")
+				}
 			} else if p.PeriodType == 2 {
 				log.Info(ctx, "New medium period duration", "Time", p.Duration.String())
+				if !p.RewardsMultiplier.Equal(newRewardsMultiplier.Medium) {
+					return vm, errors.New("new medium period rewards multiplier is not correct")
+				}
 			} else if p.PeriodType == 3 {
 				log.Info(ctx, "New long period duration", "Time", p.Duration.String())
+				if !p.RewardsMultiplier.Equal(newRewardsMultiplier.Long) {
+					return vm, errors.New("new long period rewards multiplier is not correct")
+				}
 			}
 		}
 


### PR DESCRIPTION
Add to change reward multiplier of period delegation for Mainnet. 

For Aeneid, the Virgil upgrade has already executed, so this change of upgrade handler do not change the multipliers for Aeneid. That means, anyone can sync blocks from the genesis with the new binary. 

This will only change the multipliers for Mainnet (`chainID` = `story-1`). This assumes that no period delegations will happen until the upgrade height since it will be in the singularity. 

Tested with localnet for the 2 cases
- mocking Aeneid (already upgrade executed, and sync block from the genesis with this new binary)
- mocking Mainnet (change staking params including rewards multiplier)

issue: none
