### PR TITLE
fix(evmstaking): handle residual reward by version

### DIFF
--- a/client/x/evmstaking/keeper/abci_test.go
+++ b/client/x/evmstaking/keeper/abci_test.go
@@ -64,7 +64,7 @@ func TestEndBlock(t *testing.T) {
 		{
 			name: "pass(skip): skip EndBlock within the singularity",
 			setupMocks: func(ak *estestutil.MockAccountKeeper, bk *estestutil.MockBankKeeper, dk *estestutil.MockDistributionKeeper, sk *estestutil.MockStakingKeeper) {
-				sk.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(10), nil)
+				sk.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(50), nil)
 			},
 		},
 		{
@@ -242,6 +242,7 @@ func TestEndBlock(t *testing.T) {
 			}
 
 			cachedCtx, _ := ctx.CacheContext()
+			cachedCtx = cachedCtx.WithBlockHeight(20)
 
 			if tc.setup != nil {
 				cachedCtx = tc.setup(cachedCtx, esk)

--- a/client/x/evmstaking/keeper/keeper_test.go
+++ b/client/x/evmstaking/keeper/keeper_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/ethclient"
 	"github.com/piplabs/story/lib/k1util"
+	"github.com/piplabs/story/lib/netconf"
 
 	"go.uber.org/mock/gomock"
 )
@@ -1201,7 +1202,7 @@ func setupCtxStore(t *testing.T, header *cmtproto.Header) (sdk.Context, *storety
 	if header == nil {
 		header = &cmtproto.Header{Time: cmttime.Now()}
 	}
-	ctx := testCtx.Ctx.WithBlockHeader(*header)
+	ctx := testCtx.Ctx.WithBlockHeader(*header).WithChainID(netconf.TestChainID)
 	defaultConsensusParams := genutil.DefaultConsensusParams()
 	ctx = ctx.WithConsensusParams(defaultConsensusParams.ToProto())
 

--- a/lib/netconf/chains.go
+++ b/lib/netconf/chains.go
@@ -1,0 +1,15 @@
+package netconf
+
+const (
+	// AeneidChainID is the chain ID of Aeneid main network (lib/netconf/aeneid/genesis.json).
+	AeneidChainID = "devnet-1"
+
+	// StoryChainID is the chain ID of Story main network (lib/netconf/story/genesis.json).
+	StoryChainID = "story-1"
+
+	// LocalChainID is the chain ID of Local network (lib/netconf/local/genesis.json).
+	LocalChainID = "story-1001511"
+
+	// TestChainID is the chain ID that is used for test code.
+	TestChainID = "test-1"
+)

--- a/lib/netconf/upgrades.go
+++ b/lib/netconf/upgrades.go
@@ -1,0 +1,82 @@
+package netconf
+
+import (
+	"errors"
+)
+
+const (
+	Virgil   = "virgil"
+	Ovid     = "v1.2.0"
+	Polybius = "polybius"
+
+	V121 = "v1.2.1"
+)
+
+var (
+	ErrUnknownChainID = errors.New("unknown chain ID")
+	ErrUnknownUpgrade = errors.New("unknown upgrade name")
+)
+
+type UpgradeMap map[string]int64
+
+// UpgradeHistories are the map of histories for each network.
+var UpgradeHistories = map[string]UpgradeMap{
+	TestChainID: {
+		V121: 10,
+	},
+	LocalChainID: {
+		V121: 0,
+	},
+	AeneidChainID: {
+		Virgil:   345158,
+		Ovid:     4362990,
+		V121:     5238000,
+		Polybius: 6008000,
+	},
+	StoryChainID: {
+		Virgil: 809988,
+		Ovid:   4477880,
+		V121:   5084300,
+	},
+}
+
+func (um UpgradeMap) GetUpgradeBlock(upgradeName string) (int64, error) {
+	upgradeBlock, ok := um[upgradeName]
+	if !ok {
+		return 0, ErrUnknownUpgrade
+	}
+
+	return upgradeBlock, nil
+}
+
+func GetUpgradeHistory(chainID string) (UpgradeMap, error) {
+	upgradeHistory, ok := UpgradeHistories[chainID]
+	if !ok {
+		return nil, ErrUnknownChainID
+	}
+
+	return upgradeHistory, nil
+}
+
+func GetUpgradeHeight(chainID, upgradeName string) (int64, error) {
+	upgradeMap, err := GetUpgradeHistory(chainID)
+	if err != nil {
+		return 0, err
+	}
+
+	upgradeBlock, err := upgradeMap.GetUpgradeBlock(upgradeName)
+	if err != nil {
+		return 0, err
+	}
+
+	return upgradeBlock, nil
+}
+
+func IsV121(chainID string, blockNumber int64) (bool, error) {
+	v121Block, err := GetUpgradeHeight(chainID, V121)
+	if err != nil {
+		return false, err
+	}
+
+	return blockNumber >= v121Block, nil
+}


### PR DESCRIPTION
In Story v1.2.1, the handling of residual rewards was upgraded. As a result, when syncing from the genesis block using a client running v1.2.1 or later, a state difference may occur at a certain block, leading to an app hash mismatch error. To address this issue, the residual reward handling logic has been corrected to properly account for the block height — applying the appropriate logic before and after the v1.2.1 upgrade point.

issue: none
