### PR TITLE
chore(genesis): update exec hash for local devnet

### DIFF
--- a/lib/netconf/local/genesis.json
+++ b/lib/netconf/local/genesis.json
@@ -89,7 +89,7 @@
     },
     "evmengine": {
       "params": {
-        "execution_block_hash": "AS9C2Iew0SatPOG0MGnCTVupr1HODYooc7C9v4oHsxI="
+        "execution_block_hash": "gurvaiyYkNlLdee+7GiuC2p9trFSNnU3esw+6RusvYw="
       }
     },
     "genutil": {


### PR DESCRIPTION
Updated the execution hash for local devnet according to [this change](https://github.com/piplabs/story-geth/pull/117).

issue: none
