### PR TITLE
test(x/evmengine): add unit tests for evmengine module

### DIFF
--- a/client/x/evmengine/keeper/abci.go
+++ b/client/x/evmengine/keeper/abci.go
@@ -230,7 +230,7 @@ func (k *Keeper) PostFinalize(ctx sdk.Context) error {
 	maxWithdrawals, err := k.evmstakingKeeper.MaxWithdrawalPerBlock(ctx)
 	if err != nil {
 		log.Error(ctx, "Starting optimistic build failed; get max withdrawal", err, logAttr)
-		return errors.Wrap(err, "get max withdrawal per block")
+		return nil
 	}
 	withdrawals, err := k.evmstakingKeeper.PeekEligibleWithdrawals(ctx, maxWithdrawals)
 	if err != nil {
@@ -241,7 +241,7 @@ func (k *Keeper) PostFinalize(ctx sdk.Context) error {
 	rewardWithdrawals, err := k.evmstakingKeeper.PeekEligibleRewardWithdrawals(ctx, maxRewardWithdrawals)
 	if err != nil {
 		log.Error(ctx, "Starting optimistic build failed; reward withdrawals peek", err, logAttr)
-		return errors.Wrap(err, "error on reward withdrawals dequeue")
+		return nil
 	}
 	withdrawals = append(withdrawals, rewardWithdrawals...)
 

--- a/client/x/evmengine/keeper/abci_internal_test.go
+++ b/client/x/evmengine/keeper/abci_internal_test.go
@@ -63,15 +63,17 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 	t.Run("TestRunErrScenarios", func(t *testing.T) {
 		// t.Parallel() // disable parallel testing for now
 		tests := []struct {
-			name       string
-			mockEngine mockEngineAPI
-			mockClient mock.MockClient
-			req        *abci.RequestPrepareProposal
-			wantErr    bool
-			setupMocks func(esk *moduletestutil.MockEvmStakingKeeper)
+			name               string
+			mockEngine         mockEngineAPI
+			mockClient         mock.MockClient
+			req                *abci.RequestPrepareProposal
+			wantErr            bool
+			setupMocks         func(esk *moduletestutil.MockEvmStakingKeeper)
+			isExecEngSyncing   bool
+			unsetExecutionHead bool
 		}{
 			{
-				name:       "pass: no transactions",
+				name:       "pass: no transactions (height = 1)",
 				mockEngine: mockEngineAPI{},
 				mockClient: mock.MockClient{},
 				req: &abci.RequestPrepareProposal{
@@ -81,6 +83,62 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
 				},
 				wantErr: false,
+			},
+			{
+				name: "pass: success of prepare proposal after genesis (height > 1)",
+				mockEngine: mockEngineAPI{
+					forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+						payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{
+							PayloadStatus: eengine.PayloadStatusV1{
+								Status:          eengine.VALID,
+								LatestValidHash: nil,
+								ValidationError: nil,
+							},
+							PayloadID: &eengine.PayloadID{0x1},
+						}, nil
+					},
+					getPayloadV3Func: func(ctx context.Context, id eengine.PayloadID) (*eengine.ExecutionPayloadEnvelope, error) {
+						return &eengine.ExecutionPayloadEnvelope{
+							ExecutionPayload: &eengine.ExecutableData{
+								ParentHash: common.MaxHash,
+								BlockHash:  common.MaxHash,
+							},
+						}, nil
+					},
+					filterLogsFunc: func(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+						return []types.Log{{
+							Address: zeroAddr,
+							Topics:  []common.Hash{common.MaxHash},
+						}}, nil
+					},
+				},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,        // Set to nil to simulate no transactions
+					Height:     2,          // Set height to 1 for this test case
+					Time:       time.Now(), // Set time to current time or mock a time
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: false,
+			},
+			{
+				name:       "fail: execution engine syncing",
+				mockEngine: mockEngineAPI{},
+				mockClient: mock.MockClient{},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr:          true,
+				isExecEngSyncing: true,
 			},
 			{
 				name:       "fail: max bytes is less than 9/10 of max block size",
@@ -96,6 +154,21 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 				req: &abci.RequestPrepareProposal{
 					Txs:        [][]byte{[]byte("tx1")}, // simulate transactions
 					Height:     1,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+			},
+			{
+				name:       "fail: max withdrawal per block",
+				mockEngine: mockEngineAPI{},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), errors.New("failed to get max withdrawal per block"))
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
 					Time:       time.Now(),
 					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
 				},
@@ -118,7 +191,63 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 				wantErr: true,
 			},
 			{
-				name: "fail: forkchoiceUpdateV3 not valid",
+				name:       "fail: peek eligible reward withdrawals",
+				mockEngine: mockEngineAPI{},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to peak eligible reward withdrawals"))
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+			},
+			{
+				name:       "fail: get execution head",
+				mockEngine: mockEngineAPI{},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr:            true,
+				unsetExecutionHead: true,
+			},
+			{
+				name: "fail: forkChoiceUpdatedV3 rpc err",
+				mockEngine: mockEngineAPI{
+					forkchoiceUpdatedV3Func: func(ctx context.Context, v1 eengine.ForkchoiceStateV1, attributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{}, errors.New("failed in forkChoiceUpdatedV3 call")
+					},
+				},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+			},
+			{
+				name: "fail: forkChoiceUpdatedV3 not valid",
 				mockEngine: mockEngineAPI{
 					headerByTypeFunc: func(context.Context, ethclient.HeadType) (*types.Header, error) {
 						fuzzer := ethclient.NewFuzzer(0)
@@ -154,6 +283,70 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 				},
 			},
 			{
+				name: "fail: EL is syncing",
+				mockEngine: mockEngineAPI{
+					headerByTypeFunc: func(context.Context, ethclient.HeadType) (*types.Header, error) {
+						fuzzer := ethclient.NewFuzzer(0)
+						var header *types.Header
+						fuzzer.Fuzz(&header)
+
+						return header, nil
+					},
+					forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+						payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{
+							PayloadStatus: eengine.PayloadStatusV1{
+								Status:          eengine.SYNCING,
+								LatestValidHash: nil,
+								ValidationError: nil,
+							},
+							PayloadID: nil,
+						}, nil
+					},
+				},
+				mockClient: mock.MockClient{},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+			},
+			{
+				name: "fail: missing payload ID",
+				mockEngine: mockEngineAPI{
+					forkchoiceUpdatedV3Func: func(ctx context.Context, v1 eengine.ForkchoiceStateV1, attributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{
+							PayloadStatus: eengine.PayloadStatusV1{
+								Status:          eengine.VALID,
+								LatestValidHash: nil,
+								ValidationError: nil,
+							},
+							PayloadID: nil,
+						}, nil
+					},
+				},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+			},
+			{
 				name: "fail: unknown payload",
 				mockEngine: mockEngineAPI{
 					forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
@@ -184,6 +377,150 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
 					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
 				},
+			},
+			{
+				name: "fail: getPayloadV3 rpc err",
+				mockEngine: mockEngineAPI{
+					forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+						payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{
+							PayloadStatus: eengine.PayloadStatusV1{
+								Status:          eengine.VALID,
+								LatestValidHash: nil,
+								ValidationError: nil,
+							},
+							PayloadID: &eengine.PayloadID{0x1},
+						}, nil
+					},
+					getPayloadV3Func: func(ctx context.Context, id eengine.PayloadID) (*eengine.ExecutionPayloadEnvelope, error) {
+						return &eengine.ExecutionPayloadEnvelope{}, errors.New("unknown rpc error")
+					},
+				},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+			},
+			{
+				name: "fail: filterLogs rpc err",
+				mockEngine: mockEngineAPI{
+					forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+						payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{
+							PayloadStatus: eengine.PayloadStatusV1{
+								Status:          eengine.VALID,
+								LatestValidHash: nil,
+								ValidationError: nil,
+							},
+							PayloadID: &eengine.PayloadID{0x1},
+						}, nil
+					},
+					getPayloadV3Func: func(ctx context.Context, id eengine.PayloadID) (*eengine.ExecutionPayloadEnvelope, error) {
+						return &eengine.ExecutionPayloadEnvelope{
+							ExecutionPayload: &eengine.ExecutableData{},
+						}, nil
+					},
+					filterLogsFunc: func(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+						return nil, errors.New("filterLogs rpc error")
+					},
+				},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+			},
+			{
+				name: "fail: invalid event",
+				mockEngine: mockEngineAPI{
+					forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+						payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{
+							PayloadStatus: eengine.PayloadStatusV1{
+								Status:          eengine.VALID,
+								LatestValidHash: nil,
+								ValidationError: nil,
+							},
+							PayloadID: &eengine.PayloadID{0x1},
+						}, nil
+					},
+					getPayloadV3Func: func(ctx context.Context, id eengine.PayloadID) (*eengine.ExecutionPayloadEnvelope, error) {
+						return &eengine.ExecutionPayloadEnvelope{
+							ExecutionPayload: &eengine.ExecutableData{},
+						}, nil
+					},
+					filterLogsFunc: func(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+						return []types.Log{{
+							Address: zeroAddr,
+						}}, nil
+					},
+				},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
+			},
+			{
+				name: "fail: large txs that exceed req.MaxTxBytes",
+				mockEngine: mockEngineAPI{
+					forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+						payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+						return eengine.ForkChoiceResponse{
+							PayloadStatus: eengine.PayloadStatusV1{
+								Status:          eengine.VALID,
+								LatestValidHash: nil,
+								ValidationError: nil,
+							},
+							PayloadID: &eengine.PayloadID{0x1},
+						}, nil
+					},
+					getPayloadV3Func: func(ctx context.Context, id eengine.PayloadID) (*eengine.ExecutionPayloadEnvelope, error) {
+						return &eengine.ExecutionPayloadEnvelope{
+							ExecutionPayload: &eengine.ExecutableData{
+								Transactions: [][]byte{make([]byte, cmttypes.MaxBlockSizeBytes+1)},
+							},
+						}, nil
+					},
+				},
+				mockClient: mock.MockClient{},
+				setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+					esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+					esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+					esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+				},
+				req: &abci.RequestPrepareProposal{
+					Txs:        nil,
+					Height:     2,
+					Time:       time.Now(),
+					MaxTxBytes: cmttypes.MaxBlockSizeBytes,
+				},
+				wantErr: true,
 			},
 			{
 				name: "fail: optimistic payload exists but unknown payload is returned by EL",
@@ -242,9 +579,12 @@ func TestKeeper_PrepareProposal(t *testing.T) {
 				k, err := NewKeeper(cdc, storeService, &tt.mockEngine, &tt.mockClient, txConfig, ak, esk, uk, dk)
 				require.NoError(t, err)
 				k.SetValidatorAddress(common.BytesToAddress([]byte("test")))
-				populateGenesisHead(ctx, t, k)
+				if !tt.unsetExecutionHead {
+					populateGenesisHead(ctx, t, k)
+				}
 				// Set an optimistic payload
 				k.setOptimisticPayload(eengine.PayloadID{}, optimisticPayloadHeight)
+				k.SetIsExecEngSyncing(tt.isExecEngSyncing)
 
 				_, err = k.PrepareProposal(withRandomErrs(t, ctx), tt.req)
 				if (err != nil) != tt.wantErr {
@@ -332,17 +672,17 @@ func TestKeeper_PostFinalize(t *testing.T) {
 		name             string
 		mockEngine       mockEngineAPI
 		mockClient       mock.MockClient
-		wantErr          bool
 		enableOptimistic bool
 		isNextProposer   bool
 		setupMocks       func(esk *moduletestutil.MockEvmStakingKeeper)
 		postStateCheck   func(k *Keeper)
+		isExecEngSyncing bool
+		cmtAPIValFunc    func(context.Context, int64) (*cmttypes.ValidatorSet, error)
 	}{
 		{
 			name:             "pass: nothing happens when enableOptimistic is false",
 			mockEngine:       mockEngineAPI{},
 			mockClient:       mock.MockClient{},
-			wantErr:          false,
 			enableOptimistic: false,
 			isNextProposer:   false,
 			postStateCheck:   payloadFailedToSet,
@@ -351,21 +691,81 @@ func TestKeeper_PostFinalize(t *testing.T) {
 			name:             "pass: node is not next proposer",
 			mockEngine:       mockEngineAPI{},
 			mockClient:       mock.MockClient{},
-			wantErr:          false,
 			enableOptimistic: true,
 			isNextProposer:   false,
 			postStateCheck:   payloadFailedToSet,
 		},
 		{
+			name:             "fail: evm engine syncing",
+			mockEngine:       mockEngineAPI{},
+			mockClient:       mock.MockClient{},
+			enableOptimistic: true,
+			isNextProposer:   false,
+			postStateCheck:   payloadFailedToSet,
+			isExecEngSyncing: true,
+		},
+		{
+			name:             "fail: comet API validators",
+			mockEngine:       mockEngineAPI{},
+			mockClient:       mock.MockClient{},
+			enableOptimistic: true,
+			isNextProposer:   false,
+			postStateCheck:   payloadFailedToSet,
+			cmtAPIValFunc: func(ctx context.Context, i int64) (*cmttypes.ValidatorSet, error) {
+				return nil, errors.New("failed to get validators")
+			},
+		},
+		{
+			name:             "fail: max withdrawal per block",
+			mockEngine:       mockEngineAPI{},
+			mockClient:       mock.MockClient{},
+			enableOptimistic: true,
+			isNextProposer:   true,
+			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+				esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), errors.New("failed to get max withdrawal per block"))
+			},
+			postStateCheck: payloadFailedToSet,
+		},
+		{
 			name:             "fail: peek eligible withdrawals",
 			mockEngine:       mockEngineAPI{},
 			mockClient:       mock.MockClient{},
-			wantErr:          false,
 			enableOptimistic: true,
 			isNextProposer:   true,
 			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
 				esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
 				esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to peek eligible withdrawals"))
+			},
+			postStateCheck: payloadFailedToSet,
+		},
+		{
+			name:             "fail: peek eligible reward withdrawals",
+			mockEngine:       mockEngineAPI{},
+			mockClient:       mock.MockClient{},
+			enableOptimistic: true,
+			isNextProposer:   true,
+			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+				esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to peek eligible reward withdrawals"))
+			},
+			postStateCheck: payloadFailedToSet,
+		},
+		{
+			name: "fail: forkChoiceUpdatedV3 rpc err",
+			mockEngine: mockEngineAPI{
+				forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+					payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+					return eengine.ForkChoiceResponse{}, errors.New("failed to forkChoiceUpdatedV3")
+				},
+			},
+			mockClient:       mock.MockClient{},
+			enableOptimistic: true,
+			isNextProposer:   true,
+			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+				esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
 			},
 			postStateCheck: payloadFailedToSet,
 		},
