### PR TITLE
chore(evmengine): remove logs when not related event comes in

### DIFF
--- a/client/x/evmengine/keeper/ubi.go
+++ b/client/x/evmengine/keeper/ubi.go
@@ -42,6 +42,9 @@ func (k *Keeper) ProcessUBIEvents(ctx context.Context, height uint64, logs []*ty
 				clog.Error(ctx, "Failed to process UBI percentage set", err)
 				continue
 			}
+		default:
+			// skip if the event is not from UBI pool contract
+			continue
 		}
 	}
 

--- a/client/x/evmengine/keeper/upgrades.go
+++ b/client/x/evmengine/keeper/upgrades.go
@@ -54,7 +54,7 @@ func (k *Keeper) ProcessUpgradeEvents(ctx context.Context, height uint64, logs [
 				continue
 			}
 		default:
-			clog.Error(ctx, "Unexpected event type from upgrade entrypoint contract", nil)
+			// skip if the event is not from upgrade entrypoint contract
 			continue
 		}
 	}


### PR DESCRIPTION
When processing evm events in evmengine module, it is passed to all processor of events (staking, upgrade, ubi). If it is not related one, just skip and continue processing it without logging anything. 

issue: none
