### PR TITLE
chore(evmengine): preserve error code 1

### DIFF
--- a/client/x/evmengine/types/errors.go
+++ b/client/x/evmengine/types/errors.go
@@ -3,6 +3,6 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrUpgradePending  = errors.Register(ModuleName, 1, "upgrade is already pending")
-	ErrUpgradeNotFound = errors.Register(ModuleName, 2, "upgrade not found")
+	ErrUpgradePending  = errors.Register(ModuleName, 2, "upgrade is already pending")
+	ErrUpgradeNotFound = errors.Register(ModuleName, 3, "upgrade not found")
 )


### PR DESCRIPTION
Change the error code for evmengine since cosmos-sdk [specification](https://docs.cosmos.network/v0.50/build/building-modules/errors#registration) explicitly forbids the usage of err code 1 due to it's default usage for internal errors

issue: none
