### PR TITLE
feat(evmstaking): block self unstaking for dkg validators

### DIFF
--- a/client/x/dkg/keeper/dkg_handler_internal_test.go
+++ b/client/x/dkg/keeper/dkg_handler_internal_test.go
@@ -523,6 +523,107 @@ func TestKeeper_InvalidDeal(t *testing.T) {
 	}
 }
 
+func TestKeeper_HasFinalizedRegistration(t *testing.T) {
+	k, ctx := setupDKGKeeper(t)
+
+	testValidator := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	testCodeCommitment := [32]byte{0x12, 0x34, 0x56, 0x78}
+	testRound := uint32(1)
+
+	tcs := []struct {
+		name           string
+		setup          func()
+		codeCommitment []byte
+		round          uint32
+		validatorAddr  common.Address
+		expectedResult bool
+		expectedErr    string
+	}{
+		{
+			name: "pass: returns true when registration is finalized",
+			setup: func() {
+				err := k.setDKGRegistration(ctx, testCodeCommitment, testValidator, &types.DKGRegistration{
+					Round:         testRound,
+					ValidatorAddr: testValidator.Hex(),
+					Index:         1,
+					Status:        types.DKGRegStatusFinalized,
+				})
+				require.NoError(t, err)
+			},
+			codeCommitment: testCodeCommitment[:],
+			round:          testRound,
+			validatorAddr:  testValidator,
+			expectedResult: true,
+		},
+		{
+			name: "pass: returns false when registration is verified (not finalized)",
+			setup: func() {
+				err := k.setDKGRegistration(ctx, testCodeCommitment, testValidator, &types.DKGRegistration{
+					Round:         testRound,
+					ValidatorAddr: testValidator.Hex(),
+					Index:         1,
+					Status:        types.DKGRegStatusVerified,
+				})
+				require.NoError(t, err)
+			},
+			codeCommitment: testCodeCommitment[:],
+			round:          testRound,
+			validatorAddr:  testValidator,
+			expectedResult: false,
+		},
+		{
+			name: "pass: returns false when registration is unspecified",
+			setup: func() {
+				err := k.setDKGRegistration(ctx, testCodeCommitment, testValidator, &types.DKGRegistration{
+					Round:         testRound,
+					ValidatorAddr: testValidator.Hex(),
+					Index:         1,
+					Status:        types.DKGRegStatusUnspecified,
+				})
+				require.NoError(t, err)
+			},
+			codeCommitment: testCodeCommitment[:],
+			round:          testRound,
+			validatorAddr:  testValidator,
+			expectedResult: false,
+		},
+		{
+			name:           "pass: returns false when no registration exists",
+			setup:          func() {},
+			codeCommitment: testCodeCommitment[:],
+			round:          uint32(999), // non-existent round
+			validatorAddr:  common.HexToAddress("0x0000000000000000000000000000000000000001"),
+			expectedResult: false,
+		},
+		{
+			name:           "fail: returns error when code commitment has wrong length",
+			setup:          func() {},
+			codeCommitment: []byte{0x01, 0x02}, // too short
+			round:          testRound,
+			validatorAddr:  testValidator,
+			expectedResult: false,
+			expectedErr:    "failed to cast code commitment to bytes32",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+
+			result, err := k.HasFinalizedRegistration(ctx, tc.codeCommitment, tc.round, tc.validatorAddr)
+
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+				require.False(t, result)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedResult, result)
+			}
+		})
+	}
+}
+
 // setupDKGKeeper creates a test DKG keeper with necessary dependencies.
 func setupDKGKeeper(t *testing.T) (*Keeper, context.Context) {
 	t.Helper()

--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -2,13 +2,14 @@ package keeper
 
 import (
 	"context"
-	"cosmossdk.io/collections"
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/piplabs/story/client/server/utils"
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
-	"strings"
 )
 
 // GetActiveValidators returns the bonded validators' EVM addresses excluding jailed validators.
@@ -86,13 +87,10 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context) error {
 }
 
 func (k *Keeper) shouldReshare(ctx context.Context) (bool, error) {
-	_, err := k.getLatestActiveDKGNetwork(ctx)
-	if err == nil {
-		return true, nil
-	}
-	if errors.Is(err, collections.ErrNotFound) {
-		return false, nil
+	activeNetwork, err := k.getLatestActiveDKGNetwork(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get latest active DKG network")
 	}
 
-	return false, errors.Wrap(err, "failed to get latest active DKG network")
+	return activeNetwork != nil, nil
 }

--- a/client/x/dkg/keeper/dkg_network.go
+++ b/client/x/dkg/keeper/dkg_network.go
@@ -183,16 +183,26 @@ func (k *Keeper) setLatestActiveRound(ctx context.Context, dkgNetwork *types.DKG
 	return nil
 }
 
+// GetLatestActiveRound retrieves the latest active DKG round.
+// Returns nil, nil if no active round has been set yet.
+func (k *Keeper) GetLatestActiveRound(ctx context.Context) (*types.DKGNetwork, error) {
+	return k.getLatestActiveDKGNetwork(ctx)
+}
+
 func (k *Keeper) getLatestActiveDKGNetwork(ctx context.Context) (*types.DKGNetwork, error) {
 	key, err := k.LatestActiveRound.Get(ctx)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, nil
+		}
+
 		return nil, errors.Wrap(err, "failed to get latest active round of DKG network key")
 	}
 
 	dkgNetwork, err := k.DKGNetworks.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
