### PR TITLE
chore(upgrade): add v1.4 upgrade height for mainnet

### DIFF
--- a/lib/netconf/upgrades.go
+++ b/lib/netconf/upgrades.go
@@ -43,6 +43,7 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Virgil: 809988,
 		Ovid:   4477880,
 		V121:   5084300,
+		V140:   100000000,
 	},
 }
 


### PR DESCRIPTION
add an upgrade height of v1.4 for Story mainnet.

issue: none