@@ -385,7 +785,6 @@ func TestKeeper_PostFinalize(t *testing.T) {
 				},
 			},
 			mockClient:       mock.MockClient{},
-			wantErr:          false,
 			enableOptimistic: true,
 			isNextProposer:   true,
 			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
@@ -411,7 +810,30 @@ func TestKeeper_PostFinalize(t *testing.T) {
 				},
 			},
 			mockClient:       mock.MockClient{},
-			wantErr:          false,
+			enableOptimistic: true,
+			isNextProposer:   true,
+			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
+				esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), uint32(0)).Return(nil, nil)
+			},
+			postStateCheck: payloadFailedToSet,
+		},
+		{
+			name: "fail: missing payload ID",
+			mockEngine: mockEngineAPI{
+				forkchoiceUpdatedV3Func: func(ctx context.Context, update eengine.ForkchoiceStateV1,
+					payloadAttributes *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error) {
+					return eengine.ForkChoiceResponse{
+						PayloadStatus: eengine.PayloadStatusV1{
+							Status:          eengine.VALID,
+							LatestValidHash: nil,
+							ValidationError: nil,
+						},
+					}, nil
+				},
+			},
+			mockClient:       mock.MockClient{},
 			enableOptimistic: true,
 			isNextProposer:   true,
 			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
@@ -437,7 +859,6 @@ func TestKeeper_PostFinalize(t *testing.T) {
 				},
 			},
 			mockClient:       mock.MockClient{},
