### PR TITLE
feat(staking): relax unstake requirements by rounding down to gwei

### DIFF
--- a/contracts/script/upgrades/DeployNewIPTokenStaking_V1_0_1.s.sol
+++ b/contracts/script/upgrades/DeployNewIPTokenStaking_V1_0_1.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { IPTokenStaking } from "../../src/protocol/IPTokenStaking.sol";
+import { Predeploys } from "../../src/libraries/Predeploys.sol";
+import { Create3 } from "../../src/deploy/Create3.sol";
+
+/**
+ * @title DeployNewIPTokenStakingImpl
+ * @notice Deploys a new implementation of IPTokenStaking contract to be used for upgrading
+ * @dev This script only deploys the implementation contract, it does not perform the upgrade
+ */
+contract DeployNewIPTokenStaking_V1_0_1 is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        Create3 create3 = Create3(Predeploys.Create3);
+
+        // Generate creation code for IPTokenStaking
+        bytes memory creationCode = abi.encodePacked(
+            type(IPTokenStaking).creationCode,
+            abi.encode(1 ether, 256) // Constructor args: defaultMinFee (1 IP), maxDataLength
+        );
+
+        bytes32 salt = keccak256(abi.encodePacked("IPTokenStaking_Implementation_v1_0_1"));
+
+        // Deploy using Create3
+        address newImplementation = create3.deploy(salt, creationCode);
+        if (create3.getDeployed(deployer, salt) != newImplementation) {
+            revert("Deployment failed");
+        }
+
+        vm.stopBroadcast();
+
+        console2.log("New IPTokenStaking implementation deployed at:", newImplementation);
+    }
+}

