### PR TITLE
feat(ci): enable gotest gha when push to main

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -2,6 +2,9 @@ name: go tests
 # Run this separately from pre-commit for nice visual coverage.
 
 on:
+  push:
+    branches:
+      - main
   workflow_call:
     secrets:
       CODECOV_TOKEN:


### PR DESCRIPTION
Currently, no codecov report is generated when PR is merged into main, so no report is shown in codecov badge in README.md. So, enabled to generate report when a PR is merged into main.

issue: none