-			wantErr:          false,
 			enableOptimistic: true,
 			isNextProposer:   true,
 			setupMocks: func(esk *moduletestutil.MockEvmStakingKeeper) {
@@ -466,8 +887,7 @@ func TestKeeper_PostFinalize(t *testing.T) {
 			}
 
 			var err error
-
-			cmtAPI := newMockCometAPI(t, nil)
+			cmtAPI := newMockCometAPI(t, tt.cmtAPIValFunc)
 
 			// set the header and proposer so we have the correct next proposer
 			header := cmtproto.Header{Height: 1, AppHash: tutil.RandomHash().Bytes()}
@@ -492,12 +912,9 @@ func TestKeeper_PostFinalize(t *testing.T) {
 			k.SetValidatorAddress(nxtAddr)
 			populateGenesisHead(ctx, t, k)
 			k.buildOptimistic = tt.enableOptimistic
+			k.SetIsExecEngSyncing(tt.isExecEngSyncing)
 
-			err = k.PostFinalize(ctx)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("PostFinalize() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			require.NoError(t, k.PostFinalize(ctx))
 			if tt.postStateCheck != nil {
 				tt.postStateCheck(k)
 			}
@@ -599,6 +1016,7 @@ type mockEngineAPI struct {
 	forkchoiceUpdatedV3Func func(context.Context, eengine.ForkchoiceStateV1, *eengine.PayloadAttributes) (eengine.ForkChoiceResponse, error)
 	getPayloadV3Func        func(context.Context, eengine.PayloadID) (*eengine.ExecutionPayloadEnvelope, error)
 	newPayloadV3Func        func(context.Context, eengine.ExecutableData, []common.Hash, *common.Hash) (eengine.PayloadStatusV1, error)
+	filterLogsFunc          func(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error)
 	// forceInvalidNewPayloadV3 forces the NewPayloadV3 returns an invalid status.
 	forceInvalidNewPayloadV3 bool
 	// forceInvalidForkchoiceUpdatedV3 forces the ForkchoiceUpdatedV3 returns an invalid status.
@@ -683,7 +1101,11 @@ func (m mockEngineAPI) maybeSync() (eengine.PayloadStatusV1, bool) {
 	}
 }
 
-func (mockEngineAPI) FilterLogs(context.Context, ethereum.FilterQuery) ([]types.Log, error) {
+func (m *mockEngineAPI) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	if m.filterLogsFunc != nil {
+		return m.filterLogsFunc(ctx, q)
+	}
+
 	return nil, nil
 }
 

--- a/client/x/evmengine/keeper/keeper_internal_test.go
+++ b/client/x/evmengine/keeper/keeper_internal_test.go
@@ -14,6 +14,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	etypes "github.com/ethereum/go-ethereum/core/types"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 
@@ -33,6 +34,7 @@ type args struct {
 	validatorsFunc func(context.Context, int64) (*cmttypes.ValidatorSet, error)
 	isNextProposer bool
 	header         func(height int64) cmtproto.Header
+	unsetCmtAPI    bool
 }
 
 func createTestKeeper(t *testing.T) (context.Context, *Keeper) {
@@ -92,9 +94,11 @@ func createKeeper(t *testing.T, args args) (sdk.Context, *mockCometAPI, *Keeper)
 	require.NoError(t, err)
 	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk, dk)
 	require.NoError(t, err)
-	keeper.SetCometAPI(cmtAPI)
+
+	if !args.unsetCmtAPI {
+		keeper.SetCometAPI(cmtAPI)
+	}
 	keeper.SetValidatorAddress(nxtAddr)
-	populateGenesisHead(ctx, t, keeper)
 
 	return ctx, cmtAPI, keeper
 }
@@ -119,6 +123,16 @@ func TestKeeper_SetBuildOptimistic(t *testing.T) {
 	require.True(t, keeper.buildOptimistic)
 }
 
+func TestKeeper_SetIsExecEngSyncing(t *testing.T) {
+	t.Parallel()
+	keeper := new(Keeper)
+	// check existing value
+	require.False(t, keeper.IsExecEngSyncing())
+	// set new value
+	keeper.SetIsExecEngSyncing(true)
+	require.True(t, keeper.IsExecEngSyncing())
+}
+
 func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
@@ -131,11 +145,31 @@ func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 	})
 
 	tcs := []struct {
-		name        string
-		setup       func(context.Context) sdk.Context
-		msg         func(context.Context) *types.MsgExecutionPayload
-		expectedErr string
+		name          string
+		setup         func(context.Context) sdk.Context
+		msg           func(context.Context) *types.MsgExecutionPayload
+		expectedErr   string
+		unsetExecHead bool
 	}{
+		{
+			name: "fail: invalid authority",
+			msg: func(c context.Context) *types.MsgExecutionPayload {
+				execHead, err := keeper.getExecutionHead(c)
+				require.NoError(t, err)
+
+				payload, err := ethclient.MakePayload(fuzzer, execHead.GetBlockHeight()+1, uint64(now.Unix()), execHead.Hash(), common.Address{}, execHead.Hash(), &common.Hash{})
+				require.NoError(t, err)
+
+				marshaled, err := json.Marshal(payload)
+				require.NoError(t, err)
+
+				return &types.MsgExecutionPayload{
+					ExecutionPayload: marshaled,
+					Authority:        "story1hmjw3pvkjtndpg8wqppwdn8udd835qpan4hm0y",
+				}
+			},
+			expectedErr: "invalid authority",
+		},
 		{
 			name: "fail: unmarshal payload because of invalid execution payload",
 			msg: func(_ context.Context) *types.MsgExecutionPayload {
@@ -144,7 +178,26 @@ func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 					Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
 				}
 			},
-			expectedErr: "unmarshal payload",
+			expectedErr: "validate execution payload",
+		},
+		{
+			name: "fail: disallowed field in execution payload",
+			msg: func(_ context.Context) *types.MsgExecutionPayload {
+				invalidPayload := struct {
+					Disallowed []byte `json:"disallowed"`
+				}{
+					Disallowed: []byte("disallowed"),
+				}
+
+				marshaled, err := json.Marshal(invalidPayload)
+				require.NoError(t, err)
+
+				return &types.MsgExecutionPayload{
+					ExecutionPayload: marshaled,
+					Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+				}
+			},
+			expectedErr: "validate execution payload",
 		},
 		{
 			name: "fail: payload number is not equal to head block height + 1",
@@ -163,12 +216,9 @@ func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 			expectedErr: "invalid proposed payload number",
 		},
 		{
-			name: "fail: payload parent hash is not equal to head hash",
+			name: "fail: no execution head",
 			msg: func(c context.Context) *types.MsgExecutionPayload {
-				execHead, err := keeper.getExecutionHead(c)
-				require.NoError(t, err)
-
-				payload, err := ethclient.MakePayload(fuzzer, execHead.GetBlockHeight()+1, uint64(now.Unix()), common.Hash{}, common.Address{}, common.Hash{}, &common.Hash{})
+				payload, err := ethclient.MakePayload(fuzzer, 1, uint64(now.Unix()), common.Hash{}, common.Address{}, common.Hash{}, &common.Hash{})
 				require.NoError(t, err)
 
 				marshaled, err := json.Marshal(payload)
@@ -179,7 +229,8 @@ func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 					Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
 				}
 			},
