### PR TITLE
fix(buildinfo): remove handling of default case of reading build info

### DIFF
--- a/lib/buildinfo/buildinfo.go
+++ b/lib/buildinfo/buildinfo.go
@@ -15,7 +15,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 5        // Minor version component of the current release
-	VersionPatch = 0        // Patch version component of the current release
+	VersionPatch = 1        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 
@@ -97,8 +97,6 @@ func get() (hash string, timestamp string) { //nolint:nonamedreturns // Disambig
 			hash = s.Value[:hashLen]
 		case "vcs.time":
 			timestamp = s.Value
-		default:
-			return hash, timestamp
 		}
 	}
 


### PR DESCRIPTION
There was an issue that git commit and timestamp is not printed in reading the build info. This PR fixes the issue by removing the handling of default case in reading the build info. 

issue: none
