### PR TITLE
fix(dkg): remove deals from session state

### DIFF
--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -2,12 +2,13 @@ package keeper
 
 import (
 	"context"
-	"cosmossdk.io/collections"
 	"encoding/hex"
+	"slices"
+
+	"cosmossdk.io/collections"
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
-	"slices"
 )
 
 // handleDKGDealing handles the dealing phase event.
@@ -82,11 +83,6 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 		k.stateManager.MarkFailed(ctx, session)
 
 		return
-	}
-
-	for _, deal := range resp.GetDeals() {
-		session.Deals[deal.Index] = deal
-		session.Index = deal.Index // same for all deals
 	}
 
 	if err := k.stateManager.UpdateSession(ctx, session); err != nil {

--- a/client/x/dkg/types/dkg.go
+++ b/client/x/dkg/types/dkg.go
@@ -68,7 +68,6 @@ type DKGSession struct {
 	// DKG state
 	Registrations []DKGRegistration `json:"registrations,omitempty"`
 	Commitments   []byte            `json:"commitments,omitempty"`
-	Deals         map[uint32]Deal   `json:"deals,omitempty"` // deals by dealer index
 	Complaints    []Complaint       `json:"complaints,omitempty"`
 	IsFinalized   bool              `json:"is_finalized"`
 	IsResharing   bool              `json:"is_resharing"`
@@ -92,7 +91,6 @@ func NewDKGSession(codeCommitment []byte, round uint32, activeValidators []strin
 		ActiveValidators: activeValidators,
 		Total:            0,
 		Threshold:        0,
-		Deals:            make(map[uint32]Deal),
 		IsFinalized:      false,
 		IsResharing:      isResharing,
 


### PR DESCRIPTION
issue: #673
The CL now filters deals by recipient index and forwards them to the kernel for storage. Therefore, there is no need to maintain deals on the CL side anymore.