### PR TITLE
fix(cli): change to use pre run for aliasing

### DIFF
--- a/client/cmd/cmd.go
+++ b/client/cmd/cmd.go
@@ -39,7 +39,7 @@ func newRunCmd(name string, runFunc func(context.Context, app.Config) error) *co
 		Use:     name,
 		Aliases: []string{"start"},
 		Short:   "Runs the story consensus client",
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return aliasWithComet(cmd)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/client/cmd/cmd.go
+++ b/client/cmd/cmd.go
@@ -70,10 +70,6 @@ func newRunCmd(name string, runFunc func(context.Context, app.Config) error) *co
 }
 
 func aliasWithComet(cmd *cobra.Command) error {
-	if cmd.Flags().Changed("with-comet") {
-		return nil
-	}
-
 	if cmd.Flags().Changed("with-tendermint") {
 		val, err := cmd.Flags().GetBool("with-tendermint")
 		if err != nil {


### PR DESCRIPTION
It conflicts `PersistentPreRunE` of root cmd, so changed to use `PreRun` for run command.

issue: none
