### PR TITLE
chore(genesis): update genesis execution hash for local

### DIFF
--- a/lib/netconf/local/genesis.json
+++ b/lib/netconf/local/genesis.json
@@ -89,7 +89,7 @@
     },
     "evmengine": {
       "params": {
-        "execution_block_hash": "gurvaiyYkNlLdee+7GiuC2p9trFSNnU3esw+6RusvYw="
+        "execution_block_hash": "AS9C2Iew0SatPOG0MGnCTVupr1HODYooc7C9v4oHsxI="
       }
     },
     "genutil": {


### PR DESCRIPTION
Updated the execution block hash for local network

issue: none
