### PR TITLE
feat(app): release v1.2.0

### DIFF
--- a/client/app/upgrades.go
+++ b/client/app/upgrades.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/piplabs/story/client/app/upgrades"
 	"github.com/piplabs/story/client/app/upgrades/singularity/virgil"
+	"github.com/piplabs/story/client/app/upgrades/v_1_2_0"
 )
 
 var (
@@ -16,10 +17,12 @@ var (
 	// New upgrades should be added to this slice after they are implemented.
 	Upgrades = []upgrades.Upgrade{
 		virgil.Upgrade,
+		v_1_2_0.Upgrade,
 	}
 	// Forks are for hard forks that breaks backward compatibility.
 	Forks = []upgrades.Fork{
 		virgil.Fork,
+		v_1_2_0.Fork,
 	}
 )
 
@@ -68,6 +71,14 @@ func (a *App) scheduleForkUpgrade(ctx sdk.Context) {
 				continue
 			}
 			upgradeHeight = virgilUpgradeHeight
+		}
+
+		if fork.UpgradeName == v_1_2_0.UpgradeName {
+			v120UpgradeHeight, ok := v_1_2_0.GetUpgradeHeight(ctx.ChainID())
+			if !ok {
+				continue
+			}
+			upgradeHeight = v120UpgradeHeight
 		}
 
 		if currentBlockHeight == upgradeHeight {

--- a/client/app/upgrades/v_1_2_0/constants.go
+++ b/client/app/upgrades/v_1_2_0/constants.go
@@ -1,0 +1,47 @@
+//nolint:revive,stylecheck // versioning
+package v_1_2_0
+
+import (
+	storetypes "cosmossdk.io/store/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/piplabs/story/client/app/keepers"
+	"github.com/piplabs/story/client/app/upgrades"
+)
+
+const (
+	UpgradeName = "v1.2.0"
+
+	// AeneidUpgradeHeight defines the block height at which v1.2.0 upgrade is triggered on Aeneid.
+	AeneidUpgradeHeight = 4362990
+	// StoryUpgradeHeight defines the block height at which v1.2.0 upgrade is triggered on Mainnet.
+	StoryUpgradeHeight = 4477880
+
+	// new max bytes for consensus params.
+	newMaxBytes = 20971520 // 20MB
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        storetypes.StoreUpgrades{},
+}
+
+var Fork = upgrades.Fork{
+	UpgradeName: UpgradeName,
+	UpgradeInfo: "upgrade to change the max bytes of block in consensus parameters",
+	// UpgradeHeight is set in `scheduleForkUpgrade`
+	BeginForkLogic: func(_ sdk.Context, _ *keepers.Keepers) {},
+}
+
+func GetUpgradeHeight(chainID string) (int64, bool) {
+	switch chainID {
+	case upgrades.AeneidChainID:
+		return AeneidUpgradeHeight, true
+	case upgrades.StoryChainID:
+		return StoryUpgradeHeight, true
+	default:
+		return 0, false
+	}
+}

--- a/client/app/upgrades/v_1_2_0/upgrades.go
+++ b/client/app/upgrades/v_1_2_0/upgrades.go
@@ -1,0 +1,78 @@
+//nolint:revive,stylecheck // versioning
+package v_1_2_0
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+
+	"github.com/piplabs/story/client/app/keepers"
+	"github.com/piplabs/story/lib/errors"
+	"github.com/piplabs/story/lib/log"
+)
+
+func CreateUpgradeHandler(
+	_ *module.Manager,
+	_ module.Configurator,
+	keepers *keepers.Keepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		log.Info(ctx, "Start upgrade v1.2.0")
+
+		// update consensus params
+		oldConsParams, err := keepers.ConsensusParamsKeeper.ParamsStore.Get(ctx)
+		if err != nil {
+			return vm, errors.Wrap(err, "failed to get consensus params")
+		}
+
+		updateConsParamsMsg := consensusparamtypes.MsgUpdateParams{
+			Authority: keepers.ConsensusParamsKeeper.GetAuthority(),
+			Block:     oldConsParams.Block,
+			Evidence:  oldConsParams.Evidence,
+			Validator: oldConsParams.Validator,
+			Abci:      oldConsParams.Abci,
+		}
+
+		updateConsParamsMsg.Block.MaxBytes = newMaxBytes
+
+		if _, err = keepers.ConsensusParamsKeeper.UpdateParams(ctx, &updateConsParamsMsg); err != nil {
+			return vm, errors.Wrap(err, "failed to update consensus params")
+		}
+
+		newConsParams, err := keepers.ConsensusParamsKeeper.ParamsStore.Get(ctx)
+		if err != nil {
+			return vm, errors.Wrap(err, "failed to get updated consensus params")
+		}
+
+		if !oldConsParams.Evidence.Equal(newConsParams.Evidence) {
+			return vm, errors.New("mismatch evidence in consensus params", "old_evidence", oldConsParams.Evidence, "new_evidence", newConsParams.Evidence)
+		}
+
+		if !oldConsParams.Validator.Equal(newConsParams.Validator) {
+			return vm, errors.New("mismatch validator in consensus params", "old_validator", oldConsParams.Validator, "new_validator", newConsParams.Validator)
+		}
+
+		if !oldConsParams.Abci.Equal(newConsParams.Abci) {
+			return vm, errors.New("mismatch ABCI in consensus params", "old_abci", oldConsParams.Abci, "new_abci", newConsParams.Abci)
+		}
+
+		if oldConsParams.Block.MaxGas != newConsParams.Block.MaxGas {
+			return vm, errors.New("mismatch Block in consensus params", "old_max_gas", oldConsParams.Block.MaxGas, "new_max_gas", newConsParams.Block.MaxGas)
+		}
+
+		if newConsParams.Block.MaxBytes != newMaxBytes {
+			return vm, errors.New("wrong updated max bytes in consensus params", "expected_max_bytes", newMaxBytes, "actual_max_bytes", newConsParams.Block.MaxBytes)
+		}
+
+		if oldConsParams.Version.App != newConsParams.Version.App {
+			return vm, errors.New("mismatch App version in consensus params")
+		}
+
+		log.Info(ctx, "Upgrade v1.2.0 complete")
+
+		return vm, nil
+	}
+}