-			return nil, errors.Wrap(err, "no active round of dkg network")
+			return nil, nil
 		}
 
 		return nil, errors.Wrap(err, "failed to get latest active round of dkg network")
@@ -205,6 +215,9 @@ func (k *Keeper) isInPrevActiveValSet(ctx context.Context) (bool, error) {
 	latestActive, err := k.getLatestActiveDKGNetwork(ctx)
 	if err != nil {
 		return false, err
+	}
+	if latestActive == nil {
+		return false, nil
 	}
 
 	return slices.Contains(latestActive.ActiveValSet, k.validatorEVMAddr), nil

--- a/client/x/dkg/keeper/dkg_registration.go
+++ b/client/x/dkg/keeper/dkg_registration.go
@@ -118,6 +118,25 @@ func (k *Keeper) getDKGRegistrationsByStatus(ctx context.Context, codeCommitment
 	return filteredRegs, nil
 }
 
+// HasFinalizedRegistration checks if a validator has a finalized DKG registration for a given code commitment and round.
+func (k *Keeper) HasFinalizedRegistration(ctx context.Context, codeCommitment []byte, round uint32, validatorAddr common.Address) (bool, error) {
+	codeCommitment32, err := cast.ToBytes32(codeCommitment)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to cast code commitment to bytes32")
+	}
+
+	reg, err := k.getDKGRegistration(ctx, codeCommitment32, round, validatorAddr)
+	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return reg.Status == types.DKGRegStatusFinalized, nil
+}
+
 // countDKGRegistrationsByStatus returns the count of DKG registrations in the status
 func (k *Keeper) countDKGRegistrationsByStatus(ctx context.Context, codeCommitment []byte, round uint32, status types.DKGRegStatus) (uint32, error) {
 	codeCommitment32, err := cast.ToBytes32(codeCommitment)
@@ -125,7 +144,7 @@ func (k *Keeper) countDKGRegistrationsByStatus(ctx context.Context, codeCommitme
 		return 0, errors.Wrap(err, "failed to cast to bytes32")
 	}
 
-	// Get registrations with status VERIFIED
+	// Get registrations with status of registration
 	regs, err := k.getDKGRegistrationsByStatus(ctx, codeCommitment32, round, status)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get verified registrations")

--- a/client/x/dkg/keeper/dkg_rewards.go
+++ b/client/x/dkg/keeper/dkg_rewards.go
@@ -30,12 +30,11 @@ func (k *Keeper) DistributeRewardsToActiveCommittee(ctx context.Context, senderM
 	// Get the latest active DKG network (current serving committee).
 	activeRound, err := k.getLatestActiveDKGNetwork(ctx)
 	if err != nil {
-		if errors.Is(err, collections.ErrNotFound) {
-			// No active DKG round — no committee to reward.
-			return math.ZeroInt(), nil
-		}
-
 		return math.ZeroInt(), errors.Wrap(err, "get latest active DKG network")
+	}
+	if activeRound == nil {
+		// No active DKG round — no committee to reward.
+		return math.ZeroInt(), nil
 	}
 
 	return k.distributeRewardsFromModule(ctx, activeRound, senderModule, totalAmount)
@@ -180,12 +179,11 @@ func (k *Keeper) settleRewardsForPreviousCommittee(ctx context.Context) error {
 	// Get the previous active round (the one whose committee served).
 	prevActive, err := k.getLatestActiveDKGNetwork(ctx)
 	if err != nil {
-		if errors.Is(err, collections.ErrNotFound) {
-			// First round ever — no previous committee to reward.
-			return nil
-		}
-
 		return errors.Wrap(err, "failed to get previous active DKG network")
+	}
+	if prevActive == nil {
+		// First round ever — no previous committee to reward.
+		return nil
 	}
 
 	// Read the DKG committee reward portion from params.

--- a/client/x/dkg/keeper/query.go
+++ b/client/x/dkg/keeper/query.go
@@ -151,6 +151,9 @@ func (k *Keeper) GetLatestActiveDKGNetwork(ctx context.Context, request *types.Q
 	if err != nil {
 		return nil, err
 	}
+	if latest == nil {
+		return nil, status.Error(codes.NotFound, "no active DKG network")
+	}
 
 	return &types.QueryGetLatestActiveDKGNetworkResponse{Network: *latest}, nil
 }

--- a/client/x/evmstaking/keeper/withdraw.go
+++ b/client/x/evmstaking/keeper/withdraw.go
@@ -514,6 +514,20 @@ func (k Keeper) ProcessWithdraw(ctx context.Context, ev *bindings.IPTokenStaking
 		return errors.New("depositor account not found")
 	}
 
+	// Block self-unstaking if the validator has a finalized registration in the active DKG round
+	if ev.Delegator == valEvmAddr {
+		activeRound, err := k.dkgKeeper.GetLatestActiveRound(cachedCtx)
+		if err == nil && activeRound != nil {
+			hasFinalized, err := k.dkgKeeper.HasFinalizedRegistration(cachedCtx, activeRound.CodeCommitment, activeRound.Round, valEvmAddr)
+			if err == nil && hasFinalized {
+				return errors.WrapErrWithCode(
+					errors.ActiveDKGMemberSelfUnstake,
+					errors.New("validator is a finalized member of the active DKG round and cannot self-unstake"),
+				)
+			}
+		}
+	}
+
 	lockedTokenType, err := k.stakingKeeper.GetLockedTokenType(cachedCtx)
 	if err != nil {
 		return errors.Wrap(err, "get locked token type")

--- a/client/x/evmstaking/keeper/withdraw_test.go
+++ b/client/x/evmstaking/keeper/withdraw_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/piplabs/story/client/server/utils"
+	dkgtypes "github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/client/x/evmstaking/keeper"
 	moduletestutil "github.com/piplabs/story/client/x/evmstaking/testutil"
 	"github.com/piplabs/story/client/x/evmstaking/types"
@@ -1894,6 +1895,136 @@ func TestProcessWithdraw(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestProcessWithdrawDKGBlocking(t *testing.T) {
+	pubKeys, _, _ := createAddresses(2)
+
+	// validator
+	valPubKey := pubKeys[0]
+	valEvmAddr, err := keeper.CmpPubKeyToEVMAddress(valPubKey.Bytes())
+	require.NoError(t, err)
+
+	// separate delegator (non-self unstake)
+	delPubKey := pubKeys[1]
+	delEvmAddr, err := keeper.CmpPubKeyToEVMAddress(delPubKey.Bytes())
+	require.NoError(t, err)
+
+	activeRound := &dkgtypes.DKGNetwork{
+		CodeCommitment: []byte("test-commitment"),
+		Round:          1,
+	}
+
+	// createSelfUnstake creates a withdraw event where Delegator == validator EVM address (self-unstake)
+	createSelfUnstake := func() *bindings.IPTokenStakingWithdraw {
+		return &bindings.IPTokenStakingWithdraw{
+			Delegator:          valEvmAddr,
+			ValidatorCmpPubkey: valPubKey.Bytes(),
+			StakeAmount:        new(big.Int).SetUint64(1),
+			DelegationId:       big.NewInt(0),
+			OperatorAddress:    valEvmAddr,
+		}
+	}
+
+	// createNonSelfUnstake creates a withdraw event where Delegator != validator EVM address
+	createNonSelfUnstake := func() *bindings.IPTokenStakingWithdraw {
+		return &bindings.IPTokenStakingWithdraw{
+			Delegator:          delEvmAddr,
+			ValidatorCmpPubkey: valPubKey.Bytes(),
+			StakeAmount:        new(big.Int).SetUint64(1),
+			DelegationId:       big.NewInt(0),
+			OperatorAddress:    delEvmAddr,
+		}
+	}
+
+	tcs := []struct {
+		name       string
+		setupMocks func(ak *moduletestutil.MockAccountKeeper, mockSK *moduletestutil.MockStakingKeeper, dkgk *moduletestutil.MockDKGKeeper)
+		withdraw   *bindings.IPTokenStakingWithdraw
+		expectErr  string
+	}{
+		{
+			name: "fail: self-unstake blocked when validator has finalized DKG registration",
+			setupMocks: func(ak *moduletestutil.MockAccountKeeper, mockSK *moduletestutil.MockStakingKeeper, dkgk *moduletestutil.MockDKGKeeper) {
+				mockSK.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(0), nil)
+				ak.EXPECT().HasAccount(gomock.Any(), gomock.Any()).Return(true)
+				dkgk.EXPECT().GetLatestActiveRound(gomock.Any()).Return(activeRound, nil)
+				dkgk.EXPECT().HasFinalizedRegistration(gomock.Any(), activeRound.CodeCommitment, activeRound.Round, valEvmAddr).Return(true, nil)
+			},
+			withdraw:  createSelfUnstake(),
+			expectErr: "finalized member of the active DKG round",
+		},
+		{
+			name: "pass: self-unstake allowed when no active DKG round",
+			setupMocks: func(ak *moduletestutil.MockAccountKeeper, mockSK *moduletestutil.MockStakingKeeper, dkgk *moduletestutil.MockDKGKeeper) {
+				mockSK.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(0), nil)
+				ak.EXPECT().HasAccount(gomock.Any(), gomock.Any()).Return(true)
+				dkgk.EXPECT().GetLatestActiveRound(gomock.Any()).Return(nil, nil)
+				// No HasFinalizedRegistration mock needed; DKG check is skipped
+				mockSK.EXPECT().GetLockedTokenType(gomock.Any()).Return(int32(0), errors.New("stop: past DKG check"))
+			},
+			withdraw:  createSelfUnstake(),
+			expectErr: "stop: past DKG check",
+		},
+		{
+			name: "pass: self-unstake allowed when validator is not a finalized DKG member",
+			setupMocks: func(ak *moduletestutil.MockAccountKeeper, mockSK *moduletestutil.MockStakingKeeper, dkgk *moduletestutil.MockDKGKeeper) {
+				mockSK.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(0), nil)
+				ak.EXPECT().HasAccount(gomock.Any(), gomock.Any()).Return(true)
+				dkgk.EXPECT().GetLatestActiveRound(gomock.Any()).Return(activeRound, nil)
+				dkgk.EXPECT().HasFinalizedRegistration(gomock.Any(), activeRound.CodeCommitment, activeRound.Round, valEvmAddr).Return(false, nil)
+				mockSK.EXPECT().GetLockedTokenType(gomock.Any()).Return(int32(0), errors.New("stop: past DKG check"))
+			},
+			withdraw:  createSelfUnstake(),
+			expectErr: "stop: past DKG check",
+		},
+		{
+			name: "pass: self-unstake allowed when GetLatestActiveRound errors",
+			setupMocks: func(ak *moduletestutil.MockAccountKeeper, mockSK *moduletestutil.MockStakingKeeper, dkgk *moduletestutil.MockDKGKeeper) {
+				mockSK.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(0), nil)
+				ak.EXPECT().HasAccount(gomock.Any(), gomock.Any()).Return(true)
+				dkgk.EXPECT().GetLatestActiveRound(gomock.Any()).Return(nil, errors.New("dkg error"))
+				mockSK.EXPECT().GetLockedTokenType(gomock.Any()).Return(int32(0), errors.New("stop: past DKG check"))
+			},
+			withdraw:  createSelfUnstake(),
+			expectErr: "stop: past DKG check",
+		},
+		{
+			name: "pass: self-unstake allowed when HasFinalizedRegistration errors",
+			setupMocks: func(ak *moduletestutil.MockAccountKeeper, mockSK *moduletestutil.MockStakingKeeper, dkgk *moduletestutil.MockDKGKeeper) {
+				mockSK.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(0), nil)
+				ak.EXPECT().HasAccount(gomock.Any(), gomock.Any()).Return(true)
+				dkgk.EXPECT().GetLatestActiveRound(gomock.Any()).Return(activeRound, nil)
+				dkgk.EXPECT().HasFinalizedRegistration(gomock.Any(), activeRound.CodeCommitment, activeRound.Round, valEvmAddr).Return(false, errors.New("dkg error"))
+				mockSK.EXPECT().GetLockedTokenType(gomock.Any()).Return(int32(0), errors.New("stop: past DKG check"))
+			},
+			withdraw:  createSelfUnstake(),
+			expectErr: "stop: past DKG check",
+		},
+		{
+			name: "pass: non-self unstake not blocked even with DKG active round",
+			setupMocks: func(ak *moduletestutil.MockAccountKeeper, mockSK *moduletestutil.MockStakingKeeper, dkgk *moduletestutil.MockDKGKeeper) {
+				mockSK.EXPECT().GetSingularityHeight(gomock.Any()).Return(uint64(0), nil)
+				ak.EXPECT().HasAccount(gomock.Any(), gomock.Any()).Return(true)
+				// No DKG keeper mock expectations: DKG check is not entered for non-self unstake
+				mockSK.EXPECT().GetLockedTokenType(gomock.Any()).Return(int32(0), errors.New("stop: past DKG check"))
+			},
+			withdraw:  createNonSelfUnstake(),
+			expectErr: "stop: past DKG check",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, ak, _, _, mockSK, _, dkgk, esk := createKeeperWithMockStaking(t)
+
+			tc.setupMocks(ak, mockSK, dkgk)
+
+			cachedCtx, _ := ctx.CacheContext()
+			err := esk.ProcessWithdraw(cachedCtx, tc.withdraw)
+			require.ErrorContains(t, err, tc.expectErr)
 		})
 	}
 }

