### PR TITLE
feat(cli): add to encrypt priv key

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -163,14 +167,14 @@
         "filename": "client/app/prompt.go",
         "hashed_secret": "87c3f13b0b9706003444e7bb666b658396894dde",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 89
       },
       {
         "type": "Secret Keyword",
         "filename": "client/app/prompt.go",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 93
       }
     ],
     "client/cmd/flags.go": [
@@ -958,5 +962,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-28T08:18:38Z"
+  "generated_at": "2025-03-11T06:18:47Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -133,6 +129,22 @@
     }
   ],
   "results": {
+    "client/app/privkey_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "client/app/privkey_test.go",
+        "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
+        "is_verified": false,
+        "line_number": 20
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "client/app/privkey_test.go",
+        "hashed_secret": "d8ecf7db8fc9ec9c31bc5c9ae2929cc599c75f8d",
+        "is_verified": false,
+        "line_number": 43
+      }
+    ],
     "client/app/prompt.go": [
       {
         "type": "Secret Keyword",
@@ -289,42 +301,42 @@
         "filename": "client/server/README.md",
         "hashed_secret": "51306aaf4b25bb6bb74de002a9e4d2f1885c48fb",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 212
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "client/server/README.md",
         "hashed_secret": "938689c1b3defc54ebd2606f5735fd4f9b57ac27",
         "is_verified": false,
-        "line_number": 182
+        "line_number": 238
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "client/server/README.md",
         "hashed_secret": "c5832aa908afa7dec4d2b2de42aa0355daf7a724",
         "is_verified": false,
-        "line_number": 208
+        "line_number": 264
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "client/server/README.md",
         "hashed_secret": "bcb99cdcefb6911e73e7d07198a427cc6488484f",
         "is_verified": false,
-        "line_number": 234
+        "line_number": 290
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "client/server/README.md",
         "hashed_secret": "262ec2ddde0a5781143d7750a1ca8df2fbe5a261",
         "is_verified": false,
-        "line_number": 428
+        "line_number": 484
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "client/server/README.md",
         "hashed_secret": "4cb2c954edbdedefae8776e38aeedb79d48db9b1",
         "is_verified": false,
-        "line_number": 605
+        "line_number": 661
       }
     ],
     "lib/ethclient/client_test.go": [
@@ -962,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-11T06:18:47Z"
+  "generated_at": "2025-03-11T06:41:28Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -133,171 +129,189 @@
     }
   ],
   "results": {
-    ".github/workflows/ci-main.yml": [
+    "client/app/prompt.go": [
       {
         "type": "Secret Keyword",
-        "filename": ".github/workflows/ci-main.yml",
-        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "filename": "client/app/prompt.go",
+        "hashed_secret": "158c1f674ccc860d3e910a21721f1f12e25caeb1",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "client/app/prompt.go",
+        "hashed_secret": "169b570c165368a82be350df19422c03546790bb",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "client/app/prompt.go",
+        "hashed_secret": "4a7c565d4c4430e3bb8fa6c560125d5eb37e7c3d",
         "is_verified": false,
         "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "client/app/prompt.go",
+        "hashed_secret": "87544cb50e92472816cc8722bec1d022d79e801b",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "client/app/prompt.go",
+        "hashed_secret": "87c3f13b0b9706003444e7bb666b658396894dde",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "client/app/prompt.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
+    "client/config/config.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "client/config/config.go",
+        "hashed_secret": "572cde2b2a4da9c5a16a48d9a2655a1838c3834a",
+        "is_verified": false,
+        "line_number": 34
       }
     ],
     "client/genutil/evm/testdata/TestMakeGenesis.golden": [
       {
         "type": "Hex High Entropy String",
         "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "08b650e252263f24012a9f28567c240a20c2f946",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "bba31aa004481de49b494ec166f33686c717bc26",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "28ef15964c4850182b1fef49fc55950919db756f",
+        "is_verified": false,
+        "line_number": 66
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "3f0335f2af6f7b386ef0d32f094fbe826e7e3fa7",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "c52cffacab1f07ba79bbc61c32ff164fff8f9f8b",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "0b88203fde5908bb7273ca44a7f685f977bde2ca",
+        "is_verified": false,
+        "line_number": 83
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "9d06254807267e518daa2dc5629b8e298d391966",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "a79365b8364bf8a43643be2ac6dc1ecbc56f6d6a",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
+        "hashed_secret": "aac432f7e35804ebe62d41d9f42657ce89479caf",
+        "is_verified": false,
+        "line_number": 92
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
         "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
         "is_verified": false,
-        "line_number": 39
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "a3a8c0b3bd304e1527669b9c986cc5fa5ac41a30",
-        "is_verified": false,
-        "line_number": 40
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "7207ae767d4cca593a7f62869ac682a19e1f02ad",
-        "is_verified": false,
-        "line_number": 41
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "ba7a46db2bcce63c5808782aa7785c1debcddd9b",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "189d2eed2a609e5459e1592d3254a3a0c0467e81",
-        "is_verified": false,
-        "line_number": 43
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "7ded2ebd67f6cbd9da14253b4237b1716182cb9a",
-        "is_verified": false,
-        "line_number": 44
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "client/genutil/evm/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "25e3b8bdce3ad76cf8028c17bdbd01057bade6c3",
-        "is_verified": false,
-        "line_number": 45
+        "line_number": 95
       }
     ],
     "client/genutil/testdata/TestMakeGenesis.golden": [
       {
         "type": "Base64 High Entropy String",
         "filename": "client/genutil/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "4aaa28befbfbe108123482f4cd39eefa10804b83",
-        "is_verified": false,
-        "line_number": 20
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "client/genutil/testdata/TestMakeGenesis.golden",
-        "hashed_secret": "0019803e0cfe9a6a96d766b2cf9b20c8d6f4aff7",
-        "is_verified": false,
-        "line_number": 111
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "client/genutil/testdata/TestMakeGenesis.golden",
         "hashed_secret": "77a539d98dfa381df1bc489650aef852c0ebcda6",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 123
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "client/genutil/testdata/TestMakeGenesis.golden",
         "hashed_secret": "7f171266f22732c3c265ac01943db64a68ecde9c",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 170
       }
     ],
-    "e2e/app/agent/prometheus_internal_test.go": [
+    "client/server/README.md": [
       {
-        "type": "Secret Keyword",
-        "filename": "e2e/app/agent/prometheus_internal_test.go",
-        "hashed_secret": "858b02bf93798fdd02736ef7ec278319018d1272",
+        "type": "Base64 High Entropy String",
+        "filename": "client/server/README.md",
+        "hashed_secret": "51306aaf4b25bb6bb74de002a9e4d2f1885c48fb",
         "is_verified": false,
-        "line_number": 92
-      }
-    ],
-    "e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden": [
-      {
-        "type": "Secret Keyword",
-        "filename": "e2e/app/geth/testdata/TestWriteConfigTOML_archive.golden",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 101
-      }
-    ],
-    "e2e/app/geth/testdata/TestWriteConfigTOML_full.golden": [
-      {
-        "type": "Secret Keyword",
-        "filename": "e2e/app/geth/testdata/TestWriteConfigTOML_full.golden",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 101
-      }
-    ],
-    "e2e/app/key/key_test.go": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "e2e/app/key/key_test.go",
-        "hashed_secret": "7f206c47631fb0c250283516cc47fd85c370ce6f",
-        "is_verified": false,
-        "line_number": 96
+        "line_number": 156
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "e2e/app/key/key_test.go",
-        "hashed_secret": "480c5f9eeb3033bf2dfe86627210969af5e1a665",
+        "type": "Base64 High Entropy String",
+        "filename": "client/server/README.md",
+        "hashed_secret": "938689c1b3defc54ebd2606f5735fd4f9b57ac27",
         "is_verified": false,
-        "line_number": 99
-      }
-    ],
-    "e2e/manifests/staging.toml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "e2e/manifests/staging.toml",
-        "hashed_secret": "f2400ac6800113efbeede5e2b7942549147600b3",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    "e2e/manifests/testnet.toml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "e2e/manifests/testnet.toml",
-        "hashed_secret": "70c787f6b2cb3bfce2a249c364dda0fc70b2f6b1",
-        "is_verified": false,
-        "line_number": 45
+        "line_number": 182
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "e2e/manifests/testnet.toml",
-        "hashed_secret": "7d389016386dad7957488ad08e577a7f7fef8a26",
+        "type": "Base64 High Entropy String",
+        "filename": "client/server/README.md",
+        "hashed_secret": "c5832aa908afa7dec4d2b2de42aa0355daf7a724",
         "is_verified": false,
-        "line_number": 51
-      }
-    ],
-    "lib/create3/create3_test.go": [
+        "line_number": 208
+      },
       {
-        "type": "Hex High Entropy String",
-        "filename": "lib/create3/create3_test.go",
-        "hashed_secret": "87d1b1cb78352bf048e630bd5cbe69d35bdc313d",
+        "type": "Base64 High Entropy String",
+        "filename": "client/server/README.md",
+        "hashed_secret": "bcb99cdcefb6911e73e7d07198a427cc6488484f",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 234
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "client/server/README.md",
+        "hashed_secret": "262ec2ddde0a5781143d7750a1ca8df2fbe5a261",
+        "is_verified": false,
+        "line_number": 428
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "client/server/README.md",
+        "hashed_secret": "4cb2c954edbdedefae8776e38aeedb79d48db9b1",
+        "is_verified": false,
+        "line_number": 605
       }
     ],
     "lib/ethclient/client_test.go": [
@@ -307,24 +321,6 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 89
-      }
-    ],
-    "lib/ethclient/ethbackend/backend.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "lib/ethclient/ethbackend/backend.go",
-        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
-        "is_verified": false,
-        "line_number": 131
-      }
-    ],
-    "lib/fireblocks/client.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "lib/fireblocks/client.go",
-        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
-        "is_verified": false,
-        "line_number": 44
       }
     ],
     "lib/k1util/k1util_test.go": [
@@ -364,113 +360,560 @@
         "line_number": 29
       }
     ],
