### PR TITLE
feat(cli): add verifications to cli

### DIFF
--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -67,7 +67,7 @@ func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
 	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://storyrpc.io", "RPC URL to connect to the network")
 	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1514, "Chain ID to use for the transaction")
-	cmd.Flags().StringVar(&cfg.API, "api", "", "URL of consensus client API server")
+	cmd.Flags().StringVar(&cfg.StakingAPI, "staking-api", "", "URL of Staking API server")
 }
 
 func bindValidatorCreateFlags(cmd *cobra.Command, cfg *createValidatorConfig) {
@@ -232,11 +232,11 @@ func validateValidatorCreateFlags(ctx context.Context, cmd *cobra.Command, cfg *
 		return errors.Wrap(err, "failed to extract compressed pub key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -278,11 +278,11 @@ func validateValidatorStakeFlags(ctx context.Context, cmd *cobra.Command, cfg *s
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -308,11 +308,11 @@ func validateValidatorStakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -338,11 +338,11 @@ func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg 
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -368,11 +368,11 @@ func validateValidatorUnstakeOnBehalfFlags(ctx context.Context, cmd *cobra.Comma
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -403,11 +403,11 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	existSrc, err := isValidatorFound(ctx, cfg.API, validatorSrcPubKey)
+	existSrc, err := isValidatorFound(ctx, cfg.StakingAPI, validatorSrcPubKey)
 	if err != nil {
 		return err
 	}
@@ -416,7 +416,7 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 		return errors.New("the src validator doesn't exist")
 	}
 
-	existDst, err := isValidatorFound(ctx, cfg.API, validatorDstPubKey)
+	existDst, err := isValidatorFound(ctx, cfg.StakingAPI, validatorDstPubKey)
 	if err != nil {
 		return err
 	}
@@ -447,11 +447,11 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	existSrc, err := isValidatorFound(ctx, cfg.API, validatorSrcPubKey)
+	existSrc, err := isValidatorFound(ctx, cfg.StakingAPI, validatorSrcPubKey)
 	if err != nil {
 		return err
 	}
@@ -460,7 +460,7 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 		return errors.New("the src validator doesn't exist")
 	}
 
-	existDst, err := isValidatorFound(ctx, cfg.API, validatorDstPubKey)
+	existDst, err := isValidatorFound(ctx, cfg.StakingAPI, validatorDstPubKey)
 	if err != nil {
 		return err
 	}
@@ -500,11 +500,11 @@ func validateValidatorUnjailFlags(ctx context.Context, cmd *cobra.Command, cfg *
 		return errors.Wrap(err, "failed to get compressed pub key from private key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -526,11 +526,11 @@ func validateValidatorUnjailOnBehalfFlags(ctx context.Context, cmd *cobra.Comman
 		return errors.Wrap(err, "failed to decode hex-encoded validator public key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -557,11 +557,11 @@ func validateUpdateValidatorCommissionFlags(ctx context.Context, cmd *cobra.Comm
 		return errors.Wrap(err, "failed to get compressed pub key from private key")
 	}
 
-	if cfg.API == "" {
+	if cfg.StakingAPI == "" {
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -649,7 +649,7 @@ func validateCommissionRate(ctx context.Context, cfg *createValidatorConfig) err
 }
 
 func validateNewCommissionRate(ctx context.Context, cfg *updateCommissionConfig, pubKey []byte) error {
-	validator, err := getValidatorByEVMAddr(ctx, cfg.API, pubKey)
+	validator, err := getValidatorByEVMAddr(ctx, cfg.StakingAPI, pubKey)
 	if err != nil {
 		return err
 	}

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -233,6 +233,7 @@ func validateValidatorCreateFlags(ctx context.Context, cmd *cobra.Command, cfg *
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -279,6 +280,7 @@ func validateValidatorStakeFlags(ctx context.Context, cmd *cobra.Command, cfg *s
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -309,6 +311,7 @@ func validateValidatorStakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -339,6 +342,7 @@ func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg 
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -369,6 +373,7 @@ func validateValidatorUnstakeOnBehalfFlags(ctx context.Context, cmd *cobra.Comma
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -404,6 +409,7 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -448,6 +454,7 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -501,6 +508,7 @@ func validateValidatorUnjailFlags(ctx context.Context, cmd *cobra.Command, cfg *
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -527,6 +535,7 @@ func validateValidatorUnjailOnBehalfFlags(ctx context.Context, cmd *cobra.Comman
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
@@ -558,6 +567,7 @@ func validateUpdateValidatorCommissionFlags(ctx context.Context, cmd *cobra.Comm
 	}
 
 	if cfg.StakingAPI == "" {
+		fmt.Println("No staking API is provided. Skip validator existence check and validation of new commission rate.")
 		return nil
 	}
 

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -227,13 +227,13 @@ func validateValidatorCreateFlags(ctx context.Context, cmd *cobra.Command, cfg *
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorPubKey, err := validatorKeyFileToCmpPubKey(cfg.ValidatorKeyFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to extract compressed pub key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
@@ -273,13 +273,13 @@ func validateValidatorStakeFlags(ctx context.Context, cmd *cobra.Command, cfg *s
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
@@ -303,13 +303,13 @@ func validateValidatorStakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
@@ -333,13 +333,13 @@ func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg 
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
@@ -363,13 +363,13 @@ func validateValidatorUnstakeOnBehalfFlags(ctx context.Context, cmd *cobra.Comma
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
@@ -393,13 +393,18 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorSrcPubKey, err := hex.DecodeString(cfg.ValidatorSrcPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	validatorDstPubKey, err := hex.DecodeString(cfg.ValidatorDstPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	existSrc, err := isValidatorFound(ctx, cfg.API, validatorSrcPubKey)
@@ -409,11 +414,6 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 
 	if !existSrc {
 		return errors.New("the src validator doesn't exist")
-	}
-
-	validatorDstPubKey, err := hex.DecodeString(cfg.ValidatorDstPubKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
 	existDst, err := isValidatorFound(ctx, cfg.API, validatorDstPubKey)
@@ -437,13 +437,18 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorSrcPubKey, err := hex.DecodeString(cfg.ValidatorSrcPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	validatorDstPubKey, err := hex.DecodeString(cfg.ValidatorDstPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	existSrc, err := isValidatorFound(ctx, cfg.API, validatorSrcPubKey)
@@ -453,11 +458,6 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 
 	if !existSrc {
 		return errors.New("the src validator doesn't exist")
-	}
-
-	validatorDstPubKey, err := hex.DecodeString(cfg.ValidatorDstPubKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
 	existDst, err := isValidatorFound(ctx, cfg.API, validatorDstPubKey)
@@ -490,10 +490,6 @@ func validateValidatorUnjailFlags(ctx context.Context, cmd *cobra.Command, cfg *
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	privKeyBytes, err := hex.DecodeString(cfg.PrivateKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode private key")
@@ -502,6 +498,10 @@ func validateValidatorUnjailFlags(ctx context.Context, cmd *cobra.Command, cfg *
 	validatorPubKey, err := privKeyToCmpPubKey(privKeyBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to get compressed pub key from private key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
@@ -521,13 +521,13 @@ func validateValidatorUnjailOnBehalfFlags(ctx context.Context, cmd *cobra.Comman
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode hex-encoded validator public key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
@@ -547,10 +547,6 @@ func validateUpdateValidatorCommissionFlags(ctx context.Context, cmd *cobra.Comm
 		return err
 	}
 
-	if cfg.API == "" {
-		return nil
-	}
-
 	privKeyBytes, err := hex.DecodeString(cfg.PrivateKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode private key")
@@ -559,6 +555,10 @@ func validateUpdateValidatorCommissionFlags(ctx context.Context, cmd *cobra.Comm
 	validatorPubKey, err := privKeyToCmpPubKey(privKeyBytes)
 	if err != nil {
 		return errors.Wrap(err, "failed to get compressed pub key from private key")
+	}
+
+	if cfg.API == "" {
+		return nil
 	}
 
 	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -67,7 +67,7 @@ func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
 	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://mainnet.storyrpc.io", "RPC URL to connect to the network")
 	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1514, "Chain ID to use for the transaction")
-	cmd.Flags().StringVar(&cfg.StoryAPI, "story-api", "https://mainnet.storyrpc.io", "URL of Story API server for some validations. Use empty string (\"\") for skipping validations.")
+	cmd.Flags().StringVar(&cfg.StoryAPI, "story-api", "", "URL of Story API server for some validations")
 }
 
 func bindValidatorCreateFlags(cmd *cobra.Command, cfg *createValidatorConfig) {

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -64,10 +64,10 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 }
 
 func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
-	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://storyrpc.io", "RPC URL to connect to the network")
+	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://mainnet.storyrpc.io", "RPC URL to connect to the network")
 	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1514, "Chain ID to use for the transaction")
-	cmd.Flags().StringVar(&cfg.StakingAPI, "staking-api", "", "URL of Staking API server")
+	cmd.Flags().StringVar(&cfg.StakingAPI, "staking-api", "https://mainnet.storyrpc.io", "URL of Staking API server for some validations. Use empty string (\"\") for skipping validations.")
 }
 
 func bindValidatorCreateFlags(cmd *cobra.Command, cfg *createValidatorConfig) {

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -67,7 +67,7 @@ func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
 	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://mainnet.storyrpc.io", "RPC URL to connect to the network")
 	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1514, "Chain ID to use for the transaction")
-	cmd.Flags().StringVar(&cfg.StakingAPI, "staking-api", "https://mainnet.storyrpc.io", "URL of Staking API server for some validations. Use empty string (\"\") for skipping validations.")
+	cmd.Flags().StringVar(&cfg.StoryAPI, "story-api", "https://mainnet.storyrpc.io", "URL of Story API server for some validations. Use empty string (\"\") for skipping validations.")
 }
 
 func bindValidatorCreateFlags(cmd *cobra.Command, cfg *createValidatorConfig) {
@@ -232,12 +232,12 @@ func validateValidatorCreateFlags(ctx context.Context, cmd *cobra.Command, cfg *
 		return errors.Wrap(err, "failed to extract compressed pub key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -279,12 +279,12 @@ func validateValidatorStakeFlags(ctx context.Context, cmd *cobra.Command, cfg *s
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -310,12 +310,12 @@ func validateValidatorStakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -341,12 +341,12 @@ func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg 
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -372,12 +372,12 @@ func validateValidatorUnstakeOnBehalfFlags(ctx context.Context, cmd *cobra.Comma
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -408,12 +408,12 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	existSrc, err := isValidatorFound(ctx, cfg.StakingAPI, validatorSrcPubKey)
+	existSrc, err := isValidatorFound(ctx, cfg.StoryAPI, validatorSrcPubKey)
 	if err != nil {
 		return err
 	}
@@ -422,7 +422,7 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 		return errors.New("the src validator doesn't exist")
 	}
 
-	existDst, err := isValidatorFound(ctx, cfg.StakingAPI, validatorDstPubKey)
+	existDst, err := isValidatorFound(ctx, cfg.StoryAPI, validatorDstPubKey)
 	if err != nil {
 		return err
 	}
@@ -453,12 +453,12 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 		return errors.Wrap(err, "failed to decode hex-encoded pub key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	existSrc, err := isValidatorFound(ctx, cfg.StakingAPI, validatorSrcPubKey)
+	existSrc, err := isValidatorFound(ctx, cfg.StoryAPI, validatorSrcPubKey)
 	if err != nil {
 		return err
 	}
@@ -467,7 +467,7 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 		return errors.New("the src validator doesn't exist")
 	}
 
-	existDst, err := isValidatorFound(ctx, cfg.StakingAPI, validatorDstPubKey)
+	existDst, err := isValidatorFound(ctx, cfg.StoryAPI, validatorDstPubKey)
 	if err != nil {
 		return err
 	}
@@ -507,12 +507,12 @@ func validateValidatorUnjailFlags(ctx context.Context, cmd *cobra.Command, cfg *
 		return errors.Wrap(err, "failed to get compressed pub key from private key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -534,12 +534,12 @@ func validateValidatorUnjailOnBehalfFlags(ctx context.Context, cmd *cobra.Comman
 		return errors.Wrap(err, "failed to decode hex-encoded validator public key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -566,12 +566,12 @@ func validateUpdateValidatorCommissionFlags(ctx context.Context, cmd *cobra.Comm
 		return errors.Wrap(err, "failed to get compressed pub key from private key")
 	}
 
-	if cfg.StakingAPI == "" {
+	if cfg.StoryAPI == "" {
 		fmt.Println("No staking API is provided. Skip validator existence check and validation of new commission rate.")
 		return nil
 	}
 
-	exist, err := isValidatorFound(ctx, cfg.StakingAPI, validatorPubKey)
+	exist, err := isValidatorFound(ctx, cfg.StoryAPI, validatorPubKey)
 	if err != nil {
 		return err
 	}
@@ -659,7 +659,7 @@ func validateCommissionRate(ctx context.Context, cfg *createValidatorConfig) err
 }
 
 func validateNewCommissionRate(ctx context.Context, cfg *updateCommissionConfig, pubKey []byte) error {
-	validator, err := getValidatorByEVMAddr(ctx, cfg.StakingAPI, pubKey)
+	validator, err := getValidatorByEVMAddr(ctx, cfg.StoryAPI, pubKey)
 	if err != nil {
 		return err
 	}

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -2,12 +2,20 @@ package cmd
 
 import (
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"cosmossdk.io/math"
+
+	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -15,6 +23,7 @@ import (
 	apisvr "github.com/piplabs/story/client/server"
 	libcmd "github.com/piplabs/story/lib/cmd"
 	"github.com/piplabs/story/lib/errors"
+	"github.com/piplabs/story/lib/k1util"
 	"github.com/piplabs/story/lib/netconf"
 	"github.com/piplabs/story/lib/tracer"
 
@@ -58,6 +67,7 @@ func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
 	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://storyrpc.io", "RPC URL to connect to the network")
 	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1514, "Chain ID to use for the transaction")
+	cmd.Flags().StringVar(&cfg.API, "api", "", "URL of consensus client API server")
 }
 
 func bindValidatorCreateFlags(cmd *cobra.Command, cfg *createValidatorConfig) {
@@ -184,6 +194,8 @@ func bindValidatorUpdateCommissionFlags(cmd *cobra.Command, cfg *updateCommissio
 	cmd.Flags().Uint32Var(&cfg.CommissionRate, "commission-rate", 0, "Commission rate to update (e.g. 1000 for 10%)")
 }
 
+var ErrValidatorNotFound = errors.New("the validator doesn't exist")
+
 // Flag Validation
 
 func validateFlags(cmd *cobra.Command, flags []string) error {
@@ -211,7 +223,29 @@ func validateValidatorCreateFlags(ctx context.Context, cmd *cobra.Command, cfg *
 		return err
 	}
 
-	return validateCommissionRate(ctx, cfg)
+	if err := validateCommissionRate(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorPubKey, err := validatorKeyFileToCmpPubKey(cfg.ValidatorKeyFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to extract compressed pub key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		return errors.New("the validator already exist")
+	}
+
+	return nil
 }
 
 func validateOperatorFlags(cmd *cobra.Command) error {
@@ -235,7 +269,29 @@ func validateValidatorStakeFlags(ctx context.Context, cmd *cobra.Command, cfg *s
 		return errors.Wrap(err, "failed to validate stake flags")
 	}
 
-	return validateMinStakeAmount(ctx, cfg)
+	if err := validateMinStakeAmount(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !exist {
+		return ErrValidatorNotFound
+	}
+
+	return nil
 }
 
 func validateValidatorStakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command, cfg *stakeConfig) error {
@@ -243,7 +299,29 @@ func validateValidatorStakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command
 		return errors.Wrap(err, "failed to validate stake-on-behalf flags")
 	}
 
-	return validateMinStakeAmount(ctx, cfg)
+	if err := validateMinStakeAmount(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !exist {
+		return ErrValidatorNotFound
+	}
+
+	return nil
 }
 
 func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg *unstakeConfig) error {
@@ -251,7 +329,29 @@ func validateValidatorUnstakeFlags(ctx context.Context, cmd *cobra.Command, cfg 
 		return errors.Wrap(err, "failed to validate unstake flags")
 	}
 
-	return validateMinUnstakeAmount(ctx, cfg)
+	if err := validateMinUnstakeAmount(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !exist {
+		return ErrValidatorNotFound
+	}
+
+	return nil
 }
 
 func validateValidatorUnstakeOnBehalfFlags(ctx context.Context, cmd *cobra.Command, cfg *unstakeConfig) error {
@@ -259,7 +359,29 @@ func validateValidatorUnstakeOnBehalfFlags(ctx context.Context, cmd *cobra.Comma
 		return errors.Wrap(err, "failed to validate unstake-on-behalf flags")
 	}
 
-	return validateMinUnstakeAmount(ctx, cfg)
+	if err := validateMinUnstakeAmount(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !exist {
+		return ErrValidatorNotFound
+	}
+
+	return nil
 }
 
 func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, cfg *redelegateConfig) error {
@@ -267,7 +389,43 @@ func validateValidatorRedelegateFlags(ctx context.Context, cmd *cobra.Command, c
 		return errors.Wrap(err, "failed to validate redelegate flags")
 	}
 
-	return validateMinRedelegateAmount(ctx, cfg)
+	if err := validateMinRedelegateAmount(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorSrcPubKey, err := hex.DecodeString(cfg.ValidatorSrcPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	existSrc, err := isValidatorFound(ctx, cfg.API, validatorSrcPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !existSrc {
+		return errors.New("the src validator doesn't exist")
+	}
+
+	validatorDstPubKey, err := hex.DecodeString(cfg.ValidatorDstPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	existDst, err := isValidatorFound(ctx, cfg.API, validatorDstPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !existDst {
+		return errors.New("the dst validator doesn't exist")
+	}
+
+	return nil
 }
 
 func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Command, cfg *redelegateConfig) error {
@@ -275,7 +433,43 @@ func validateValidatorRedelegateOnBehalfFlags(ctx context.Context, cmd *cobra.Co
 		return errors.Wrap(err, "failed to validate redelegate-on-behalf flags")
 	}
 
-	return validateMinRedelegateAmount(ctx, cfg)
+	if err := validateMinRedelegateAmount(ctx, cfg); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorSrcPubKey, err := hex.DecodeString(cfg.ValidatorSrcPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	existSrc, err := isValidatorFound(ctx, cfg.API, validatorSrcPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !existSrc {
+		return errors.New("the src validator doesn't exist")
+	}
+
+	validatorDstPubKey, err := hex.DecodeString(cfg.ValidatorDstPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded pub key")
+	}
+
+	existDst, err := isValidatorFound(ctx, cfg.API, validatorDstPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !existDst {
+		return errors.New("the dst validator doesn't exist")
+	}
+
+	return nil
 }
 
 func validateKeyConvertFlags(cmd *cobra.Command) error {
@@ -291,16 +485,92 @@ func validateGenPrivKeyJSONFlags(cfg *genPrivKeyJSONConfig) error {
 	return nil
 }
 
-func validateValidatorUnjailFlags(cmd *cobra.Command) error {
-	return validateFlags(cmd, []string{})
+func validateValidatorUnjailFlags(ctx context.Context, cmd *cobra.Command, cfg *unjailConfig) error {
+	if err := validateFlags(cmd, []string{}); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	privKeyBytes, err := hex.DecodeString(cfg.PrivateKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode private key")
+	}
+
+	validatorPubKey, err := privKeyToCmpPubKey(privKeyBytes)
+	if err != nil {
+		return errors.Wrap(err, "failed to get compressed pub key from private key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !exist {
+		return ErrValidatorNotFound
+	}
+
+	return nil
 }
 
-func validateValidatorUnjailOnBehalfFlags(cmd *cobra.Command) error {
-	return validateFlags(cmd, []string{"validator-pubkey"})
+func validateValidatorUnjailOnBehalfFlags(ctx context.Context, cmd *cobra.Command, cfg *unjailConfig) error {
+	if err := validateFlags(cmd, []string{"validator-pubkey"}); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	validatorPubKey, err := hex.DecodeString(cfg.ValidatorPubKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode hex-encoded validator public key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !exist {
+		return ErrValidatorNotFound
+	}
+
+	return nil
 }
 
-func validateUpdateValidatorCommissionFlags(cmd *cobra.Command) error {
-	return validateFlags(cmd, []string{"commission-rate"})
+func validateUpdateValidatorCommissionFlags(ctx context.Context, cmd *cobra.Command, cfg *updateCommissionConfig) error {
+	if err := validateFlags(cmd, []string{"commission-rate"}); err != nil {
+		return err
+	}
+
+	if cfg.API == "" {
+		return nil
+	}
+
+	privKeyBytes, err := hex.DecodeString(cfg.PrivateKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode private key")
+	}
+
+	validatorPubKey, err := privKeyToCmpPubKey(privKeyBytes)
+	if err != nil {
+		return errors.Wrap(err, "failed to get compressed pub key from private key")
+	}
+
+	exist, err := isValidatorFound(ctx, cfg.API, validatorPubKey)
+	if err != nil {
+		return err
+	}
+
+	if !exist {
+		return ErrValidatorNotFound
+	}
+
+	return validateNewCommissionRate(ctx, cfg, validatorPubKey)
 }
 
 func validateMinStakeAmount(ctx context.Context, cfg *stakeConfig) error {
@@ -345,7 +615,7 @@ func validateMinRedelegateAmount(ctx context.Context, cfg *redelegateConfig) err
 		return fmt.Errorf("invalid redelegate amount: %s", cfg.StakeAmount)
 	}
 
-	minRedelegateAmount, err := getUint256(ctx, &cfg.baseConfig, "minRedelegateAmount")
+	minRedelegateAmount, err := getUint256(ctx, &cfg.baseConfig, "minStakeAmount")
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve minimum redelegate amount")
 	}
@@ -376,4 +646,81 @@ func validateCommissionRate(ctx context.Context, cfg *createValidatorConfig) err
 	}
 
 	return nil
+}
+
+func validateNewCommissionRate(ctx context.Context, cfg *updateCommissionConfig, pubKey []byte) error {
+	validator, err := getValidatorByEVMAddr(ctx, cfg.API, pubKey)
+	if err != nil {
+		return err
+	}
+
+	if validator.OperatorAddress == "" {
+		return errors.New("validator not found")
+	}
+
+	prevCommission := validator.Commission
+	newCommission := math.LegacyNewDecWithPrec(int64(cfg.CommissionRate), 4)
+
+	if time.Since(prevCommission.UpdateTime).Hours() < 24 {
+		return stypes.ErrCommissionUpdateTime
+	}
+
+	if newCommission.GT(prevCommission.MaxRate) {
+		return stypes.ErrCommissionGTMaxRate
+	}
+
+	if newCommission.Sub(prevCommission.Rate).GT(prevCommission.MaxChangeRate) {
+		return stypes.ErrCommissionGTMaxChangeRate
+	}
+
+	return nil
+}
+
+type ValidatorResponse struct {
+	Code  int    `json:"code"`
+	Error string `json:"error"`
+	Msg   struct {
+		Validator stypes.Validator `json:"validator"`
+	} `json:"msg"`
+}
+
+// isValidatorFound checks whether a validator with the given public key exists.
+func isValidatorFound(ctx context.Context, endpoint string, pubKey []byte) (bool, error) {
+	validator, err := getValidatorByEVMAddr(ctx, endpoint, pubKey)
+	if err != nil {
+		return false, err
+	}
+
+	return validator.OperatorAddress != "", nil
+}
+
+// getValidatorByEVMAddr gets a validator with the given public key.
+func getValidatorByEVMAddr(ctx context.Context, endpoint string, pubKey []byte) (stypes.Validator, error) {
+	valEVMAddr, err := k1util.CosmosPubkeyToEVMAddress(pubKey)
+	if err != nil {
+		return stypes.Validator{}, errors.Wrap(err, "failed to convert pub key to evm address")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/staking/validators/%s", endpoint, valEVMAddr), nil)
+	if err != nil {
+		return stypes.Validator{}, errors.Wrap(err, "failed to create request for getting validator")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return stypes.Validator{}, errors.Wrap(err, "failed to get validator")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return stypes.Validator{}, errors.Wrap(err, "failed to read response body")
+	}
+
+	var response ValidatorResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return stypes.Validator{}, errors.Wrap(err, "failed to unmarshal response")
+	}
+
+	return response.Msg.Validator, nil
 }

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -710,6 +710,9 @@ func getValidatorByEVMAddr(ctx context.Context, endpoint string, pubKey []byte) 
 	if err != nil {
 		return stypes.Validator{}, errors.Wrap(err, "failed to get validator")
 	}
+	if resp.StatusCode != http.StatusOK {
+		return stypes.Validator{}, errors.New("failed to get validator")
+	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)

--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -80,7 +80,7 @@ type baseConfig struct {
 	ChainID      int64
 	ABI          *abi.ABI
 	ContractAddr common.Address
-	StakingAPI   string
+	StoryAPI     string
 }
 
 type createValidatorConfig struct {

--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -152,7 +152,7 @@ type genPrivKeyJSONConfig struct {
 }
 
 func loadEnv() {
-	if err := godotenv.Load("../.env"); err != nil {
+	if err := godotenv.Load(); err != nil {
 		fmt.Println("Warning: No .env file found")
 	}
 }

--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -80,7 +80,7 @@ type baseConfig struct {
 	ChainID      int64
 	ABI          *abi.ABI
 	ContractAddr common.Address
-	API          string
+	StakingAPI   string
 }
 
 type createValidatorConfig struct {

--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -80,6 +80,7 @@ type baseConfig struct {
 	ChainID      int64
 	ABI          *abi.ABI
 	ContractAddr common.Address
+	API          string
 }
 
 type createValidatorConfig struct {
@@ -491,7 +492,10 @@ func newValidatorUnjailCmd() *cobra.Command {
 			return initializeBaseConfig(&cfg.baseConfig)
 		},
 		RunE: runValidatorCommand(
-			validateValidatorUnjailFlags,
+			func(cmd *cobra.Command) error {
+				ctx := cmd.Context()
+				return validateValidatorUnjailFlags(ctx, cmd, &cfg)
+			},
 			func(ctx context.Context) error { return unjail(ctx, cfg) },
 		),
 	}
@@ -512,7 +516,10 @@ func newValidatorUnjailOnBehalfCmd() *cobra.Command {
 			return initializeBaseConfig(&cfg.baseConfig)
 		},
 		RunE: runValidatorCommand(
-			validateValidatorUnjailOnBehalfFlags,
+			func(cmd *cobra.Command) error {
+				ctx := cmd.Context()
+				return validateValidatorUnjailOnBehalfFlags(ctx, cmd, &cfg)
+			},
 			func(ctx context.Context) error { return unjailOnBehalf(ctx, cfg) },
 		),
 	}
@@ -533,7 +540,10 @@ func newUpdateValidatorCommission() *cobra.Command {
 			return initializeBaseConfig(&cfg.baseConfig)
 		},
 		RunE: runValidatorCommand(
-			validateUpdateValidatorCommissionFlags,
+			func(cmd *cobra.Command) error {
+				ctx := cmd.Context()
+				return validateUpdateValidatorCommissionFlags(ctx, cmd, &cfg)
+			},
 			func(ctx context.Context) error {
 				return updateValidatorCommission(ctx, cfg)
 			},
@@ -932,7 +942,6 @@ func redelegate(ctx context.Context, cfg redelegateConfig) error {
 		validatorDstPubKeyBytes,
 		delegationID,
 		redelegateAmount,
-		[]byte{},
 	)
 	if err != nil {
 		return err
@@ -984,7 +993,6 @@ func redelegateOnBehalf(ctx context.Context, cfg redelegateConfig) error {
 		validatorDstPubKeyBytes,
 		delegationID,
 		redelegateAmount,
-		[]byte{},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Added some verifications to CLI to prevent potential fund loss.
- create validate: check if the validator does not exist
- stake, unstake, redelegate, unjail, and update commission rate (including onBehalf): check if the validator exist
- update commission rate: check if the new commission rate is valid based on the previous one

issue: none
