### PR TITLE
feat(cmd): enable to rollback multiple blocks

### DIFF
--- a/client/app/rollback.go
+++ b/client/app/rollback.go
@@ -10,7 +10,7 @@ import (
 
 func RollbackCometAndAppState(a *App, cometCfg cmtcfg.Config, rollbackCfg config.RollbackConfig) (lastHeight int64, lastHash []byte, err error) {
 	for range rollbackCfg.RollbackHeights {
-		lastHeight, lastHash, err = cmtcmd.RollbackState(&cometCfg, false)
+		lastHeight, lastHash, err = cmtcmd.RollbackState(&cometCfg, true)
 		if err != nil {
 			return lastHeight, lastHash, errors.Wrap(err, "failed to rollback CometBFT state")
 		}


### PR DESCRIPTION
Previously, the rollback command was only able to roll back a single latest block, regardless of the value provided via the `--number` flag. Even when attempting to roll back multiple blocks, the command would repeatedly revert to the state of `latest - 1` block without progressing further.

To enable proper multi-block rollback, the second parameter `removeBlock` in CometBFT’s `RollbackState` must be set to true. This allows the rollback loop to proceed block by block until the desired number of blocks is reverted. This PR updates the logic accordingly by setting removeBlock to true to support multi-block rollback as expected.

issue: none