-    "lib/netconf/testnet/consensus-genesis.json": [
+    "lib/netconf/aeneid/genesis.json": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "78485ad758eb7f54eacf642b7d44e59973b14210",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "1ba53d02131d9a9a80401ab90d7e80d401a3c21f",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "4ebde9b496ed24d137adc623c0310f83ddd5e6a0",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "1b01319fdc5b90e9e4ba98f3f96a6c66b55bc2d9",
         "is_verified": false,
         "line_number": 61
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "079ce31142c73b41232804b2ce75219c2eaadfef",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "1bfc91cc9b6bc232cd57230057831951c211f209",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 75
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "5ddd709a757e109fc9bb1cfd5d31be465aed4b1b",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "4f64acb85eee643de4e0d3a95fdc47df50ecd88b",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 89
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "8e0c256cabc5dd532535b0ba6880e182e9b84734",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "b43986be5440bddfaab8a134921c50284ea02e09",
         "is_verified": false,
-        "line_number": 207
+        "line_number": 216
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "3d355ec69568c554afeb8f48ce334bdc9a11f5bf",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "1adc49a52504da71e437822092d8dd410a77b56a",
         "is_verified": false,
-        "line_number": 210
+        "line_number": 240
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "a4329c8b1f80ed1bc79dd9486c9067efea573a36",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "ac534bd68d19e7273eeb68acc15ea799f749878d",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 243
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "676eda12004d7f562dcb73fd8be616a0e5e2b772",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "fce6f76b99249c3ea04ab4113b0514f5f5d6cee6",
         "is_verified": false,
-        "line_number": 257
+        "line_number": 291
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lib/netconf/testnet/consensus-genesis.json",
-        "hashed_secret": "f1be26cd282bedb59a16f423b05f15dd7680d105",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "4a103c66bbf1695750e1c107ecd8aeebc18c22a6",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 339
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "a215f1395860d1941179547d6fa98b733960a1ac",
+        "is_verified": false,
+        "line_number": 384
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/aeneid/genesis.json",
+        "hashed_secret": "fb15fd6543997d37c328556e4be5ea2f73e5fbb0",
+        "is_verified": false,
+        "line_number": 387
       }
     ],
