### PR TITLE
chore(config): set default with comet true

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -112,6 +112,7 @@ var (
 		ExternalAddress:    "",
 		Seeds:              "",
 		SeedMode:           false,
+		WithComet:          true,
 	}
 	StoryConfig = Config{
 		HomeDir:            DefaultHomeDir(),
@@ -133,6 +134,7 @@ var (
 		ExternalAddress:    "",
 		Seeds:              "",
 		SeedMode:           false,
+		WithComet:          true,
 	}
 	LocalConfig = Config{
 		HomeDir:            DefaultHomeDir(),


### PR DESCRIPTION
Set the default value of `--with-comet` flag for Aeneid and Mainnet.

issue: none