-			expectedErr: "invalid proposed payload parent hash",
+			expectedErr:   "latest execution block",
+			unsetExecHead: true,
 		},
 		{
 			name: "fail: invalid payload timestamp",
@@ -221,7 +272,7 @@ func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 			expectedErr: "invalid payload random",
 		},
 		{
-			name: "fail: invalid authority",
+			name: "fail: nil Withdrawals in payload",
 			msg: func(c context.Context) *types.MsgExecutionPayload {
 				execHead, err := keeper.getExecutionHead(c)
 				require.NoError(t, err)
@@ -229,15 +280,80 @@ func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 				payload, err := ethclient.MakePayload(fuzzer, execHead.GetBlockHeight()+1, uint64(now.Unix()), execHead.Hash(), common.Address{}, execHead.Hash(), &common.Hash{})
 				require.NoError(t, err)
 
+				payload.Withdrawals = nil
+
 				marshaled, err := json.Marshal(payload)
 				require.NoError(t, err)
 
 				return &types.MsgExecutionPayload{
 					ExecutionPayload: marshaled,
-					Authority:        "story1hmjw3pvkjtndpg8wqppwdn8udd835qpan4hm0y",
+					Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
 				}
 			},
-			expectedErr: "invalid authority",
+			expectedErr: "the followings must not be nil",
+		},
+		{
+			name: "fail: nil BlobGasUsed in payload",
+			msg: func(c context.Context) *types.MsgExecutionPayload {
+				execHead, err := keeper.getExecutionHead(c)
+				require.NoError(t, err)
+
+				payload, err := ethclient.MakePayload(fuzzer, execHead.GetBlockHeight()+1, uint64(now.Unix()), execHead.Hash(), common.Address{}, execHead.Hash(), &common.Hash{})
+				require.NoError(t, err)
+
+				payload.BlobGasUsed = nil
+
+				marshaled, err := json.Marshal(payload)
+				require.NoError(t, err)
+
+				return &types.MsgExecutionPayload{
+					ExecutionPayload: marshaled,
+					Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+				}
+			},
+			expectedErr: "the followings must not be nil",
+		},
+		{
+			name: "fail: nil ExcessBlobGas in payload",
+			msg: func(c context.Context) *types.MsgExecutionPayload {
+				execHead, err := keeper.getExecutionHead(c)
+				require.NoError(t, err)
+
+				payload, err := ethclient.MakePayload(fuzzer, execHead.GetBlockHeight()+1, uint64(now.Unix()), execHead.Hash(), common.Address{}, execHead.Hash(), &common.Hash{})
+				require.NoError(t, err)
+
+				payload.ExcessBlobGas = nil
+
+				marshaled, err := json.Marshal(payload)
+				require.NoError(t, err)
+
+				return &types.MsgExecutionPayload{
+					ExecutionPayload: marshaled,
+					Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+				}
+			},
+			expectedErr: "the followings must not be nil",
+		},
+		{
+			name: "fail: non-nil ExecutionWitness in payload",
+			msg: func(c context.Context) *types.MsgExecutionPayload {
+				execHead, err := keeper.getExecutionHead(c)
+				require.NoError(t, err)
+
+				payload, err := ethclient.MakePayload(fuzzer, execHead.GetBlockHeight()+1, uint64(now.Unix()), execHead.Hash(), common.Address{}, execHead.Hash(), &common.Hash{})
+				require.NoError(t, err)
+
+				payload.ExecutionWitness = &etypes.ExecutionWitness{}
+
+				marshaled, err := json.Marshal(payload)
+				require.NoError(t, err)
+
+				return &types.MsgExecutionPayload{
+					ExecutionPayload: marshaled,
+					Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
+				}
+			},
+			expectedErr: "witness not allowed in payload",
 		},
 		{
 			name: "pass: valid payload",
@@ -298,6 +414,10 @@ func TestKeeper_parseAndVerifyProposedPayload(t *testing.T) {
 		//nolint:tparallel // cannot run parallel because of data race on execution head table
 		t.Run(tc.name, func(t *testing.T) {
 			cachedCtx, _ := ctx.CacheContext()
+			if !tc.unsetExecHead {
+				populateGenesisHead(cachedCtx, t, keeper)
+			}
+
 			if tc.setup != nil {
 				cachedCtx = tc.setup(cachedCtx)
 			}
@@ -326,8 +446,11 @@ func TestKeeper_setOptimisticPayload(t *testing.T) {
 
 	// set new values
 	keeper.setOptimisticPayload(engine.PayloadID{1}, 1)
-	require.Equal(t, uint64(1), keeper.mutablePayload.Height)
-	require.Equal(t, engine.PayloadID{1}, keeper.mutablePayload.ID)
+
+	// get optimistic payload
+	payloadID, payloadHeight, _ := keeper.getOptimisticPayload()
+	require.Equal(t, uint64(1), payloadHeight)
+	require.Equal(t, engine.PayloadID{1}, payloadID)
 }
 
 func TestKeeper_isNextProposer(t *testing.T) {
@@ -339,6 +462,19 @@ func TestKeeper_isNextProposer(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
+		{
+			name: "nil cmtAPI for keeper",
+			args: args{
+				height:         height,
+				isNextProposer: false,
+				header: func(height int64) cmtproto.Header {
+					return cmtproto.Header{Height: height}
+				},
+				unsetCmtAPI: true,
+			},
+			want:    false,
+			wantErr: false,
+		},
 		{
 			name: "not proposer",
 			args: args{
@@ -393,7 +529,9 @@ func TestKeeper_isNextProposer(t *testing.T) {
 				t.Errorf("isNextProposer() got = %v, want %v", got, tt.want)
 			}
 			// make sure that height passed into Validators is correct
-			require.Equal(t, tt.args.height, cmtAPI.height)
+			if !tt.args.unsetCmtAPI {
+				require.Equal(t, tt.args.height, cmtAPI.height)
+			}
 		})
 	}
 }

--- a/client/x/evmengine/keeper/msg_server.go
+++ b/client/x/evmengine/keeper/msg_server.go
@@ -149,7 +149,7 @@ func (s msgServer) ExecutionPayload(ctx context.Context, msg *types.MsgExecution
 	if err := s.ProcessUpgradeEvents(ctx, payload.Number-1, msg.PrevPayloadEvents); err != nil {
 		return nil, errors.Wrap(err, "deliver upgrade-related event logs")
 	}
-	if err := s.ProcessUbiEvents(ctx, payload.Number-1, msg.PrevPayloadEvents); err != nil {
+	if err := s.ProcessUBIEvents(ctx, payload.Number-1, msg.PrevPayloadEvents); err != nil {
 		return nil, errors.Wrap(err, "deliver ubi-related event logs")
 	}
 

--- a/client/x/evmengine/keeper/msg_server_internal_test.go
+++ b/client/x/evmengine/keeper/msg_server_internal_test.go
@@ -160,6 +160,15 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 			expectedError:           "invalid proposed payload number",
 		},
 		{
+			name: "fail: MaxWithdrawalPerBlock error",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), errors.New("failed to get max withdrawal per block"))
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "error getting max withdrawal per block",
+		},
+		{
 			name: "fail: DequeueEligibleWithdrawals error",
 			setup: func(ctx context.Context) sdk.Context {
 				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
@@ -169,6 +178,55 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 			},
 			createPayload: createValidPayload,
 			expectedError: "error on withdrawals dequeue",
+		},
+		{
+			name: "fail: dequeued withdrawals are greater than withdrawals in payload",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().DequeueEligibleWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "dequeued withdrawals 1 should not greater than proposed withdrawals 0",
+		},
+		{
+			name: "fail: DequeueEligibleRewardWithdrawals error",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().DequeueEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().DequeueEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, errors.New("failed to dequeue"))
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "error on reward withdrawals dequeue",
+		},
+		{
+			name: "fail: dequeued total withdrawals are greater than total withdrawals in payload",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().DequeueEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().DequeueEligibleRewardWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "dequeued total withdrawals 1 should equal to proposed withdrawals 0",
 		},
 		{
 			name: "fail: NewPayloadV3 returns status invalid",
@@ -213,7 +271,7 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 			expectedError:           "deliver staking-related event logs",
 		},
 		{
-			name: "fail: ProcessUpgradeEvents error",
+			name: "fail: invalid event log error",
 			setup: func(ctx context.Context) sdk.Context {
 				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
 				esk.EXPECT().DequeueEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
@@ -237,7 +295,7 @@ func Test_msgServer_ExecutionPayload(t *testing.T) {
 					TxHash:  dummyHash.Bytes(),
 				}}
 			},
-			expectedError: "deliver upgrade-related event logs",
+			expectedError: "verify log [BUG]",
 		},
 	}
 