--- a/contracts/src/interfaces/IIPTokenStaking.sol
+++ b/contracts/src/interfaces/IIPTokenStaking.sol
@@ -91,7 +91,7 @@ interface IIPTokenStaking {
     /// @notice Emitted when a user withdraws her stake and starts the unbonding period.
     /// @param delegator The delegator's address
     /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key.
-    /// @param stakeAmount Token deposited.
+    /// @param stakeAmount Token unstaked. WARNING: This amount is rounded down to STAKE_ROUNDING.
     /// @param delegationId The ID of the delegation, 0 if flexible
     /// @param operatorAddress The caller's address
     /// @param data Additional data for the deposit
@@ -263,11 +263,12 @@ interface IIPTokenStaking {
     ) external payable;
 
     /// @notice Entry point for unstaking the previously staked token.
+    /// NOTE: If the amount is not divisible by STAKE_ROUNDING, it will be rounded down.
     /// @dev Unstake (withdrawal) will trigger native minting, so token in this contract is considered as burned.
     /// Charges fee (CL spam prevention). Must be exact amount.
     /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key.
     /// @param delegationId The delegation ID, 0 for flexible staking.
-    /// @param amount Token amount to unstake.
+    /// @param amount Token amount to unstake. This amount will be rounded down to STAKE_ROUNDING.
     /// @param data Additional data for the unstake.
     function unstake(
         bytes calldata validatorCmpPubkey,
@@ -278,12 +279,13 @@ interface IIPTokenStaking {
 
     /// @notice Entry point for unstaking the previously staked token on behalf of the delegator.
     /// Charges fee (CL spam prevention). Must be exact amount.
+    /// NOTE: If the amount is not divisible by STAKE_ROUNDING, it will be rounded down.
     /// @dev Caller must be the operator for the delegator, set via `setOperator`. The operator check is done in CL, so
     /// this method will succeed even if the caller is not the operator (but will fail in CL).
     /// @param delegator The delegator's address
     /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key.
     /// @param delegationId The delegation ID, 0 for flexible staking.
-    /// @param amount Token amount to unstake.
+    /// @param amount Token amount to unstake. This amount will be rounded down to STAKE_ROUNDING.
     /// @param data Additional data for the unstake.
     function unstakeOnBehalf(
         address delegator,

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -335,8 +335,6 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         (uint256 stakeAmount, uint256 remainder) = roundedStakeAmount(msg.value);
         require(stakeAmount >= minStakeAmount, "IPTokenStaking: Stake amount under min");
 
-        // REvert if msg.value is not rounded to STAKE_ROUNDING
-
         uint256 delegationId = 0;
         if (stakingPeriod != IIPTokenStaking.StakingPeriod.FLEXIBLE) {
             delegationId = ++_delegationIdCounter;

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -335,6 +335,8 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         (uint256 stakeAmount, uint256 remainder) = roundedStakeAmount(msg.value);
         require(stakeAmount >= minStakeAmount, "IPTokenStaking: Stake amount under min");
 
+        // REvert if msg.value is not rounded to STAKE_ROUNDING
+
         uint256 delegationId = 0;
         if (stakingPeriod != IIPTokenStaking.StakingPeriod.FLEXIBLE) {
             delegationId = ++_delegationIdCounter;
@@ -434,12 +436,13 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
     }
 
     /// @notice Entry point for unstaking the previously staked token on behalf of the delegator.
+    /// NOTE: If the amount is not divisible by STAKE_ROUNDING, it will be rounded down.
     /// @dev Caller must be the operator for the delegator, set via `setOperator`. The operator check is done in CL, so
-    /// this method will succeed even if the caller is not the operator (but will fail in CL).
+    /// this method will succeed even if the caller is not the operator (but will fail in CL)
     /// @param delegator The delegator's address
     /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
     /// @param delegationId The delegation ID, 0 for flexible staking.
-    /// @param amount Token amount to unstake.
+    /// @param amount Token amount to unstake. This amount will be rounded to STAKE_ROUNDING.
     /// @param data Additional data for the unstake.
     function unstakeOnBehalf(
         address delegator,
@@ -459,10 +462,16 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         bytes calldata data
     ) private verifyCmpPubkey(validatorCmpPubkey) {
         require(delegationId <= _delegationIdCounter, "IPTokenStaking: Invalid delegation id");
-        require(amount >= minUnstakeAmount, "IPTokenStaking: Unstake amount under min");
-        require(amount % STAKE_ROUNDING == 0, "IPTokenStaking: Amount must be rounded to STAKE_ROUNDING");
+        uint256 unstakeAmount = amount;
+        // Due to CL having less decimals, we need to round down to the nearest STAKE_ROUNDING.
+        // Dust may be left over, this is currently a known issue.
+        if (amount % STAKE_ROUNDING != 0) {
+            unstakeAmount = amount / STAKE_ROUNDING * STAKE_ROUNDING;
+        }
+        require(unstakeAmount >= minUnstakeAmount, "IPTokenStaking: Unstake amount under min");
         require(data.length <= MAX_DATA_LENGTH, "IPTokenStaking: Data length over max");
-        emit Withdraw(delegator, validatorCmpPubkey, amount, delegationId, msg.sender, data);
+
+        emit Withdraw(delegator, validatorCmpPubkey, unstakeAmount, delegationId, msg.sender, data);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/contracts/src/protocol/IPTokenStaking.sol
+++ b/contracts/src/protocol/IPTokenStaking.sol
@@ -460,12 +460,7 @@ contract IPTokenStaking is IIPTokenStaking, Ownable2StepUpgradeable, ReentrancyG
         bytes calldata data
     ) private verifyCmpPubkey(validatorCmpPubkey) {
         require(delegationId <= _delegationIdCounter, "IPTokenStaking: Invalid delegation id");
-        uint256 unstakeAmount = amount;
-        // Due to CL having less decimals, we need to round down to the nearest STAKE_ROUNDING.
-        // Dust may be left over, this is currently a known issue.
-        if (amount % STAKE_ROUNDING != 0) {
-            unstakeAmount = amount / STAKE_ROUNDING * STAKE_ROUNDING;
-        }
+        (uint256 unstakeAmount, ) = roundedStakeAmount(amount);
         require(unstakeAmount >= minUnstakeAmount, "IPTokenStaking: Unstake amount under min");
         require(data.length <= MAX_DATA_LENGTH, "IPTokenStaking: Data length over max");
 


### PR DESCRIPTION
Instead of reverting, round down

issue: none