-    "lib/netconf/testnet/execution-genesis.json": [
+    "lib/netconf/iliad/genesis.json": [
       {
-        "type": "Hex High Entropy String",
-        "filename": "lib/netconf/testnet/execution-genesis.json",
-        "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "445f1b489636c6923df2b0241fb651a2c3034c07",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 52
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "lib/netconf/testnet/execution-genesis.json",
-        "hashed_secret": "a3a8c0b3bd304e1527669b9c986cc5fa5ac41a30",
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "507f27ca0b774ae3a2e8d8432ef667b34e696659",
+        "is_verified": false,
+        "line_number": 66
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "3a19cbee49e587f670858670611e9260f3f7373e",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "38d1b9c2de7dc9edb22e7bb85a8308da23ea31fa",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "285a81b60b48f51cd8b1fe6047e0a2635ed6e82a",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "2a3435667d6804cf94f879c1d1321fcda11494c8",
+        "is_verified": false,
+        "line_number": 203
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "0f6a770a1f8563e545150c6cfc5250acd2995865",
+        "is_verified": false,
+        "line_number": 230
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "89781d05673c7f2ccdefc07918aee1facb69190e",
+        "is_verified": false,
+        "line_number": 274
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "8ff7d77f4bdda1c34e9de65dca9a940ea704b22b",
+        "is_verified": false,
+        "line_number": 277
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "579e1b4338234d5c7ea8f26fd796d83b8cf56438",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "4db27ecd8d797acb496a035da55a0c6233edc2d3",
+        "is_verified": false,
+        "line_number": 324
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "1e3ca04dd5e5e3651096aaeb25b105a0296b9b90",
+        "is_verified": false,
+        "line_number": 368
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "02321b162b22e40f6d8da646a0d0628bf057ddb7",
+        "is_verified": false,
+        "line_number": 371
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "8c0b8e96ce7931a0de0104b2b7f61d6820f85ee9",
+        "is_verified": false,
+        "line_number": 415
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "a4cb50ab127c7b21de3b5009b99486dc6824252e",
+        "is_verified": false,
+        "line_number": 418
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "e9fb4eff63b558924615b4edebb2ec5d9e13a155",
+        "is_verified": false,
+        "line_number": 462
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "5e931bf6068f114f972c0a4f5d399fd5159ef7ab",
+        "is_verified": false,
+        "line_number": 465
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "1cf361dba1a9a4857cd8ece14a027ed1fe013a7a",
+        "is_verified": false,
+        "line_number": 509
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "c07579b8d7806aa3fb34e5ec9c9202a7b87a4578",
+        "is_verified": false,
+        "line_number": 512
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "6eefafbaacc0cebaf98eef4179cd68a31f8f25bc",
+        "is_verified": false,
+        "line_number": 556
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/iliad/genesis.json",
+        "hashed_secret": "77ac04c10749ecad6dbeba7592f6709b6fc06e93",
+        "is_verified": false,
+        "line_number": 559
+      }
+    ],
+    "lib/netconf/local/genesis.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/local/genesis.json",
+        "hashed_secret": "f9b54413b9bd85cfa8ae32703695b5287f77a555",
+        "is_verified": false,
+        "line_number": 92
+      }
+    ],
+    "lib/netconf/odyssey/genesis.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "0941a0fd07a0ca00c25df8847af1b420dc15c331",
         "is_verified": false,
         "line_number": 40
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "lib/netconf/testnet/execution-genesis.json",
-        "hashed_secret": "7207ae767d4cca593a7f62869ac682a19e1f02ad",
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "a4c5a70ddfc73dd9ac27c418b1ab0237dc77aa3a",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 61
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "4f7daf433e65a7a454a5dd5162d77af91d852020",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "78abba5f031d10c223ccdac6bdc664a6b216644a",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "c8b6986367b401b497679f3735840e12db9adf88",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "2ef591b5ecd52c442c9feffbb45c8ea40f00633b",
+        "is_verified": false,
+        "line_number": 216
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "28a2619b3048bb458bf4662204adde00237b1545",
+        "is_verified": false,
+        "line_number": 240
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "048807435d3e5186782210b2b01c863e5892724c",
+        "is_verified": false,
+        "line_number": 243
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "8ce75170c130b10c31084f5a1902e7185bcdc4cf",
+        "is_verified": false,
+        "line_number": 288
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "bf221776d133d18bbc55637034cda0e48345e3c6",
+        "is_verified": false,
+        "line_number": 291
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "4207b57a1bf8079259cd5356b672653dfc0f1c99",
+        "is_verified": false,
+        "line_number": 339
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "16ca9f36ab4afa85a6acd5f9d056165a974eb295",
+        "is_verified": false,
+        "line_number": 384
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "0f6d479843276eeb144089868712c501fc2c8daf",
+        "is_verified": false,
+        "line_number": 387
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "d61d5b10f5561d562aa8d6c8e5356dcec36a90e4",
+        "is_verified": false,
+        "line_number": 432
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "9ef46adb0e222dac93dcd5ac59e7483b27b8e8e8",
+        "is_verified": false,
+        "line_number": 435
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "e923e1fb1c56e7564e7ae9deceda8bc600649257",
+        "is_verified": false,
+        "line_number": 483
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "60173c89cee41db73083ea3ae102b617b720c0da",
+        "is_verified": false,
+        "line_number": 528
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "a207bab58b0d13e2a05a56e757a51fe4aee77dc4",
+        "is_verified": false,
+        "line_number": 531
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "7f2626a219f8c6b29ad8679c143cd2fa146ca81f",
+        "is_verified": false,
+        "line_number": 576
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/odyssey/genesis.json",
+        "hashed_secret": "b5a1bc85150c45dfae7d6e257b8e948a41ce12ab",
+        "is_verified": false,
+        "line_number": 579
+      }
+    ],
+    "lib/netconf/story/genesis.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "513ad84fad27e8335ab36c95951ddf28590020c1",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "d399a67d48985068f6664c69944cef6bca1d38cd",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "e28eccd5cd27d1db1ac045deb04cdedcbc37f5ec",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "fc686b0822de5a0ea6ea3509626d25fc89ce4100",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "59df18dcc9d8f2903307084e62b01491d52ebac0",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "3fb9dd07773ca43878567d1bff340376e7ff4e1d",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "77f85656a34778b3b39c069b24992b96032e03fc",
+        "is_verified": false,
+        "line_number": 216
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "0e4fe3b1a6d6181e7662331c6c02fbd233a98515",
+        "is_verified": false,
+        "line_number": 240
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "dd2c86720f047e823586ddda68d0b566a926cbba",
+        "is_verified": false,
+        "line_number": 243
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "37e7d5756e92a127b8bc335ffb16ef1f8fdedd66",
+        "is_verified": false,
+        "line_number": 288
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "3ce8b72ba78866a84df0151eafdee609df481657",
+        "is_verified": false,
+        "line_number": 291
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "lib/netconf/testnet/execution-genesis.json",
-        "hashed_secret": "ba7a46db2bcce63c5808782aa7785c1debcddd9b",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "9f6ded837bbd60f639dc1f38d3957a667b7648fe",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 324
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "2c49a2af8a4e47955a145fa54853883d37b362ec",
+        "is_verified": false,
+        "line_number": 336
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "131b64c7fd6c72eba61159ac10a17e0c880e8b04",
+        "is_verified": false,
+        "line_number": 339
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "94eda9012bbd71d142f9de7b1df2f2165549b3c3",
+        "is_verified": false,
+        "line_number": 384
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "25716f4891718175c00504493ecdd60276f095d5",
+        "is_verified": false,
+        "line_number": 387
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "d81c3711fa87f8b94f6c93835c937ca924c712c6",
+        "is_verified": false,
+        "line_number": 432
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "397d15dd2021e8341090fe6a1eb8aeb9b5eef7f9",
+        "is_verified": false,
+        "line_number": 435
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "c7e6f3c628a253892b8e7808065ff815a506e4e0",
+        "is_verified": false,
+        "line_number": 480
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "04ab777f4335d1ce4e6eb7cd795fbc0e93de5af1",
+        "is_verified": false,
+        "line_number": 483
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "lib/netconf/testnet/execution-genesis.json",
-        "hashed_secret": "189d2eed2a609e5459e1592d3254a3a0c0467e81",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "133f88da726cd10f8a6818f34010f12b4b6f2080",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 516
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "lib/netconf/testnet/execution-genesis.json",
-        "hashed_secret": "7ded2ebd67f6cbd9da14253b4237b1716182cb9a",
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "8042ae4d5a0a5d71a2a0bf1909d7913282a20bd7",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 531
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "lib/netconf/testnet/execution-genesis.json",
-        "hashed_secret": "25e3b8bdce3ad76cf8028c17bdbd01057bade6c3",
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "d194391409d253675f1dd4d128d517cc89593532",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 576
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/netconf/story/genesis.json",
+        "hashed_secret": "b9cdd37891dc7b00d058097759a0388a897e402f",
+        "is_verified": false,
+        "line_number": 579
       }
     ],
     "lib/tutil/testdata/genesis.json": [
@@ -504,95 +947,7 @@
         "is_verified": false,
         "line_number": 9
       }