--- a/client/x/evmengine/keeper/abci.go
+++ b/client/x/evmengine/keeper/abci.go
@@ -173,11 +173,16 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 		return nil, errors.Wrap(err, "encode tx builder")
 	}
 
+	if int64(len(tx)) > req.MaxTxBytes {
+		return nil, errors.New("tx size exceeds the max bytes of tx")
+	}
+
 	log.Info(ctx, "Proposing new block",
 		"height", req.Height,
 		log.Hex7("execution_block_hash", payloadResp.ExecutionPayload.BlockHash[:]),
 		// "vote_msgs", len(voteMsgs),
 		"evm_events", len(evmEvents),
+		"tx_bytes", len(tx),
 	)
 
 	return &abci.ResponsePrepareProposal{Txs: [][]byte{tx}}, nil

--- a/go.mod
+++ b/go.mod
@@ -338,7 +338,7 @@ replace (
 	cosmossdk.io/x/evidence => github.com/piplabs/cosmos-sdk/x/evidence v0.1.1-piplabs-v1.0
 
 	// Direct cosmos-sdk branch link: https://github.com/piplabs/cosmos-sdk/tree/piplabs/v0.50.10, current branch: piplabs/v0.50.10
-	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.10-piplabs-v1.1
+	github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.10-piplabs-v1.2
 
 	// See https://github.com/cosmos/cosmos-sdk/pull/14952
 	// Also https://github.com/cosmos/cosmos-db/blob/main/go.mod#L11-L12

--- a/go.sum
+++ b/go.sum
@@ -1089,8 +1089,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/piplabs/cosmos-sdk v0.50.10-piplabs-v1.1 h1:soVcwY1GdVbSyTfQBgUPSoimm4EJavBNBZu1azfwWog=
-github.com/piplabs/cosmos-sdk v0.50.10-piplabs-v1.1/go.mod h1:1y5mNq5FXdhnZVcrgsAiJB7Isq5IcIev+4+PIQEOwoI=
+github.com/piplabs/cosmos-sdk v0.50.10-piplabs-v1.2 h1:GXtHjRxlvDztq+xYRdumiHP7woowv8qmf3JXalVWcZw=
+github.com/piplabs/cosmos-sdk v0.50.10-piplabs-v1.2/go.mod h1:1y5mNq5FXdhnZVcrgsAiJB7Isq5IcIev+4+PIQEOwoI=
 github.com/piplabs/cosmos-sdk/x/evidence v0.1.1-piplabs-v1.0 h1:OF24g4iOChJpe8pmeF6gQGPUZ8GI2owoR7isq7Dv51I=
 github.com/piplabs/cosmos-sdk/x/evidence v0.1.1-piplabs-v1.0/go.mod h1:gDr1NQr2l+3/5cU4jDNrQ4GQxV/Rn4AeRehNmfwooFg=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
These PR includes 3 commits for release v1.2.0 as below.
- disallow unexported fields in cosmos tx in processing proposal
- add check if the size of tx from EL exceeds the MaxTxBytes of abci request
- change max bytes of CL block to 20MB in consensus params

**v1.2.0 will require hardfork since it contains update of consensus params.**

issue: none