--- a/client/x/evmengine/keeper/proposal_server.go
+++ b/client/x/evmengine/keeper/proposal_server.go
@@ -26,7 +26,7 @@ func (s proposalServer) ExecutionPayload(ctx context.Context, msg *types.MsgExec
 
 	payload, err := s.parseAndVerifyProposedPayload(ctx, msg)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal payload")
+		return nil, errors.Wrap(err, "parse and verify payload")
 	}
 
 	// Ensure that the withdrawals in the payload are from the front indices of the queue.

--- a/client/x/evmengine/keeper/proposal_server_internal_test.go
+++ b/client/x/evmengine/keeper/proposal_server_internal_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	etypes "github.com/ethereum/go-ethereum/core/types"
@@ -16,6 +18,7 @@ import (
 
 	moduletestutil "github.com/piplabs/story/client/x/evmengine/testutil"
 	"github.com/piplabs/story/client/x/evmengine/types"
+	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/ethclient"
 	"github.com/piplabs/story/lib/ethclient/mock"
 	"github.com/piplabs/story/lib/expbackoff"
@@ -23,6 +26,8 @@ import (
 
 	"go.uber.org/mock/gomock"
 )
+
+var maxAddr = common.MaxAddress
 
 func Test_proposalServer_ExecutionPayload(t *testing.T) {
 	t.Parallel()
@@ -35,70 +40,536 @@ func Test_proposalServer_ExecutionPayload(t *testing.T) {
 	esk := moduletestutil.NewMockEvmStakingKeeper(ctrl)
 	uk := moduletestutil.NewMockUpgradeKeeper(ctrl)
 	dk := moduletestutil.NewMockDistrKeeper(ctrl)
-	esk.EXPECT().MaxWithdrawalPerBlock(gomock.Any()).Return(uint32(0), nil).AnyTimes()
-	esk.EXPECT().PeekEligibleWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	esk.EXPECT().PeekEligibleRewardWithdrawals(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
-	sdkCtx, storeKey, storeService := setupCtxStore(t, &cmtproto.Header{AppHash: tutil.RandomHash().Bytes()})
-	sdkCtx = sdkCtx.WithExecMode(sdk.ExecModeFinalize)
+	ctx, storeKey, storeService := setupCtxStore(t, &cmtproto.Header{AppHash: tutil.RandomHash().Bytes()})
+	ctx = ctx.WithExecMode(sdk.ExecModeFinalize)
+	evmLogProc := mockLogProvider{deliverErr: errors.New("test error")}
 	mockEngine, err := newMockEngineAPI(storeKey, 0)
 	require.NoError(t, err)
 	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk, dk)
 	require.NoError(t, err)
-	populateGenesisHead(sdkCtx, t, keeper)
+	populateGenesisHead(ctx, t, keeper)
 	propSrv := NewProposalServer(keeper)
 
 	keeper.SetValidatorAddress(common.BytesToAddress([]byte("test")))
 
-	var payloadData []byte
-	var payloadID engine.PayloadID
-	var latestHeight uint64
-	var block *etypes.Block
-	newPayload := func(ctx context.Context) {
+	createValidPayload := func(c context.Context, withWithdrawals bool) (*etypes.Block, engine.PayloadID, []byte) {
 		// get latest block to build on top
-		latestBlock, err := mockEngine.HeaderByType(ctx, ethclient.HeadLatest)
+		latestBlock, err := mockEngine.HeaderByType(c, ethclient.HeadLatest)
 		require.NoError(t, err)
-		latestHeight = latestBlock.Number.Uint64()
+		latestHeight := latestBlock.Number.Uint64()
 
-		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		sdkCtx := sdk.UnwrapSDKContext(c)
 		appHash := common.BytesToHash(sdkCtx.BlockHeader().AppHash)
 
-		b, execPayload := mockEngine.nextBlock(
-			t,
-			latestHeight+1,
-			uint64(sdkCtx.BlockHeader().Time.Unix()),
-			latestBlock.Hash(),
-			keeper.validatorAddr,
-			&appHash,
-		)
-		block = b
+		block, execPayload := mockEngine.nextBlock(t, latestHeight+1, uint64(time.Now().Unix()), latestBlock.Hash(), keeper.validatorAddr, &appHash)
 
-		payloadID, err = ethclient.MockPayloadID(execPayload, &appHash)
+		if withWithdrawals {
+			execPayload.Withdrawals = []*etypes.Withdrawal{
+				{
+					Index:     uint64(0),
+					Validator: uint64(0),
+					Address:   common.MaxAddress,
+					Amount:    uint64(0),
+				},
+			}
+		}
+
+		payloadID, err := ethclient.MockPayloadID(execPayload, &appHash)
 		require.NoError(t, err)
 
 		// Create execution payload message
-		payloadData, err = json.Marshal(execPayload)
+		payloadData, err := json.Marshal(execPayload)
 		require.NoError(t, err)
+
+		return block, payloadID, payloadData
 	}
 
-	assertExecutionPayload := func(ctx context.Context) {
-		resp, err := propSrv.ExecutionPayload(ctx, &types.MsgExecutionPayload{
-			Authority:        authtypes.NewModuleAddress(types.ModuleName).String(),
-			ExecutionPayload: payloadData,
+	createRandomEvents := func(c context.Context, blkHash common.Hash) []*types.EVMEvent {
+		events, err := evmLogProc.Prepare(c, blkHash)
+		require.NoError(t, err)
+
+		return events
+	}
+
+	tcs := []struct {
+		name                    string
+		setup                   func(c context.Context) sdk.Context
+		createPayload           func(c context.Context, withWithdrawals bool) (*etypes.Block, engine.PayloadID, []byte)
+		withWithdrawal          bool
+		createPrevPayloadEvents func(c context.Context, blkHash common.Hash) []*types.EVMEvent
+		expectedError           string
+		postCheck               func(c context.Context, block *etypes.Block, payloadID engine.PayloadID)
+		afterTest               func(c context.Context)
+	}{
+		{
+			name: "pass: valid payload",
+			setup: func(c context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(c).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(c, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(c, gomock.Any()).Return(nil, nil)
+
+				mockEngine.filterLogsFunc = func(ctx context.Context, query ethereum.FilterQuery) ([]etypes.Log, error) {
+					return []etypes.Log{
+						{
+							Address: maxAddr,
+							Topics:  []common.Hash{common.MaxHash},
+							TxHash:  common.MaxHash,
+						},
+					}, nil
+				}
+
+				return sdk.UnwrapSDKContext(c)
+			},
+			createPayload: createValidPayload,
+			createPrevPayloadEvents: func(c context.Context, blkHash common.Hash) []*types.EVMEvent {
+				return []*types.EVMEvent{
+					{
+						Address: maxAddr[:],
+						Topics:  [][]byte{common.MaxHash[:]},
+						TxHash:  common.MaxHash[:],
+					},
+				}
+			},
+			postCheck: func(c context.Context, block *etypes.Block, payloadID engine.PayloadID) {
+				gotPayload, err := mockEngine.GetPayloadV3(c, payloadID)
+				require.NoError(t, err)
+				require.Equal(t, gotPayload.ExecutionPayload.Number, block.Header().Number.Uint64())
+				require.Equal(t, gotPayload.ExecutionPayload.BlockHash, block.Hash())
+				require.Equal(t, gotPayload.ExecutionPayload.FeeRecipient, keeper.validatorAddr)
+				require.Empty(t, gotPayload.ExecutionPayload.Withdrawals)
+			},
+		},
+		{
+			name: "fail: execution engine is syncing",
+			setup: func(c context.Context) sdk.Context {
+				keeper.SetIsExecEngSyncing(true)
+
+				return sdk.UnwrapSDKContext(c)
+			},
+			expectedError: "execution engine is syncing",
+			afterTest: func(c context.Context) {
+				keeper.SetIsExecEngSyncing(false)
+			},
+		},
+		{
+			name: "fail: no execution head",
+			setup: func(c context.Context) sdk.Context {
+				head, err := keeper.headTable.Get(c, executionHeadID)
+				require.NoError(t, err)
+				require.NoError(t, keeper.headTable.Delete(c, head))
+
+				return sdk.UnwrapSDKContext(c)
+			},
+			createPayload: createValidPayload,
+			expectedError: "not found",
+		},
+		{
+			name: "fail: invalid payload - wrong payload number",
+			createPayload: func(ctx context.Context, withWithdrawal bool) (*etypes.Block, engine.PayloadID, []byte) {
+				latestBlock, err := mockEngine.HeaderByType(ctx, ethclient.HeadLatest)
+				require.NoError(t, err)
+				latestHeight := latestBlock.Number.Uint64()
+				wrongNextHeight := latestHeight + 2
+
+				sdkCtx := sdk.UnwrapSDKContext(ctx)
+				appHash := common.BytesToHash(sdkCtx.BlockHeader().AppHash)
+
+				block, execPayload := mockEngine.nextBlock(t, wrongNextHeight, uint64(time.Now().Unix()), latestBlock.Hash(), keeper.validatorAddr, &appHash)
+				payloadID, err := ethclient.MockPayloadID(execPayload, &appHash)
+				require.NoError(t, err)
+
+				// Create execution payload message
+				payloadData, err := json.Marshal(execPayload)
+				require.NoError(t, err)
+
+				return block, payloadID, payloadData
+			},
+			expectedError: "parse and verify payload",
+		},
+		{
+			name: "fail: MaxWithdrawalPerBlock error",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), errors.New("failed to get max withdrawal per block"))
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "get max withdrawals per block",
+		},
+		{
+			name: "fail: PeekEligibleWithdrawals error",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, errors.New("failed to peek"))
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "peek withdrawals",
+		},
+		{
+			name: "fail: peeked withdrawals are greater than withdrawals in payload",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "expected withdrawals 1 should not greater than actual withdrawals 0",
+		},
+		{
+			name: "fail: PeekEligibleRewardWithdrawals error",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, errors.New("failed to dequeue"))
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "peek reward withdrawals",
+		},
+		{
+			name: "fail: peeked total withdrawals are greater than total withdrawals in payload",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "expected total withdrawals 1 should equal to actual withdrawals 0",
+		},
+		{
+			name: "fail: withdrawals index mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(1),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal index",
+		},
+		{
+			name: "fail: withdrawals type mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(1),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal type",
+		},
+		{
+			name: "fail: withdrawals address mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.Address{},
+						Amount:    uint64(0),
+					},
+				}, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal address",
+		},
+		{
+			name: "fail: withdrawals amount mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(1),
+					},
+				}, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal amount",
+		},
+		{
+			name: "fail: reward withdrawals index mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(1),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal index",
+		},
+		{
+			name: "fail: reward withdrawals type mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(1),
+						Address:   common.MaxAddress,
+						Amount:    uint64(0),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal type",
+		},
+		{
+			name: "fail: reward withdrawals address mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.Address{},
+						Amount:    uint64(0),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal address",
+		},
+		{
+			name: "fail: reward withdrawals amount mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(etypes.Withdrawals{
+					&etypes.Withdrawal{
+						Index:     uint64(0),
+						Validator: uint64(0),
+						Address:   common.MaxAddress,
+						Amount:    uint64(1),
+					},
+				}, nil)
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:  createValidPayload,
+			withWithdrawal: true,
+			expectedError:  "invalid withdrawal amount",
+		},
+		{
+			name: "fail: NewPayloadV3 returns status invalid",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				mockEngine.forceInvalidNewPayloadV3 = true
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "payload invalid",
+		},
+		{
+			name: "fail: NewPayloadV3 returns status syncing",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				mockEngine.newPayloadV3Func = func(ctx context.Context, data engine.ExecutableData, hashes []common.Hash, hash *common.Hash) (engine.PayloadStatusV1, error) {
+					return engine.PayloadStatusV1{
+						Status: engine.SYNCING,
+					}, nil
+				}
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "execution engine is syncing",
+		},
+		{
+			name: "fail: invalid event",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				mockEngine.newPayloadV3Func = func(ctx context.Context, data engine.ExecutableData, hashes []common.Hash, hash *common.Hash) (engine.PayloadStatusV1, error) {
+					return engine.PayloadStatusV1{
+						Status:          engine.VALID,
+						LatestValidHash: nil,
+						ValidationError: nil,
+					}, nil
+				}
+				mockEngine.filterLogsFunc = func(ctx context.Context, query ethereum.FilterQuery) ([]etypes.Log, error) {
+					return []etypes.Log{{
+						Address: common.MaxAddress,
+					}}, nil
+				}
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload: createValidPayload,
+			expectedError: "verify event",
+		},
+		{
+			name: "fail: event count mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				mockEngine.newPayloadV3Func = func(ctx context.Context, data engine.ExecutableData, hashes []common.Hash, hash *common.Hash) (engine.PayloadStatusV1, error) {
+					return engine.PayloadStatusV1{
+						Status:          engine.VALID,
+						LatestValidHash: nil,
+						ValidationError: nil,
+					}, nil
+				}
+				mockEngine.filterLogsFunc = func(ctx context.Context, query ethereum.FilterQuery) ([]etypes.Log, error) {
+					return []etypes.Log{
+						{
+							Address: common.MaxAddress,
+							Topics:  []common.Hash{common.MaxHash},
+						},
+						{
+							Address: common.MaxAddress,
+							Topics:  []common.Hash{common.HexToHash("0x1")},
+						},
+					}, nil
+				}
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:           createValidPayload,
+			createPrevPayloadEvents: createRandomEvents,
+			expectedError:           "count mismatch",
+		},
+		{
+			name: "fail: event log mismatch",
+			setup: func(ctx context.Context) sdk.Context {
+				esk.EXPECT().MaxWithdrawalPerBlock(ctx).Return(uint32(0), nil)
+				esk.EXPECT().PeekEligibleWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				esk.EXPECT().PeekEligibleRewardWithdrawals(ctx, gomock.Any()).Return(nil, nil)
+				mockEngine.newPayloadV3Func = func(ctx context.Context, data engine.ExecutableData, hashes []common.Hash, hash *common.Hash) (engine.PayloadStatusV1, error) {
+					return engine.PayloadStatusV1{
+						Status:          engine.VALID,
+						LatestValidHash: nil,
+						ValidationError: nil,
+					}, nil
+				}
+				mockEngine.filterLogsFunc = func(ctx context.Context, query ethereum.FilterQuery) ([]etypes.Log, error) {
+					return []etypes.Log{{
+						Address: common.MaxAddress,
+						Topics:  []common.Hash{common.MaxHash},
+					}}, nil
+				}
+
+				return sdk.UnwrapSDKContext(ctx)
+			},
+			createPayload:           createValidPayload,
+			createPrevPayloadEvents: createRandomEvents,
+			expectedError:           "log mismatch",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				payloadData []byte
+				payloadID   engine.PayloadID
+				block       *etypes.Block
+				events      []*types.EVMEvent
+			)
+
+			cachedCtx, _ := ctx.CacheContext()
+			if tc.setup != nil {
+				cachedCtx = tc.setup(cachedCtx)
+			}
+			if tc.createPayload != nil {
+				block, payloadID, payloadData = tc.createPayload(cachedCtx, tc.withWithdrawal)
+			}
+			if tc.createPrevPayloadEvents != nil {
+				events = tc.createPrevPayloadEvents(cachedCtx, block.Hash())
+			}
+
+			resp, err := propSrv.ExecutionPayload(cachedCtx, &types.MsgExecutionPayload{
+				Authority:         authtypes.NewModuleAddress(types.ModuleName).String(),
+				ExecutionPayload:  payloadData,
+				PrevPayloadEvents: events,
+			})
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				if tc.postCheck != nil {
+					tc.postCheck(cachedCtx, block, payloadID)
+				}
+			}
+
+			if tc.afterTest != nil {
+				tc.afterTest(cachedCtx)
+			}
 		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-