-    ],
-    "scripts/gethdevnet/execution/genesis.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/genesis.json",
-        "hashed_secret": "ac3758d662cbdd3b3067756b1979a60d0e654a19",
-        "is_verified": false,
-        "line_number": 39
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/genesis.json",
-        "hashed_secret": "a3a8c0b3bd304e1527669b9c986cc5fa5ac41a30",
-        "is_verified": false,
-        "line_number": 40
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/genesis.json",
-        "hashed_secret": "7207ae767d4cca593a7f62869ac682a19e1f02ad",
-        "is_verified": false,
-        "line_number": 41
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/genesis.json",
-        "hashed_secret": "ba7a46db2bcce63c5808782aa7785c1debcddd9b",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/genesis.json",
-        "hashed_secret": "189d2eed2a609e5459e1592d3254a3a0c0467e81",
-        "is_verified": false,
-        "line_number": 43
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/genesis.json",
-        "hashed_secret": "7ded2ebd67f6cbd9da14253b4237b1716182cb9a",
-        "is_verified": false,
-        "line_number": 44
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/genesis.json",
-        "hashed_secret": "25e3b8bdce3ad76cf8028c17bdbd01057bade6c3",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "scripts/gethdevnet/execution/keystore/UTC--2022-08-19T17-38-31.257380510Z--123463a4b065722e99115d6c222f267d9cabb524": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/keystore/UTC--2022-08-19T17-38-31.257380510Z--123463a4b065722e99115d6c222f267d9cabb524",
-        "hashed_secret": "0c067d3944d8dd16687a1fdc416d92b0d78a523c",
-        "is_verified": false,
-        "line_number": 1
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/keystore/UTC--2022-08-19T17-38-31.257380510Z--123463a4b065722e99115d6c222f267d9cabb524",
-        "hashed_secret": "a6ba42fe5667d5fdfa788c219dd88a99031566a3",
-        "is_verified": false,
-        "line_number": 1
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/keystore/UTC--2022-08-19T17-38-31.257380510Z--123463a4b065722e99115d6c222f267d9cabb524",
-        "hashed_secret": "ba1aecf13c1fc45aa1867beb65afbebcf594026d",
-        "is_verified": false,
-        "line_number": 1
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/keystore/UTC--2022-08-19T17-38-31.257380510Z--123463a4b065722e99115d6c222f267d9cabb524",
-        "hashed_secret": "cd78c461e40612bf67425e745c3c03df6071d98c",
-        "is_verified": false,
-        "line_number": 1
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/gethdevnet/execution/keystore/UTC--2022-08-19T17-38-31.257380510Z--123463a4b065722e99115d6c222f267d9cabb524",
-        "hashed_secret": "f0a9052734814c9b196f44eb9feda62efdf931c5",
-        "is_verified": false,
-        "line_number": 1
-      }
     ]
   },
-  "generated_at": "2024-11-21T08:57:28Z"
+  "generated_at": "2025-02-28T01:50:43Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -173,6 +173,15 @@
         "line_number": 94
       }
     ],
+    "client/cmd/flags.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "client/cmd/flags.go",
+        "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
+        "is_verified": false,
+        "line_number": 511
+      }
+    ],
     "client/config/config.go": [
       {
         "type": "Secret Keyword",
@@ -949,5 +958,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-28T01:50:43Z"
+  "generated_at": "2025-02-28T05:12:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -179,7 +179,7 @@
         "filename": "client/cmd/flags.go",
         "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
         "is_verified": false,
-        "line_number": 511
+        "line_number": 516
       }
     ],
     "client/config/config.go": [
@@ -958,5 +958,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-28T05:12:18Z"
+  "generated_at": "2025-02-28T08:18:38Z"
 }

