### PR TITLE
chore(upgrade): set terence height for mainnet

### DIFF
--- a/lib/netconf/upgrades.go
+++ b/lib/netconf/upgrades.go
@@ -47,7 +47,7 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Ovid:     4477880,
 		V121:     5084300,
 		Polybius: 8270000,
-		Terence:  100000000, // TODO: need to set actual upgrade height for story mainnet
+		Terence:  11538000,
 	},
 }
 


### PR DESCRIPTION
port the commit for setting the Terence upgrade height for mainnet. 

https://www.storyscan.io/block/countdown/11538000

issue: none