-		gotPayload, err := mockEngine.GetPayloadV3(ctx, payloadID)
-		require.NoError(t, err)
-		require.Equal(t, latestHeight+1, gotPayload.ExecutionPayload.Number)
-		require.Equal(t, block.Hash(), gotPayload.ExecutionPayload.BlockHash)
-		require.Equal(t, keeper.validatorAddr, gotPayload.ExecutionPayload.FeeRecipient)
-		require.Empty(t, gotPayload.ExecutionPayload.Withdrawals)
 	}
-
-	newPayload(sdkCtx)
-	assertExecutionPayload(sdkCtx)
 }
 
 func fastBackoffForT() {

--- a/client/x/evmengine/keeper/ubi.go
+++ b/client/x/evmengine/keeper/ubi.go
@@ -18,7 +18,7 @@ import (
 	clog "github.com/piplabs/story/lib/log"
 )
 
-func (k *Keeper) ProcessUbiEvents(ctx context.Context, height uint64, logs []*types.EVMEvent) error {
+func (k *Keeper) ProcessUBIEvents(ctx context.Context, height uint64, logs []*types.EVMEvent) error {
 	for _, evmLog := range logs {
 		if err := evmLog.Verify(); err != nil {
 			return errors.Wrap(err, "verify log [BUG]")

--- a/client/x/evmengine/keeper/ubi_internal_test.go
+++ b/client/x/evmengine/keeper/ubi_internal_test.go
@@ -1,0 +1,243 @@
+package keeper
+
+import (
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	"github.com/stretchr/testify/require"
+
+	moduletestutil "github.com/piplabs/story/client/x/evmengine/testutil"
+	"github.com/piplabs/story/client/x/evmengine/types"
+	"github.com/piplabs/story/contracts/bindings"
+	"github.com/piplabs/story/lib/errors"
+	"github.com/piplabs/story/lib/ethclient/mock"
+	"github.com/piplabs/story/lib/k1util"
+	"github.com/piplabs/story/lib/tutil"
+
+	"go.uber.org/mock/gomock"
+)
+
+// const (
+//	dummyAddressHex = "0x1398C32A45Bc409b6C652E25bb0a3e702492A4ab"
+//)
+//
+// var (
+//	dummyContractAddress = common.HexToAddress(dummyAddressHex)
+//	dummyHash            = common.HexToHash("0x1398C32A45Bc409b6C652E25bb0a3e702492A4ab")
+//)
+
+func TestKeeper_ProcessUBIPercentageSet(t *testing.T) {
+	keeper, ctx, ctrl, dk := setupUBITestEnvironment(t)
+	t.Cleanup(ctrl.Finish)
+
+	tcs := []struct {
+		name        string
+		ev          func() *bindings.UBIPoolUBIPercentageSet
+		setupMock   func()
+		expectedErr string
+	}{
+		{
+			name: "pass: valid UBI percentage set event",
+			ev: func() *bindings.UBIPoolUBIPercentageSet {
+				return &bindings.UBIPoolUBIPercentageSet{
+					Percentage: 2000,
+				}
+			},
+			setupMock: func() {
+				dk.EXPECT().SetUbi(gomock.Any(), gomock.Any()).Return(nil)
+			},
+		},
+		// Fail cases: The following test cases simulate basic error scenarios.
+		// Since a mocked distribution keeper is used, not all error cases can be tested here.
+		// Comprehensive error testing would require the real distribution keeper, which is beyond the scope of this unit test.
+		{
+			name: "fail: invalid UBI percentage set event - value is 0",
+			ev: func() *bindings.UBIPoolUBIPercentageSet {
+				return &bindings.UBIPoolUBIPercentageSet{
+					Percentage: 11000,
+				}
+			},
+			setupMock: func() {
+				dk.EXPECT().SetUbi(gomock.Any(), gomock.Any()).Return(errors.New("ubi too large"))
+			},
+			expectedErr: "set new UBI percentage",
+		},
+		{
+			name: "fail: invalid UBI set request",
+			ev: func() *bindings.UBIPoolUBIPercentageSet {
+				return &bindings.UBIPoolUBIPercentageSet{
+					Percentage: 2000,
+				}
+			},
+			setupMock: func() {
+				dk.EXPECT().SetUbi(gomock.Any(), gomock.Any()).Return(sdkerrors.ErrInvalidRequest)
+			},
+			expectedErr: "invalid request",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setupMock()
+			err := keeper.ProcessUBIPercentageSet(ctx, tc.ev())
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKeeper_ProcessUBIEvents(t *testing.T) {
+	keeper, ctx, ctrl, dk := setupUBITestEnvironment(t)
+	t.Cleanup(ctrl.Finish)
+
+	ubiAbi, err := bindings.UBIPoolMetaData.GetAbi()
+	require.NoError(t, err, "failed to load ABI")
+
+	tcs := []struct {
+		name        string
+		evmEvents   func() []*types.EVMEvent
+		setupMock   func()
+		expectedErr string
+	}{
+		{
+			name:      "pass: nil events - nothing to process",
+			evmEvents: func() []*types.EVMEvent { return nil },
+		},
+		{
+			name:      "pass: empty events - nothing to process",
+			evmEvents: func() []*types.EVMEvent { return []*types.EVMEvent{} },
+		},
+		{
+			name: "pass: one valid UBI percentage set event",
+			evmEvents: func() []*types.EVMEvent {
+				data, err := ubiAbi.Events["UBIPercentageSet"].Inputs.NonIndexed().Pack(uint32(2000))
+				require.NoError(t, err)
+
+				return []*types.EVMEvent{
+					{
+						Address: dummyContractAddress.Bytes(),
+						Topics:  [][]byte{types.UBIPercentageSetEvent.ID.Bytes()},
+						Data:    data,
+						TxHash:  dummyHash.Bytes(),
+					},
+				}
+			},
+			setupMock: func() {
+				dk.EXPECT().SetUbi(gomock.Any(), gomock.Any()).Return(nil)
+			},
+		},
+		// Failed but pass cases: The following test cases simulate basic error scenarios.
+		// Since a mocked distribution keeper is used, not all error cases can be tested here.
+		// Comprehensive error testing would require the real distribution keeper, which is beyond the scope of this unit test.
+		{
+			name: "pass(failed but continue): invalid UBI percentage set event - too large value",
+			evmEvents: func() []*types.EVMEvent {
+				data, err := ubiAbi.Events["UBIPercentageSet"].Inputs.NonIndexed().Pack(uint32(11000))
+				require.NoError(t, err)
+
+				return []*types.EVMEvent{
+					{
+						Address: dummyContractAddress.Bytes(),
+						Topics:  [][]byte{types.UBIPercentageSetEvent.ID.Bytes()},
+						Data:    data,
+						TxHash:  dummyHash.Bytes(),
+					},
+				}
+			},
+			setupMock: func() {
+				dk.EXPECT().SetUbi(gomock.Any(), gomock.Any()).Return(errors.New("ubi too large"))
+			},
+		},
+		{
+			name: "pass(failed but continue): invalid UBI percentage set event",
+			evmEvents: func() []*types.EVMEvent {
+				return []*types.EVMEvent{
+					{
+						Address: dummyContractAddress.Bytes(),
+						Topics:  [][]byte{types.UBIPercentageSetEvent.ID.Bytes(), dummyHash.Bytes()},
+						TxHash:  dummyHash.Bytes(),
+					},
+				}
+			},
+		},
+
+		// Fail case: When given EVMEvent is not valid
+		{
+			name: "fail: invalid EVMEvent - invalid address",
+			evmEvents: func() []*types.EVMEvent {
+				return []*types.EVMEvent{
+					{
+						Address: []byte("invalid address"),
+						Topics:  [][]byte{types.UBIPercentageSetEvent.ID.Bytes()},
+						TxHash:  dummyHash.Bytes(),
+					},
+				}
+			},
+			expectedErr: "invalid address length",
+		},
+		{
+			name: "fail: invalid EVMEvent - empty topics",
+			evmEvents: func() []*types.EVMEvent {
+				return []*types.EVMEvent{
+					{
+						Address: dummyContractAddress.Bytes(),
+						TxHash:  dummyHash.Bytes(),
+					},
+				}
+			},
+			expectedErr: "empty topics",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setupMock != nil {
+				tc.setupMock()
+			}
+			cachedCtx, _ := ctx.CacheContext()
+			err := keeper.ProcessUBIEvents(cachedCtx, 1, tc.evmEvents())
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func setupUBITestEnvironment(t *testing.T) (*Keeper, sdk.Context, *gomock.Controller, *moduletestutil.MockDistrKeeper) {
+	t.Helper()
+	cdc := getCodec(t)
+	txConfig := authtx.NewTxConfig(cdc, nil)
+
+	cmtAPI := newMockCometAPI(t, nil)
+	header := cmtproto.Header{Height: 1, AppHash: tutil.RandomHash().Bytes(), ProposerAddress: cmtAPI.validatorSet.Validators[0].Address}
+	ctrl := gomock.NewController(t)
+	mockClient := mock.NewMockClient(ctrl)
+	ak := moduletestutil.NewMockAccountKeeper(ctrl)
+	esk := moduletestutil.NewMockEvmStakingKeeper(ctrl)
+	uk := moduletestutil.NewMockUpgradeKeeper(ctrl)
+	dk := moduletestutil.NewMockDistrKeeper(ctrl)
+
+	ctx, storeKey, storeService := setupCtxStore(t, &header)
+	mockEngine, err := newMockEngineAPI(storeKey, 0)
+	require.NoError(t, err)
+
+	keeper, err := NewKeeper(cdc, storeService, &mockEngine, mockClient, txConfig, ak, esk, uk, dk)
+	require.NoError(t, err)
+	keeper.SetCometAPI(cmtAPI)
+	nxtAddr, err := k1util.PubKeyToAddress(cmtAPI.validatorSet.CopyIncrementProposerPriority(1).Proposer.PubKey)
+	require.NoError(t, err)
+	keeper.SetValidatorAddress(nxtAddr)
+	populateGenesisHead(ctx, t, keeper)
+
+	return keeper, ctx, ctrl, dk
+}

--- a/client/x/evmengine/types/executable_data.go
+++ b/client/x/evmengine/types/executable_data.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/piplabs/story/lib/errors"
 )
@@ -15,23 +16,24 @@ import (
 // However, since engine.ExecutableData implements the MarshalJSON and UnmarshalJSON methods,
 // json.Decode.DisallowUnknownFields() cannot be used (see encoding/json/decode.go#L479).
 type ExecutableData struct {
-	ParentHash    *common.Hash    `json:"parentHash"`
-	FeeRecipient  *common.Address `json:"feeRecipient"`
-	StateRoot     *common.Hash    `json:"stateRoot"`
-	ReceiptsRoot  *common.Hash    `json:"receiptsRoot"`
-	LogsBloom     *hexutil.Bytes  `json:"logsBloom"`
-	Random        *common.Hash    `json:"prevRandao"`
-	Number        *hexutil.Uint64 `json:"blockNumber"`
-	GasLimit      *hexutil.Uint64 `json:"gasLimit"`
-	GasUsed       *hexutil.Uint64 `json:"gasUsed"`
-	Timestamp     *hexutil.Uint64 `json:"timestamp"`
-	ExtraData     *hexutil.Bytes  `json:"extraData"`
-	BaseFeePerGas *hexutil.Big    `json:"baseFeePerGas"`
-	BlockHash     *common.Hash    `json:"blockHash"`
-	Transactions  []hexutil.Bytes `json:"transactions"`
-	Withdrawals   []*Withdrawal   `json:"withdrawals"`
-	BlobGasUsed   *hexutil.Uint64 `json:"blobGasUsed"`
-	ExcessBlobGas *hexutil.Uint64 `json:"excessBlobGas"`
+	ParentHash       *common.Hash            `json:"parentHash"`
+	FeeRecipient     *common.Address         `json:"feeRecipient"`
+	StateRoot        *common.Hash            `json:"stateRoot"`
+	ReceiptsRoot     *common.Hash            `json:"receiptsRoot"`
+	LogsBloom        *hexutil.Bytes          `json:"logsBloom"`
+	Random           *common.Hash            `json:"prevRandao"`
+	Number           *hexutil.Uint64         `json:"blockNumber"`
+	GasLimit         *hexutil.Uint64         `json:"gasLimit"`
+	GasUsed          *hexutil.Uint64         `json:"gasUsed"`
+	Timestamp        *hexutil.Uint64         `json:"timestamp"`
+	ExtraData        *hexutil.Bytes          `json:"extraData"`
+	BaseFeePerGas    *hexutil.Big            `json:"baseFeePerGas"`
+	BlockHash        *common.Hash            `json:"blockHash"`
+	Transactions     []hexutil.Bytes         `json:"transactions"`
+	Withdrawals      []*Withdrawal           `json:"withdrawals"`
+	BlobGasUsed      *hexutil.Uint64         `json:"blobGasUsed"`
+	ExcessBlobGas    *hexutil.Uint64         `json:"excessBlobGas"`
+	ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 }
 
 type Withdrawal struct {


### PR DESCRIPTION
Added unit tests for evmengine module. The coverage of functions in keeper is increased from 64.9% to 84%.

issue: none