--- a/client/app/privkey_test.go
+++ b/client/app/privkey_test.go
@@ -1,0 +1,63 @@
+package app_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+	"github.com/cometbft/cometbft/privval"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piplabs/story/client/app"
+)
+
+func setupTestEnv(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	stateFileDir := filepath.Join(t.TempDir(), "stateFileDir")
+	encFileDir := filepath.Join(t.TempDir(), "encFileDir")
+	password := "testpassword"
+
+	return stateFileDir, encFileDir, password
+}
+
+func TestEncryptAndDecrypt_Success(t *testing.T) {
+	stateFileDir, encFileDir, password := setupTestEnv(t)
+
+	pv := privval.NewFilePV(k1.GenPrivKey(), "", stateFileDir)
+
+	// Encryption
+	err := app.EncryptAndStoreKey(pv.Key, password, encFileDir)
+	require.NoError(t, err)
+
+	// Decryption
+	loadedKey, err := app.LoadEncryptedPrivKey(password, encFileDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, pv.Key, loadedKey, "The decrypted key must match the original.")
+}
+
+func TestLoadEncryptedPrivKey_WrongPassword(t *testing.T) {
+	stateFileDir, encFileDir, password := setupTestEnv(t)
+	wrongPassword := "wrongpassword"
+
+	pv := privval.NewFilePV(k1.GenPrivKey(), "", stateFileDir)
+
+	// Encryption
+	err := app.EncryptAndStoreKey(pv.Key, password, encFileDir)
+	require.NoError(t, err)
+
+	// Decrypt with wrong password
+	_, err = app.LoadEncryptedPrivKey(wrongPassword, encFileDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong password for wallet entered")
+}
+
+func TestLoadEncryptedPrivKey_FileNotFound(t *testing.T) {
+	_, encFileDir, password := setupTestEnv(t)
+
+	_, err := app.LoadEncryptedPrivKey(password, encFileDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read enc_priv_key.json file")
+}

--- a/client/app/prompt.go
+++ b/client/app/prompt.go
@@ -1,0 +1,111 @@
+//nolint:revive,wrapcheck // This file is taken from Prysm
+package app
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/logrusorgru/aurora"
+
+	"github.com/piplabs/story/lib/errors"
+)
+
+const (
+	// Constants for passwords.
+	minPasswordLength = 8
+
+	// NewKeyPasswordPromptText for key creation.
+	NewKeyPasswordPromptText = "New key password"
+	// PasswordPromptText for wallet unlocking.
+	PasswordPromptText = "Key password"
+	// ConfirmPasswordPromptText for confirming a key password.
+	ConfirmPasswordPromptText = "Confirm password"
+)
+
+var (
+	au = aurora.NewAurora(true)
+
+	errPasswordWeak = errors.New("password must have at least 8 characters")
+)
+
+// PasswordReaderFunc takes in a *file and returns a password using the terminal package.
+func passwordReaderFunc(file *os.File) ([]byte, error) {
+	pass, err := terminal.ReadPassword(int(file.Fd()))
+
+	return pass, err
+}
+
+// PasswordReader has passwordReaderFunc as the default but can be changed for testing purposes.
+var PasswordReader = passwordReaderFunc
+
+// PasswordPrompt prompts the user for a password, that repeatedly requests the password until it qualifies the
+// passed in validation function.
+func PasswordPrompt(promptText string, validateFunc func(string) error) (string, error) {
+	var responseValid bool
+	var response string
+	for !responseValid {
+		fmt.Printf("%s: ", au.Bold(promptText))
+		bytePassword, err := PasswordReader(os.Stdin)
+		if err != nil {
+			return "", err
+		}
+		response = strings.TrimRight(string(bytePassword), "\r\n")
+		if err := validateFunc(response); err != nil {
+			fmt.Printf("\nEntry not valid: %s\n", au.BrightRed(err))
+		} else {
+			fmt.Println("")
+			responseValid = true
+		}
+	}
+
+	return response, nil
+}
+
+// InputPassword with a custom validator along capabilities of confirming
+// the password and reading it from disk if a specified flag is set.
+func InputPassword(
+	promptText, confirmText string,
+	shouldConfirmPassword bool,
+	passwordValidator func(input string) error,
+) (string, error) {
+	if strings.Contains(strings.ToLower(promptText), "new wallet") {
+		fmt.Println("Password requirements: at least 8 characters")
+	}
+	var hasValidPassword bool
+	var password string
+	var err error
+	for !hasValidPassword {
+		password, err = PasswordPrompt(promptText, passwordValidator)
+		if err != nil {
+			return "", errors.Wrap(err, "could not read password")
+		}
+		if shouldConfirmPassword {
+			passwordConfirmation, err := PasswordPrompt(confirmText, passwordValidator)
+			if err != nil {
+				return "", errors.Wrap(err, "could not read password confirmation")
+			}
+			if password != passwordConfirmation {
+				fmt.Println(au.BrightRed("Passwords do not match"))
+				continue
+			}
+			hasValidPassword = true
+		} else {
+			return password, nil
+		}
+	}
+
+	return password, nil
+}
+
+// ValidatePasswordInput validates a strong password input for new accounts,
+// including a min length.
+func ValidatePasswordInput(input string) error {
+	if len(input) < minPasswordLength {
+		return errPasswordWeak
+	}
+
+	return nil
+}

--- a/client/app/prompt.go
+++ b/client/app/prompt.go
@@ -64,8 +64,7 @@ func PasswordPrompt(promptText string, validateFunc func(string) error) (string,
 	return response, nil
 }
 
-// InputPassword with a custom validator along capabilities of confirming
-// the password and reading it from disk if a specified flag is set.
+// InputPassword with a custom validator along capabilities of confirming the password.
 func InputPassword(
 	promptText, confirmText string,
 	shouldConfirmPassword bool,

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -26,9 +26,6 @@ import (
 	"github.com/piplabs/story/lib/k1util"
 	"github.com/piplabs/story/lib/netconf"
 	"github.com/piplabs/story/lib/tracer"
-
-	// Used for ABI embedding of the staking contract.
-	_ "embed"
 )
 
 func bindRunFlags(cmd *cobra.Command, cfg *config.Config) {
@@ -61,9 +58,11 @@ func bindInitFlags(flags *pflag.FlagSet, cfg *InitConfig) {
 	flags.BoolVar(&cfg.SeedMode, "seed-mode", false, "Enable seed mode")
 	flags.StringVar(&cfg.PersistentPeers, "persistent-peers", "", "Override the persistent peers (comma-separated)")
 	flags.StringVar(&cfg.Moniker, "moniker", "", "Declare a custom moniker for your node")
+	flags.BoolVar(&cfg.EncryptPrivKey, "encrypt-priv-key", false, "Encrypt the validator's private key")
 }
 
 func bindValidatorBaseFlags(cmd *cobra.Command, cfg *baseConfig) {
+	libcmd.BindHomeFlag(cmd.Flags(), &cfg.HomeDir)
 	cmd.Flags().StringVar(&cfg.RPC, "rpc", "https://mainnet.storyrpc.io", "RPC URL to connect to the network")
 	cmd.Flags().StringVar(&cfg.Explorer, "explorer", "https://storyscan.xyz", "URL of the blockchain explorer")
 	cmd.Flags().Int64Var(&cfg.ChainID, "chain-id", 1514, "Chain ID to use for the transaction")

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -155,7 +155,7 @@ func bindValidatorKeyExportFlags(cmd *cobra.Command, cfg *exportKeyConfig) {
 	cmd.Flags().StringVar(&cfg.EvmKeyFile, "evm-key-path", defaultEVMKeyFilePath, "Path to save the exported EVM private key")
 }
 
-func bindValidatorGenPrivKeyJSONFlags(cmd *cobra.Command, cfg *genPrivKeyJSONConfig) {
+func bindKeyGenPrivKeyJSONFlags(cmd *cobra.Command, cfg *genPrivKeyJSONConfig) {
 	bindValidatorKeyFlags(cmd, &cfg.ValidatorKeyFile)
 	bindValidatorBaseFlags(cmd, &cfg.baseConfig)
 }
@@ -493,7 +493,7 @@ func validateGenPrivKeyJSONFlags(cfg *genPrivKeyJSONConfig) error {
 	return nil
 }
 
-func validateEncryptPrivKeyFlags(cfg *baseConfig) error {
+func validateEncryptFlags(cfg *baseConfig) error {
 	if cmtos.FileExists(cfg.EncPrivKeyFile()) {
 		return errors.New("already encrypted private key exists")
 	}

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -15,7 +15,9 @@ import (
 
 	"cosmossdk.io/math"
 
+	cmtos "github.com/cometbft/cometbft/libs/os"
 	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -487,6 +489,26 @@ func validateGenPrivKeyJSONFlags(cfg *genPrivKeyJSONConfig) error {
 	if _, err := os.Stat(cfg.ValidatorKeyFile); err == nil {
 		return errors.New("priv_validator_key.json file already exists")
 	}
+
+	return nil
+}
+
+func validateEncryptPrivKeyFlags(cfg *baseConfig) error {
+	if cmtos.FileExists(cfg.EncPrivKeyFile()) {
+		return errors.New("already encrypted private key exists")
+	}
+
+	loadEnv()
+	pk := os.Getenv("PRIVATE_KEY")
+	if pk == "" {
+		return errors.New("no private key is provided")
+	}
+
+	if _, err := crypto.HexToECDSA(pk); err != nil {
+		return errors.New("invalid secp256k1 private key")
+	}
+
+	cfg.PrivateKey = pk
 
 	return nil
 }

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -160,6 +160,11 @@ func bindKeyGenPrivKeyJSONFlags(cmd *cobra.Command, cfg *genPrivKeyJSONConfig) {
 	bindValidatorBaseFlags(cmd, &cfg.baseConfig)
 }
 
+func bindKeyShowEncryptedFlags(cmd *cobra.Command, cfg *showEncryptedConfig) {
+	bindValidatorBaseFlags(cmd, &cfg.baseConfig)
+	cmd.Flags().BoolVar(&cfg.ShowPrivate, "show-private", false, "Show private key")
+}
+
 func bindValidatorKeyFlags(cmd *cobra.Command, keyFilePath *string) {
 	defaultKeyFilePath := filepath.Join(config.DefaultHomeDir(), "config", "priv_validator_key.json")
 	cmd.Flags().StringVar(keyFilePath, "keyfile", defaultKeyFilePath, "Path to the Tendermint key file")
@@ -509,6 +514,14 @@ func validateEncryptFlags(cfg *baseConfig) error {
 	}
 
 	cfg.PrivateKey = pk
+
+	return nil
+}
+
+func validateShowEncryptedFlags(cfg *showEncryptedConfig) error {
+	if !cmtos.FileExists(cfg.EncPrivKeyFile()) {
+		return errors.New("no encrypted private key file")
+	}
 
 	return nil
 }

--- a/client/cmd/init.go
+++ b/client/cmd/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 
+	"github.com/piplabs/story/client/app"
 	storycfg "github.com/piplabs/story/client/config"
 	libcmd "github.com/piplabs/story/lib/cmd"
 	"github.com/piplabs/story/lib/errors"
@@ -40,6 +41,11 @@ type InitConfig struct {
 	SeedMode        bool
 	Moniker         string
 	PersistentPeers string
+	EncryptPrivKey  bool
+}
+
+func (cfg InitConfig) EncPrivKeyFile() string {
+	return filepath.Join(cfg.HomeDir, storycfg.DefaultEncPrivKeyPath)
 }
 
 // newInitCmd returns a new cobra command that initializes the files and folders required by story.
@@ -88,7 +94,7 @@ The home directory should only contain subdirectories, no files, use --force to 
 // InitFiles initializes the files and folders required by story.
 // It ensures a network and genesis file is generated/downloaded for the provided network.
 //
-//nolint:gocognit,nestif // This is just many sequential steps.
+//nolint:gocognit,nestif,gocyclo // This is just many sequential steps.
 func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	if initCfg.Network == "" {
 		return errors.New("required flag --network empty")
@@ -204,21 +210,21 @@ func InitFiles(ctx context.Context, initCfg InitConfig) error {
 	}
 
 	// Setup comet private validator
-	var pv *privval.FilePV
-	privValKeyFile := comet.PrivValidatorKeyFile()
+	var (
+		pv  *privval.FilePV
+		err error
+	)
+
 	privValStateFile := comet.PrivValidatorStateFile()
-	if cmtos.FileExists(privValKeyFile) {
-		pv = privval.LoadFilePV(privValKeyFile, privValStateFile) // This hard exits on any error.
-		log.Info(ctx, "Found cometBFT private validator",
-			"key_file", privValKeyFile,
-			"state_file", privValStateFile,
-		)
+	if initCfg.EncryptPrivKey {
+		encPrivKeyFile := initCfg.EncPrivKeyFile()
+		pv, err = loadOrCreateEncryptedPrivKey(ctx, encPrivKeyFile, privValStateFile)
+		if err != nil {
+			return err
+		}
 	} else {
-		pv = privval.NewFilePV(k1.GenPrivKey(), privValKeyFile, privValStateFile)
-		pv.Save()
-		log.Info(ctx, "Generated private validator",
-			"key_file", privValKeyFile,
-			"state_file", privValStateFile)
+		privValKeyFile := comet.PrivValidatorKeyFile()
+		pv = loadOrCreatePrivKey(ctx, privValKeyFile, privValStateFile)
 	}
 
 	// Setup node key
@@ -314,4 +320,52 @@ func SplitAndTrim(input string) []string {
 	}
 
 	return ret
+}
+
+func loadOrCreateEncryptedPrivKey(ctx context.Context, encPrivKeyFile, privValStateFile string) (pv *privval.FilePV, err error) {
+	if cmtos.FileExists(encPrivKeyFile) {
+		key, err := app.LoadEncryptedPrivKey(encPrivKeyFile)
+		if err != nil {
+			return nil, err
+		}
+
+		pv = privval.NewFilePV(key.PrivKey, "", privValStateFile)
+		log.Info(ctx, "Found encrypted validator private key",
+			"enc_key_file", encPrivKeyFile,
+			"state_file", privValStateFile,
+		)
+	} else {
+		pv = privval.NewFilePV(k1.GenPrivKey(), "", privValStateFile)
+		if err := app.EncryptAndStoreKey(pv.Key, encPrivKeyFile); err != nil {
+			return nil, err
+		}
+		pv.LastSignState.Save()
+
+		log.Info(ctx, "Generated encrypted validator private key",
+			"enc_key_file", encPrivKeyFile,
+			"state_file", privValStateFile,
+		)
+	}
+
+	return pv, nil
+}
+
+func loadOrCreatePrivKey(ctx context.Context, privValKeyFile, privValStateFile string) (pv *privval.FilePV) {
+	if cmtos.FileExists(privValKeyFile) {
+		pv = privval.LoadFilePV(privValKeyFile, privValStateFile) // This hard exits on any error.
+
+		log.Info(ctx, "Found cometBFT private validator",
+			"key_file", privValKeyFile,
+			"state_file", privValStateFile,
+		)
+	} else {
+		pv = privval.NewFilePV(k1.GenPrivKey(), privValKeyFile, privValStateFile)
+		pv.Save()
+
+		log.Info(ctx, "Generated private validator",
+			"key_file", privValKeyFile,
+			"state_file", privValStateFile)
+	}
+
+	return pv
 }

--- a/client/cmd/keys.go
+++ b/client/cmd/keys.go
@@ -198,6 +198,16 @@ func genValidatorPrivKeyJSON(_ context.Context, cfg genPrivKeyJSONConfig) error 
 }
 
 func encryptPrivKey(cfg baseConfig) error {
+	password, err := app.InputPassword(
+		app.NewKeyPasswordPromptText,
+		app.ConfirmPasswordPromptText,
+		true, /* Should confirm password */
+		app.ValidatePasswordInput,
+	)
+	if err != nil {
+		return errors.Wrap(err, "error occurred while input password")
+	}
+
 	privKeyBytes, err := hex.DecodeString(cfg.PrivateKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode private key")
@@ -210,7 +220,7 @@ func encryptPrivKey(cfg baseConfig) error {
 		Address: pk.PubKey().Address(),
 	}
 
-	if err := app.EncryptAndStoreKey(pv, cfg.EncPrivKeyFile()); err != nil {
+	if err := app.EncryptAndStoreKey(pv, password, cfg.EncPrivKeyFile()); err != nil {
 		return errors.Wrap(err, "failed to encrypt and store the key")
 	}
 
@@ -218,8 +228,18 @@ func encryptPrivKey(cfg baseConfig) error {
 }
 
 func showEncryptedKey(cfg showEncryptedConfig) error {
+	password, err := app.InputPassword(
+		app.PasswordPromptText,
+		"",
+		false,
+		app.ValidatePasswordInput,
+	)
+	if err != nil {
+		return errors.Wrap(err, "error occurred while input password")
+	}
+
 	encPrivKeyFile := cfg.EncPrivKeyFile()
-	pv, err := app.LoadEncryptedPrivKey(encPrivKeyFile)
+	pv, err := app.LoadEncryptedPrivKey(password, encPrivKeyFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to load encrypted private key")
 	}

--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -157,6 +157,11 @@ type genPrivKeyJSONConfig struct {
 	ValidatorKeyFile string
 }
 
+type showEncryptedConfig struct {
+	baseConfig
+	ShowPrivate bool
+}
+
 func loadEnv() {
 	if err := godotenv.Load(); err != nil {
 		fmt.Println("Warning: No .env file found")

--- a/client/cmd/validator.go
+++ b/client/cmd/validator.go
@@ -1090,7 +1090,17 @@ func initializeBaseConfig(cfg *baseConfig) error {
 func loadPrivKey(cfg *baseConfig) (string, error) {
 	encPrivKeyFile := cfg.EncPrivKeyFile()
 	if cmtos.FileExists(encPrivKeyFile) {
-		pv, err := app.LoadEncryptedPrivKey(encPrivKeyFile)
+		password, err := app.InputPassword(
+			app.PasswordPromptText,
+			"",
+			false,
+			app.ValidatePasswordInput,
+		)
+		if err != nil {
+			return "", errors.Wrap(err, "error occurred while input password")
+		}
+
+		pv, err := app.LoadEncryptedPrivKey(password, encPrivKeyFile)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to load encrypted private key")
 		}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	pruningtypes "cosmossdk.io/store/pruning/types"
 
+	cmtconfig "github.com/cometbft/cometbft/config"
 	cmtos "github.com/cometbft/cometbft/libs/os"
 	db "github.com/cosmos/cosmos-db"
 
@@ -25,11 +26,12 @@ import (
 )
 
 const (
-	configFile      = "story.toml"
-	dataDir         = "data"
-	configDir       = "config"
-	snapshotDataDir = "snapshots"
-	networkFile     = "network.json"
+	configFile            = "story.toml"
+	dataDir               = "data"
+	configDir             = "config"
+	snapshotDataDir       = "snapshots"
+	networkFile           = "network.json"
+	DefaultEncPrivKeyName = "enc_priv_key.json"
 
 	DefaultEngineEndpoint     = "http://localhost:8551" // Default host endpoint for the Engine API
 	defaultSnapshotInterval   = 1000                    // Roughly once an hour (given 3s blocks)
@@ -42,6 +44,9 @@ const (
 	defaultEVMBuildOptimistic = true
 )
 
+var DefaultEncPrivKeyPath = filepath.Join(cmtconfig.DefaultConfigDir, DefaultEncPrivKeyName)
+
+// network config.
 var (
 	IliadConfig = Config{
 		HomeDir:            DefaultHomeDir(),
@@ -227,6 +232,10 @@ func (c Config) AppStateDir() string {
 
 func (c Config) SnapshotDir() string {
 	return filepath.Join(c.DataDir(), snapshotDataDir)
+}
+
+func (c Config) EncPrivKeyFile() string {
+	return filepath.Join(c.HomeDir, DefaultEncPrivKeyPath)
 }
 
 func (c Config) Verify() error {

--- a/go.mod
+++ b/go.mod
@@ -223,7 +223,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/crypto v0.32.0
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
@@ -247,6 +247,8 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.4
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/joho/godotenv v1.5.1
+	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -527,6 +527,8 @@ github.com/felixge/fgprof v0.9.5/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZP
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/ferranbt/fastssz v0.1.3 h1:ZI+z3JH05h4kgmFXdHuR1aWYsgrg7o+Fw7/NCzM16Mo=
+github.com/ferranbt/fastssz v0.1.3/go.mod h1:0Y9TEd/9XuFlh7mskMPfXiI2Dkw4Ddg9EyXt1W7MRvE=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
@@ -824,6 +826,8 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/hdevalence/ed25519consensus v0.1.0 h1:jtBwzzcHuTmFrQN6xQZn6CQEO/V9f7HsjsjeEZ6auqU=
 github.com/hdevalence/ed25519consensus v0.1.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
+github.com/herumi/bls-eth-go-binary v1.31.0 h1:9eeW3EA4epCb7FIHt2luENpAW69MvKGL5jieHlBiP+w=
+github.com/herumi/bls-eth-go-binary v1.31.0/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
 github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 h1:X4egAf/gcS1zATw6wn4Ej8vjuVGxeHdan+bRb2ebyv4=
 github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
@@ -891,6 +895,8 @@ github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
+github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -921,6 +927,8 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-b
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linxGnu/grocksdb v1.8.14 h1:HTgyYalNwBSG/1qCQUIott44wU5b2Y9Kr3z7SK5OfGQ=
 github.com/linxGnu/grocksdb v1.8.14/go.mod h1:QYiYypR2d4v63Wj1adOOfzglnoII0gLj3PNh4fZkcFA=
+github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
+github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
@@ -952,6 +960,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
 github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
+github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
+github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -1257,6 +1267,12 @@ github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=
 github.com/urfave/cli/v2 v2.27.2/go.mod h1:g0+79LmHHATl7DAcHO99smiR/T7uGLw84w8Y42x+4eM=
 github.com/vbatts/tar-split v0.11.6 h1:4SjTW5+PU11n6fZenf2IPoV8/tz3AaYHMWjf23envGs=
 github.com/vbatts/tar-split v0.11.6/go.mod h1:dqKNtesIOr2j2Qv3W/cHjnvk9I8+G7oAkFDFN6TCBEI=
+github.com/wealdtech/go-eth2-types/v2 v2.8.2 h1:b5aXlNBLKgjAg/Fft9VvGlqAUCQMP5LzYhlHRrr4yPg=
+github.com/wealdtech/go-eth2-types/v2 v2.8.2/go.mod h1:IAz9Lz1NVTaHabQa+4zjk2QDKMv8LVYo0n46M9o/TXw=
+github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1 h1:9j7bpwjT9wmwBb54ZkBhTm1uNIlFFcCJXefd/YskZPw=
+github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1/go.mod h1:+tI1VD76E1WINI+Nstg7RVGpUolL5ql10nu2YztMO/4=
+github.com/wealdtech/go-eth2-wallet-types/v2 v2.11.0 h1:yX9+FfUXvPDvZ8Q5bhF+64AWrQwh4a3/HpfTx99DnZc=
+github.com/wealdtech/go-eth2-wallet-types/v2 v2.11.0/go.mod h1:UVP9YFcnPiIzHqbmCMW3qrQ3TK5FOqr1fmKqNT9JGr8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=

--- a/lib/cmd/flags.go
+++ b/lib/cmd/flags.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	storycfg "github.com/piplabs/story/client/config"
 	"github.com/piplabs/story/lib/log"
 )
 
@@ -16,7 +17,8 @@ const homeFlag = "home"
 // This is generally only required for apps that require multiple config files or persist data to disk.
 // Using this flag will result in the viper config directory to be updated from default "." to "<home>/config".
 func BindHomeFlag(flags *pflag.FlagSet, homeDir *string) {
-	flags.StringVar(homeDir, homeFlag, *homeDir, "The application home directory containing config and data")
+	defaultHomeDir := storycfg.DefaultHomeDir()
+	flags.StringVar(homeDir, homeFlag, defaultHomeDir, "The application home directory containing config and data")
 }
 
 // LogFlags logs the configured flags kv pairs.


### PR DESCRIPTION
Support validator priv key encryption. 

## Updated

### `init` command

Operators can encrypt the newly generated private key with `--encrypt-priv-key` flag. Without this flag, no encryption is done for private key as before. The encrypted file is stored under `story/config/enc_priv_key.json`. 

For all validator CLI, the private key is retrieved from the encrypted private key file by decrypting it if the `enc_priv_key.json` file exists. Otherwise, it is retrieved from `.env` file.

## Added

### `encrypt` command 

To support the existing operators (using not encrypted key), one command is also added to encrypt the existing private key in `.env` file: `./story key encrypt`. It will generate the encrypted private key file under `story/config/enc_priv_key.json`. 

### `show` command

Also, introduced a new command to decrypt and show the encrypted key: `./story key show-encrypted`. With `--show-private` flag, user can show the private key. 

issue: #151 