--- a/client/x/evmstaking/testutil/expected_keepers_mocks.go
+++ b/client/x/evmstaking/testutil/expected_keepers_mocks.go
@@ -21,6 +21,8 @@ import (
 	types0 "github.com/cosmos/cosmos-sdk/types"
 	types1 "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	types2 "github.com/cosmos/cosmos-sdk/x/staking/types"
+	common "github.com/ethereum/go-ethereum/common"
+	types3 "github.com/piplabs/story/client/x/dkg/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -787,6 +789,36 @@ func (m *MockDKGKeeper) DistributeRewardsToActiveCommittee(ctx context.Context, 
 func (mr *MockDKGKeeperMockRecorder) DistributeRewardsToActiveCommittee(ctx, senderModule, totalAmount any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributeRewardsToActiveCommittee", reflect.TypeOf((*MockDKGKeeper)(nil).DistributeRewardsToActiveCommittee), ctx, senderModule, totalAmount)
+}
+
+// GetLatestActiveRound mocks base method.
+func (m *MockDKGKeeper) GetLatestActiveRound(ctx context.Context) (*types3.DKGNetwork, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestActiveRound", ctx)
+	ret0, _ := ret[0].(*types3.DKGNetwork)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestActiveRound indicates an expected call of GetLatestActiveRound.
+func (mr *MockDKGKeeperMockRecorder) GetLatestActiveRound(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestActiveRound", reflect.TypeOf((*MockDKGKeeper)(nil).GetLatestActiveRound), ctx)
+}
+
+// HasFinalizedRegistration mocks base method.
+func (m *MockDKGKeeper) HasFinalizedRegistration(ctx context.Context, codeCommitment []byte, round uint32, validatorAddr common.Address) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasFinalizedRegistration", ctx, codeCommitment, round, validatorAddr)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasFinalizedRegistration indicates an expected call of HasFinalizedRegistration.
+func (mr *MockDKGKeeperMockRecorder) HasFinalizedRegistration(ctx, codeCommitment, round, validatorAddr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasFinalizedRegistration", reflect.TypeOf((*MockDKGKeeper)(nil).HasFinalizedRegistration), ctx, codeCommitment, round, validatorAddr)
 }
 
 // MockDistributionKeeper is a mock of DistributionKeeper interface.

--- a/client/x/evmstaking/types/expected_keepers.go
+++ b/client/x/evmstaking/types/expected_keepers.go
@@ -12,6 +12,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	dkgtypes "github.com/piplabs/story/client/x/dkg/types"
 )
 
 // AccountKeeper defines the expected account keeper (noalias).
@@ -84,6 +88,8 @@ type SlashingKeeper interface {
 
 // DKGKeeper defines the expected interface for the DKG module.
 type DKGKeeper interface {
+	GetLatestActiveRound(ctx context.Context) (*dkgtypes.DKGNetwork, error)
+	HasFinalizedRegistration(ctx context.Context, codeCommitment []byte, round uint32, validatorAddr common.Address) (bool, error)
 	// DistributeRewardsToActiveCommittee distributes the configured portion of UBI
 	// to active DKG committee members. The senderModule must hold totalAmount coins.
 	// Returns the total amount distributed to committee members (0 if no active committee).

--- a/lib/errors/codes.go
+++ b/lib/errors/codes.go
@@ -7,72 +7,75 @@ import (
 type ErrCode uint32
 
 const (
-	Unspecified              ErrCode = 0
-	UnexpectedCondition      ErrCode = 1
-	InvalidCmpPubKey         ErrCode = 2
-	ValidatorNotFound        ErrCode = 3
-	ValidatorAlreadyExists   ErrCode = 4
-	InvalidTokenType         ErrCode = 5
-	InvalidOperator          ErrCode = 6
-	InvalidCommissionRate    ErrCode = 7
-	InvalidMinSelfDelegation ErrCode = 8
-	InvalidPeriodType        ErrCode = 9
-	InvalidDelegationAmount  ErrCode = 10
-	DelegationNotFound       ErrCode = 11
-	PeriodDelegationNotFound ErrCode = 12
-	InvalidRequest           ErrCode = 13
-	SelfRedelegation         ErrCode = 14
-	TokenTypeMismatch        ErrCode = 15
-	MissingSelfDelegation    ErrCode = 16
-	ValidatorNotJailed       ErrCode = 17
-	ValidatorStillJailed     ErrCode = 18
-	PendingUpgradeExists     ErrCode = 19
+	Unspecified                ErrCode = 0
+	UnexpectedCondition        ErrCode = 1
+	InvalidCmpPubKey           ErrCode = 2
+	ValidatorNotFound          ErrCode = 3
+	ValidatorAlreadyExists     ErrCode = 4
+	InvalidTokenType           ErrCode = 5
+	InvalidOperator            ErrCode = 6
+	InvalidCommissionRate      ErrCode = 7
+	InvalidMinSelfDelegation   ErrCode = 8
+	InvalidPeriodType          ErrCode = 9
+	InvalidDelegationAmount    ErrCode = 10
+	DelegationNotFound         ErrCode = 11
+	PeriodDelegationNotFound   ErrCode = 12
+	InvalidRequest             ErrCode = 13
+	SelfRedelegation           ErrCode = 14
+	TokenTypeMismatch          ErrCode = 15
+	MissingSelfDelegation      ErrCode = 16
+	ValidatorNotJailed         ErrCode = 17
+	ValidatorStillJailed       ErrCode = 18
+	PendingUpgradeExists       ErrCode = 19
+	ActiveDKGMemberSelfUnstake ErrCode = 20
 )
 
 var (
-	ErrUnspecified              = stderrors.New("unspecified")
-	ErrUnexpectedCondition      = stderrors.New("unexpected_condition")
-	ErrInvalidCmpPubKey         = stderrors.New("invalid_compressed_pubkey")
-	ErrValidatorNotFound        = stderrors.New("validator_not_found")
-	ErrValidatorAlreadyExists   = stderrors.New("validator_already_exists")
-	ErrInvalidTokenType         = stderrors.New("invalid_token_type")
-	ErrInvalidOperator          = stderrors.New("invalid_operator")
-	ErrInvalidCommissionRate    = stderrors.New("invalid_commission_rate")
-	ErrInvalidMinSelfDelegation = stderrors.New("invalid_min_self_delegation")
-	ErrInvalidPeriodType        = stderrors.New("invalid_period_type")
-	ErrInvalidDelegationAmount  = stderrors.New("invalid_delegation_amount")
-	ErrDelegationNotFound       = stderrors.New("delegation_not_found")
-	ErrPeriodDelegationNotFound = stderrors.New("period_delegation_not_found")
-	ErrInvalidRequest           = stderrors.New("invalid_request")
-	ErrSelfRedelegation         = stderrors.New("self_redelegation")
-	ErrTokenTypeMismatch        = stderrors.New("token_type_mismatch")
-	ErrMissingSelfDelegation    = stderrors.New("missing_self_delegation")
-	ErrValidatorNotJailed       = stderrors.New("validator_not_jailed")
-	ErrValidatorStillJailed     = stderrors.New("validator_still_jailed")
-	ErrPendingUpgradeExists     = stderrors.New("pending_upgrade_exists")
+	ErrUnspecified                = stderrors.New("unspecified")
+	ErrUnexpectedCondition        = stderrors.New("unexpected_condition")
+	ErrInvalidCmpPubKey           = stderrors.New("invalid_compressed_pubkey")
+	ErrValidatorNotFound          = stderrors.New("validator_not_found")
+	ErrValidatorAlreadyExists     = stderrors.New("validator_already_exists")
+	ErrInvalidTokenType           = stderrors.New("invalid_token_type")
+	ErrInvalidOperator            = stderrors.New("invalid_operator")
+	ErrInvalidCommissionRate      = stderrors.New("invalid_commission_rate")
+	ErrInvalidMinSelfDelegation   = stderrors.New("invalid_min_self_delegation")
+	ErrInvalidPeriodType          = stderrors.New("invalid_period_type")
+	ErrInvalidDelegationAmount    = stderrors.New("invalid_delegation_amount")
+	ErrDelegationNotFound         = stderrors.New("delegation_not_found")
+	ErrPeriodDelegationNotFound   = stderrors.New("period_delegation_not_found")
+	ErrInvalidRequest             = stderrors.New("invalid_request")
+	ErrSelfRedelegation           = stderrors.New("self_redelegation")
+	ErrTokenTypeMismatch          = stderrors.New("token_type_mismatch")
+	ErrMissingSelfDelegation      = stderrors.New("missing_self_delegation")
+	ErrValidatorNotJailed         = stderrors.New("validator_not_jailed")
+	ErrValidatorStillJailed       = stderrors.New("validator_still_jailed")
+	ErrPendingUpgradeExists       = stderrors.New("pending_upgrade_exists")
+	ErrActiveDKGMemberSelfUnstake = stderrors.New("active_dkg_member_self_unstake")
 )
 
 var codeToErr = map[ErrCode]error{
-	Unspecified:              ErrUnspecified,
-	UnexpectedCondition:      ErrUnexpectedCondition,
-	InvalidCmpPubKey:         ErrInvalidCmpPubKey,
-	ValidatorNotFound:        ErrValidatorNotFound,
-	ValidatorAlreadyExists:   ErrValidatorAlreadyExists,
-	InvalidTokenType:         ErrInvalidTokenType,
-	InvalidOperator:          ErrInvalidOperator,
-	InvalidCommissionRate:    ErrInvalidCommissionRate,
-	InvalidMinSelfDelegation: ErrInvalidMinSelfDelegation,
-	InvalidPeriodType:        ErrInvalidPeriodType,
-	InvalidDelegationAmount:  ErrInvalidDelegationAmount,
-	DelegationNotFound:       ErrDelegationNotFound,
-	PeriodDelegationNotFound: ErrPeriodDelegationNotFound,
-	InvalidRequest:           ErrInvalidRequest,
-	SelfRedelegation:         ErrSelfRedelegation,
-	TokenTypeMismatch:        ErrTokenTypeMismatch,
-	MissingSelfDelegation:    ErrMissingSelfDelegation,
-	ValidatorNotJailed:       ErrValidatorNotJailed,
-	ValidatorStillJailed:     ErrValidatorStillJailed,
-	PendingUpgradeExists:     ErrPendingUpgradeExists,
+	Unspecified:                ErrUnspecified,
+	UnexpectedCondition:        ErrUnexpectedCondition,
+	InvalidCmpPubKey:           ErrInvalidCmpPubKey,
+	ValidatorNotFound:          ErrValidatorNotFound,
+	ValidatorAlreadyExists:     ErrValidatorAlreadyExists,
+	InvalidTokenType:           ErrInvalidTokenType,
+	InvalidOperator:            ErrInvalidOperator,
+	InvalidCommissionRate:      ErrInvalidCommissionRate,
+	InvalidMinSelfDelegation:   ErrInvalidMinSelfDelegation,
+	InvalidPeriodType:          ErrInvalidPeriodType,
+	InvalidDelegationAmount:    ErrInvalidDelegationAmount,
+	DelegationNotFound:         ErrDelegationNotFound,
+	PeriodDelegationNotFound:   ErrPeriodDelegationNotFound,
+	InvalidRequest:             ErrInvalidRequest,
+	SelfRedelegation:           ErrSelfRedelegation,
+	TokenTypeMismatch:          ErrTokenTypeMismatch,
+	MissingSelfDelegation:      ErrMissingSelfDelegation,
+	ValidatorNotJailed:         ErrValidatorNotJailed,
+	ValidatorStillJailed:       ErrValidatorStillJailed,
+	PendingUpgradeExists:       ErrPendingUpgradeExists,
+	ActiveDKGMemberSelfUnstake: ErrActiveDKGMemberSelfUnstake,
 }
 
 func (c ErrCode) String() string {
@@ -134,6 +137,8 @@ func UnwrapErrCode(err error) ErrCode {
 		return ValidatorStillJailed
 	case stderrors.Is(err, ErrPendingUpgradeExists):
 		return PendingUpgradeExists
+	case stderrors.Is(err, ErrActiveDKGMemberSelfUnstake):
+		return ActiveDKGMemberSelfUnstake
 	default:
 		return Unspecified
 	}


### PR DESCRIPTION
## Summary

 - Block validators from self-unstaking while they are in the active DKG round
 - Add `HasFinalizedRegistration` query to the DKG keeper and expose `GetLatestActiveRound` as a public method
 - Add `ActiveDKGMemberSelfUnstake` error code to the error codes registry
 - Fix `getLatestActiveDKGNetwork` to return `nil, nil` instead of error when no active round exists (propagated to `shouldReshare`, `DistributeRewardsToActiveCommittee`, `settleRewardsForPreviousCommittee`, `isInPrevActiveValSet`, and the gRPC query)

issue: none
