### PR TITLE
fix(cli): retrieve pub key from priv key in create validator

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "client/cmd/flags.go",
         "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
         "is_verified": false,
-        "line_number": 521
+        "line_number": 528
       }
     ],
     "client/config/config.go": [
@@ -974,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-12T11:00:02Z"
+  "generated_at": "2025-03-13T08:57:21Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
       {
         "type": "Secret Keyword",
         "filename": "client/app/prompt.go",
-        "hashed_secret": "158c1f674ccc860d3e910a21721f1f12e25caeb1",
+        "hashed_secret": "fac169fe0cce155386d0f0515fa9603796614d24",
         "is_verified": false,
         "line_number": 21
       },
@@ -974,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-14T05:32:10Z"
+  "generated_at": "2025-03-14T05:46:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "client/cmd/flags.go",
         "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 527
       }
     ],
     "client/config/config.go": [
@@ -974,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-13T08:57:21Z"
+  "generated_at": "2025-03-14T05:32:10Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "client/cmd/flags.go",
         "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
         "is_verified": false,
-        "line_number": 527
+        "line_number": 532
       }
     ],
     "client/config/config.go": [
@@ -974,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-14T05:46:04Z"
+  "generated_at": "2025-03-19T01:27:34Z"
 }

--- a/client/app/prompt.go
+++ b/client/app/prompt.go
@@ -18,7 +18,7 @@ const (
 	minPasswordLength = 8
 
 	// NewKeyPasswordPromptText for key creation.
-	NewKeyPasswordPromptText = "New key password"
+	NewKeyPasswordPromptText = "New key password (at least 8 characters)"
 	// PasswordPromptText for wallet unlocking.
 	PasswordPromptText = "Key password"
 	// ConfirmPasswordPromptText for confirming a key password.

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -514,7 +514,7 @@ func validateGenPrivKeyJSONFlags(cfg *genPrivKeyJSONConfig) error {
 	return nil
 }
 
-func validateEncryptFlags(cfg *baseConfig) error {
+func validateEncryptFlags(cmd *cobra.Command, cfg *baseConfig) error {
 	if cmtos.FileExists(cfg.EncPrivKeyFile) {
 		return errors.New("already encrypted private key exists")
 	}
@@ -531,15 +531,15 @@ func validateEncryptFlags(cfg *baseConfig) error {
 
 	cfg.PrivateKey = pk
 
-	return nil
+	return validateFlags(cmd, []string{"enc-key-file"})
 }
 
-func validateShowEncryptedFlags(cfg *showEncryptedConfig) error {
+func validateShowEncryptedFlags(cmd *cobra.Command, cfg *showEncryptedConfig) error {
 	if !cmtos.FileExists(cfg.EncPrivKeyFile) {
 		return errors.New("no encrypted private key file")
 	}
 
-	return nil
+	return validateFlags(cmd, []string{"enc-key-file"})
 }
 
 func validateValidatorUnjailFlags(ctx context.Context, cmd *cobra.Command, cfg *unjailConfig) error {

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -177,8 +177,7 @@ func bindValidatorKeyFlags(cmd *cobra.Command, keyFilePath *string) {
 }
 
 func bindEncPrivKeyFileFlags(cmd *cobra.Command, encKeyFilePath *string) {
-	defaultEncPrivKeyPath := filepath.Join(config.DefaultHomeDir(), config.DefaultEncPrivKeyPath)
-	cmd.Flags().StringVar(encKeyFilePath, "enc-key-file", defaultEncPrivKeyPath, "Path to the encrypted private key file")
+	cmd.Flags().StringVar(encKeyFilePath, "enc-key-file", "", "Path to the encrypted private key file")
 }
 
 func bindStatusFlags(flags *pflag.FlagSet, cfg *StatusConfig) {

--- a/client/cmd/keys.go
+++ b/client/cmd/keys.go
@@ -23,6 +23,7 @@ type keyConfig struct {
 	PubKeyHex             string
 	PubKeyBase64          string
 	PubKeyHexUncompressed string
+	EncPrivKeyFile        string
 }
 
 func newKeyCmds() *cobra.Command {
@@ -165,6 +166,22 @@ func convertKey(_ context.Context, cfg keyConfig) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to convert uncompressed pub key")
 		}
+	case cfg.EncPrivKeyFile != "":
+		password, err := app.InputPassword(
+			app.PasswordPromptText,
+			"",
+			false,
+			app.ValidatePasswordInput,
+		)
+		if err != nil {
+			return errors.Wrap(err, "error occurred while input password")
+		}
+
+		pv, err := app.LoadEncryptedPrivKey(password, cfg.EncPrivKeyFile)
+		if err != nil {
+			return errors.Wrap(err, "failed to load encrypted private key")
+		}
+		compressedPubKeyBytes = pv.PubKey.Bytes()
 	default:
 		return errors.New("no valid key input provided")
 	}
@@ -220,7 +237,7 @@ func encryptPrivKey(cfg baseConfig) error {
 		Address: pk.PubKey().Address(),
 	}
 
-	if err := app.EncryptAndStoreKey(pv, password, cfg.EncPrivKeyFile()); err != nil {
+	if err := app.EncryptAndStoreKey(pv, password, cfg.EncPrivKeyFile); err != nil {
 		return errors.Wrap(err, "failed to encrypt and store the key")
 	}
 
@@ -238,8 +255,7 @@ func showEncryptedKey(cfg showEncryptedConfig) error {
 		return errors.Wrap(err, "error occurred while input password")
 	}
 
-	encPrivKeyFile := cfg.EncPrivKeyFile()
-	pv, err := app.LoadEncryptedPrivKey(password, encPrivKeyFile)
+	pv, err := app.LoadEncryptedPrivKey(password, cfg.EncPrivKeyFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to load encrypted private key")
 	}

--- a/client/cmd/keys.go
+++ b/client/cmd/keys.go
@@ -95,8 +95,8 @@ func newKeyEncryptCmd() *cobra.Command {
 			return nil
 		},
 		RunE: runValidatorCommand(
-			func(_ *cobra.Command) error {
-				return validateEncryptFlags(&cfg)
+			func(cmd *cobra.Command) error {
+				return validateEncryptFlags(cmd, &cfg)
 			},
 			func(_ context.Context) error { return encryptPrivKey(cfg) },
 		),
@@ -118,8 +118,8 @@ func newKeyShowEncryptedCmd() *cobra.Command {
 			return nil
 		},
 		RunE: runValidatorCommand(
-			func(_ *cobra.Command) error {
-				return validateShowEncryptedFlags(&cfg)
+			func(cmd *cobra.Command) error {
+				return validateShowEncryptedFlags(cmd, &cfg)
 			},
 			func(_ context.Context) error { return showEncryptedKey(cfg) },
 		),


### PR DESCRIPTION
In the `CreateValidator` CLI, the public key is retrieved from `config.PrivateKey` instead of the validator key file (`priv_validator_key.json`).

Additionally, the encrypted key file path can now be passed as a flag, allowing operators to use the `*OnBehalf` CLI with key encryption.

issue: none
