### PR TITLE
feat(cli): add alias of with comet flag

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "client/cmd/flags.go",
         "hashed_secret": "6924110cde4fa051bfdc600a60620dc7aa9d3c6a",
         "is_verified": false,
-        "line_number": 532
+        "line_number": 533
       }
     ],
     "client/config/config.go": [
@@ -624,7 +624,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "lib/netconf/local/genesis.json",
-        "hashed_secret": "f9b54413b9bd85cfa8ae32703695b5287f77a555",
+        "hashed_secret": "4a6e149fa2f319048e1498f970d423b98445c9ac",
         "is_verified": false,
         "line_number": 92
       }
@@ -974,5 +974,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-19T01:45:01Z"
+  "generated_at": "2025-03-19T09:11:15Z"
 }

--- a/client/cmd/flags.go
+++ b/client/cmd/flags.go
@@ -49,6 +49,7 @@ func bindRunFlags(cmd *cobra.Command, cfg *config.Config) {
 	flags.DurationVar(&cfg.EVMBuildDelay, "evm-build-delay", cfg.EVMBuildDelay, "Minimum delay between triggering and fetching a EVM payload build")
 	flags.BoolVar(&cfg.EVMBuildOptimistic, "evm-build-optimistic", cfg.EVMBuildOptimistic, "Enables optimistic building of EVM payloads on previous block finalize")
 	flags.BoolVar(&cfg.WithComet, "with-comet", true, "Run abci app embedded in-process with CometBFT")
+	flags.Bool("with-tendermint", true, "Alias for --with-comet")
 	flags.StringVar(&cfg.Address, "address", "tcp://127.0.0.1:26658", "Address of proxy app")
 	flags.StringVar(&cfg.Transport, "transport", "socket", "Specify abci transport (socket | grpc)")
 }


### PR DESCRIPTION
Added alias for `--with-comet` flag, `--with-tendermint`, per request from KYVE team. This alias flag is also commonly used in cosmos ecosystem. 

issue: #517 
