### PR TITLE
feat(api): add endpoint to query staked token amount

### DIFF
--- a/client/app/app.go
+++ b/client/app/app.go
@@ -235,3 +235,12 @@ func (a App) GetUpgradeKeeper() *upgradekeeper.Keeper {
 func (a App) GetMintKeeper() mintkeeper.Keeper {
 	return a.Keepers.MintKeeper
 }
+
+func (a App) CreateQueryContext(height int64, prove bool) (sdk.Context, error) {
+	ctx, err := a.BaseApp.CreateQueryContext(height, prove)
+	if err != nil {
+		return sdk.Context{}, errors.Wrap(err, "failed to create query context")
+	}
+
+	return ctx, nil
+}

--- a/client/server/README.md
+++ b/client/server/README.md
@@ -725,6 +725,63 @@ URL: [GET] /staking/delegators/{delegator_addr}/validators/{validator_addr}
 }
 ```
 
+## GetDelegatorStakedToken
+
+URL: [GET] /staking/delegators/{delegator_addr}/staked_token
+
+### Path Params
+| Name           | Type   | Example                                      | Required |
+|----------------|--------|----------------------------------------------|----------|
+| delegator_addr | string | 0x00a842dbd3d11176b4868dd753a552b8919d5a63   | ✔        |
+
+### Query Params
+| Name                   | Type    | Example                                    | Required |
+|------------------------|---------|--------------------------------------------|----------|
+| pagination.key         | string  | FPoybu9dO+FCSV562u9keKVgUwur               |          |
+| pagination.offset      | string  | 0                                          |          |
+| pagination.limit       | array   | 10                                         |          |
+| pagination.count_total | boolean | true                                       |          |
+| pagination.reverse     | boolean | true                                       |          |
+
+### Response Example
+```json
+{
+  "code": 200,
+  "msg": {
+    "delegation_staked_token": [
+      {
+        "validator_operator_address": "0x88355450c9003d1d43773bd72b837e818693a781",
+        "staked_token": "2048000000000.000000000000000000"
+      }
+    ],
+    "pagination": {
+      "total": "1"
+    }
+  },
+  "error": ""
+}
+```
+
+## GetDelegatorTotalStakedToken
+
+URL: [GET] /staking/delegators/{delegator_addr}/total_staked_token
+
+### Path Params
+| Name           | Type   | Example                                      | Required |
+|----------------|--------|----------------------------------------------|----------|
+| delegator_addr | string | 0x00a842dbd3d11176b4868dd753a552b8919d5a63   | ✔        |
+
+### Response Example
+```json
+{
+  "code": 200,
+  "msg": {
+    "staked_token": "2048000000000.000000000000000000"
+  },
+  "error": ""
+}
+```
+
 ## GetDelegatorRewardsToken
 
 URL: [GET] /staking/delegators/{delegator_addr}/rewards_token

--- a/client/server/payload.go
+++ b/client/server/payload.go
@@ -79,12 +79,30 @@ type getModuleVersionsRequest struct {
 	ModuleName string `mapstructure:"module_name"`
 }
 
+type getStakedTokenByDelegatorAddressRequest struct {
+	Pagination pagination `mapstructure:"pagination"`
+}
+
 type getRewardsTokenByDelegatorAddressRequest struct {
 	Pagination pagination `mapstructure:"pagination"`
 }
 
 type QueryTotalDelegationsCountResponse struct {
 	Total int `json:"total"`
+}
+
+type DelegationStakedToken struct {
+	ValidatorOperatorAddress string         `json:"validator_operator_address"`
+	StakedToken              math.LegacyDec `json:"staked_token"`
+}
+
+type QueryStakedTokenByDelegatorAddressResponse struct {
+	DelegationStakedToken []DelegationStakedToken `json:"delegation_staked_token"`
+	Pagination            *query.PageResponse     `json:"pagination"`
+}
+
+type QueryTotalStakedTokenByDelegatorAddressResponse struct {
+	StakedToken math.LegacyDec `json:"staked_token"`
 }
 
 type DelegationRewardsToken struct {

--- a/client/server/staking.go
+++ b/client/server/staking.go
@@ -38,6 +38,8 @@ func (s *Server) initStakingRoute() {
 	s.httpMux.HandleFunc("/staking/delegators/{delegator_address}/unbonding_delegations", utils.AutoWrap(s.aminoCodec, s.GetUnbondingDelegationsByDelegatorAddress))
 	s.httpMux.HandleFunc("/staking/delegators/{delegator_address}/validators", utils.AutoWrap(s.aminoCodec, s.GetValidatorsByDelegatorAddress))
 	s.httpMux.HandleFunc("/staking/delegators/{delegator_address}/validators/{validator_address}", utils.SimpleWrap(s.aminoCodec, s.GetValidatorsByDelegatorAddressValidatorAddress))
+	s.httpMux.HandleFunc("/staking/delegators/{delegator_address}/staked_token", utils.AutoWrap(s.aminoCodec, s.GetStakedTokenByDelegatorAddress))
+	s.httpMux.HandleFunc("/staking/delegators/{delegator_address}/total_staked_token", utils.SimpleWrap(s.aminoCodec, s.GetTotalStakedTokenByDelegatorAddress))
 	s.httpMux.HandleFunc("/staking/delegators/{delegator_address}/rewards_token", utils.AutoWrap(s.aminoCodec, s.GetRewardsTokenByDelegatorAddress))
 	s.httpMux.HandleFunc("/staking/delegators/{delegator_address}/total_rewards_token", utils.SimpleWrap(s.aminoCodec, s.GetTotalRewardsTokenByDelegatorAddress))
 }
@@ -623,6 +625,115 @@ func (s *Server) GetValidatorsByDelegatorAddressValidatorAddress(r *http.Request
 	}
 
 	return queryResp, nil
+}
+
+func (s *Server) GetStakedTokenByDelegatorAddress(req *getStakedTokenByDelegatorAddressRequest, r *http.Request) (resp any, err error) {
+	queryContext, err := s.createQueryContextByHeader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	bech32AccAddress, err := utils.EvmAddressToBech32AccAddress(mux.Vars(r)["delegator_address"])
+	if err != nil {
+		return nil, err
+	}
+
+	queryResp, err := keeper.NewQuerier(s.store.GetStakingKeeper()).DelegatorDelegations(queryContext, &stakingtypes.QueryDelegatorDelegationsRequest{
+		DelegatorAddr: bech32AccAddress.String(),
+		Pagination: &query.PageRequest{
+			Key:        []byte(req.Pagination.Key),
+			Offset:     req.Pagination.Offset,
+			Limit:      req.Pagination.Limit,
+			CountTotal: req.Pagination.CountTotal,
+			Reverse:    req.Pagination.Reverse,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var delStakedToken []DelegationStakedToken
+	for _, delResp := range queryResp.DelegationResponses {
+		valAddr, err := sdk.ValAddressFromBech32(delResp.Delegation.ValidatorAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		val, err := keeper.NewQuerier(s.store.GetStakingKeeper()).GetValidator(queryContext, valAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		evmOperatorAddress, err := utils.Bech32ValidatorAddressToEvmAddress(val.OperatorAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		stakedToken := val.TokensFromShares(delResp.Delegation.Shares)
+		delStakedToken = append(delStakedToken, DelegationStakedToken{
+			ValidatorOperatorAddress: evmOperatorAddress,
+			StakedToken:              stakedToken,
+		})
+	}
+
+	return QueryStakedTokenByDelegatorAddressResponse{
+		DelegationStakedToken: delStakedToken,
+		Pagination:            queryResp.Pagination,
+	}, nil
+}
+
+func (s *Server) GetTotalStakedTokenByDelegatorAddress(r *http.Request) (resp any, err error) {
+	queryContext, err := s.createQueryContextByHeader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	bech32AccAddress, err := utils.EvmAddressToBech32AccAddress(mux.Vars(r)["delegator_address"])
+	if err != nil {
+		return nil, err
+	}
+
+	var nextKey []byte
+	totalStakedToken := math.LegacyZeroDec()
+
+	for {
+		queryResp, err := keeper.NewQuerier(s.store.GetStakingKeeper()).DelegatorDelegations(queryContext, &stakingtypes.QueryDelegatorDelegationsRequest{
+			DelegatorAddr: bech32AccAddress.String(),
+			Pagination: &query.PageRequest{
+				Key:        nextKey,
+				Limit:      100,
+				CountTotal: false,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, delResp := range queryResp.DelegationResponses {
+			valAddr, err := sdk.ValAddressFromBech32(delResp.Delegation.ValidatorAddress)
+			if err != nil {
+				return nil, err
+			}
+
+			val, err := keeper.NewQuerier(s.store.GetStakingKeeper()).GetValidator(queryContext, valAddr)
+			if err != nil {
+				return nil, err
+			}
+
+			stakedToken := val.TokensFromShares(delResp.Delegation.Shares)
+			totalStakedToken = totalStakedToken.Add(stakedToken)
+		}
+
+		if queryResp.Pagination == nil || len(queryResp.Pagination.NextKey) == 0 {
+			break
+		}
+
+		nextKey = queryResp.Pagination.NextKey
+	}
+
+	return QueryTotalStakedTokenByDelegatorAddressResponse{
+		StakedToken: totalStakedToken,
+	}, nil
 }
 
 func (s *Server) GetRewardsTokenByDelegatorAddress(req *getRewardsTokenByDelegatorAddressRequest, r *http.Request) (resp any, err error) {


### PR DESCRIPTION
Added APIs to fetch the staked token amount.
Also, implemented `CreateQueryContext` to allow querying data at a specific block height via the `X-Block-Height` request header.

issue: #589 
