### PR TITLE
feat(dkg): replace hardcoded enclave type with config driven value

### DIFF
--- a/client/app/start.go
+++ b/client/app/start.go
@@ -224,7 +224,8 @@ func CreateApp(ctx context.Context, cfg Config) (*App, *privval.FilePV, error) {
 	app.Keepers.EVMEngKeeper.SetValidatorAddress(addr)
 
 	if cfg.DKG.Enable {
-		if err := app.Keepers.DKGKeeper.InitDKGService(cfg.DKGStateDir(), addr); err != nil {
+		enclaveType := storycfg.EnclaveTypeToBytes32(cfg.DKG.EnclaveType)
+		if err := app.Keepers.DKGKeeper.InitDKGService(cfg.DKGStateDir(), addr, enclaveType); err != nil {
 			return nil, nil, errors.Wrap(err, "dkg service is enabled, but failed to init dkg service")
 		}
 	}

--- a/client/config/config.toml.tmpl
+++ b/client/config/config.toml.tmpl
@@ -136,3 +136,6 @@ tee-endpoint = "{{ .DKG.TEEEndpoint }}"
 
 # The RPC endpoint of execution layer
 engine-rpc-endpoint = "{{ .DKG.EngineRPCEndpoint }}"
+
+# TEE enclave type identifier (e.g. 1 for SGX)
+enc-type = {{ .DKG.EnclaveType }}

--- a/client/config/dkg_config.go
+++ b/client/config/dkg_config.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"encoding/binary"
+
 	"github.com/piplabs/story/lib/errors"
 	"github.com/spf13/pflag"
 )
+
+const DefaultEnclaveType uint64 = 1 // SGX
 
 type DKGConfig struct {
 	// Enable enables or disables the DKG client
@@ -14,6 +18,9 @@ type DKGConfig struct {
 
 	// EngineRPCEndpoint is the RPC endpoint of the execution layer
 	EngineRPCEndpoint string
+
+	// EnclaveType is the TEE enclave type identifier (e.g. 1 for SGX), stored as bytes32 on-chain
+	EnclaveType uint64
 }
 
 func DefaultDKGConfig() DKGConfig {
@@ -21,6 +28,7 @@ func DefaultDKGConfig() DKGConfig {
 		Enable:            false,
 		TEEEndpoint:       "127.0.0.1:50051",
 		EngineRPCEndpoint: "http://127.0.0.1:8545",
+		EnclaveType:       DefaultEnclaveType,
 	}
 }
 
@@ -28,6 +36,7 @@ func BindDKGFlags(flags *pflag.FlagSet, cfg *DKGConfig) {
 	flags.BoolVar(&cfg.Enable, "dkg-enable", cfg.Enable, "DKG client is enabled or not")
 	flags.StringVar(&cfg.TEEEndpoint, "dkg-tee-endpoint", cfg.TEEEndpoint, "The endpoint of TEE client for DKG")
 	flags.StringVar(&cfg.EngineRPCEndpoint, "dkg-engine-rpc-endpoint", cfg.EngineRPCEndpoint, "The RPC endpoint of execution layer")
+	flags.Uint64Var(&cfg.EnclaveType, "dkg-enc-type", cfg.EnclaveType, "TEE enclave type identifier (e.g. 1 for SGX)")
 }
 
 func (c *DKGConfig) Validate() error {
@@ -43,5 +52,17 @@ func (c *DKGConfig) Validate() error {
 		return errors.New("engine rpc endpoint should not be empty")
 	}
 
+	if c.EnclaveType == 0 {
+		return errors.New("enc-type must not be zero")
+	}
+
 	return nil
+}
+
+// EnclaveTypeToBytes32 converts a uint64 enclave type to a [32]byte (big-endian, right-aligned).
+func EnclaveTypeToBytes32(v uint64) [32]byte {
+	var result [32]byte
+	binary.BigEndian.PutUint64(result[24:], v)
+
+	return result
 }

--- a/client/config/testdata/story.toml
+++ b/client/config/testdata/story.toml
@@ -132,3 +132,6 @@ tee-endpoint = "127.0.0.1:50051"
 
 # The RPC endpoint of execution layer
 engine-rpc-endpoint = "http://127.0.0.1:8545"
+
+# TEE enclave type identifier (e.g. 1 for SGX)
+enc-type = 1

--- a/client/x/dkg/keeper/contract_client.go
+++ b/client/x/dkg/keeper/contract_client.go
@@ -98,10 +98,10 @@ func NewContractClient(ctx context.Context, engineEndpoint string, engineChainID
 }
 
 // Register calls the register contract method.
-func (c *ContractClient) Register(ctx context.Context, round uint32, codeCommitment []byte, startBlockHeight uint64, startBlockHash []byte, dkgPubKey []byte, commPubKey []byte, enclaveReport []byte) (*types.Receipt, error) {
+func (c *ContractClient) Register(ctx context.Context, round uint32, enclaveType [32]byte, startBlockHeight uint64, startBlockHash []byte, dkgPubKey []byte, commPubKey []byte, enclaveReport []byte) (*types.Receipt, error) {
 	log.Info(ctx, "Calling register contract method",
 		"round", round,
-		"code_commitment", hex.EncodeToString(codeCommitment),
+		"enclave_type", hex.EncodeToString(enclaveType[:]),
 		"start_block_height", startBlockHeight,
 		"start_block_hash", hex.EncodeToString(startBlockHash),
 		"dkg_pub_key", hex.EncodeToString(dkgPubKey),
@@ -113,10 +113,6 @@ func (c *ContractClient) Register(ctx context.Context, round uint32, codeCommitm
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert startBlockHash to bytes32")
 	}
-
-	// TODO: retrieve enclaveType from session instead of hardcoding
-	var enclaveType [32]byte
-	enclaveType[31] = 1 // bytes32(1) for SGX
 
 	enclaveInstanceData := bindings.IDKGEnclaveInstanceData{
 		Round:          round,
@@ -142,7 +138,7 @@ func (c *ContractClient) Register(ctx context.Context, round uint32, codeCommitm
 func (c *ContractClient) Finalize(
 	ctx context.Context,
 	round uint32,
-	codeCommitment []byte,
+	enclaveType [32]byte,
 	participantsRoot []byte,
 	globalPubKey []byte,
 	publicCoeffs [][]byte,
@@ -150,16 +146,12 @@ func (c *ContractClient) Finalize(
 	signature []byte,
 ) (*types.Receipt, error) {
 	log.Info(ctx, "Calling finalize contract method",
-		"code_commitment", hex.EncodeToString(codeCommitment),
+		"enclave_type", hex.EncodeToString(enclaveType[:]),
 		"round", round,
 		"global_pub_key", hex.EncodeToString(globalPubKey),
 		"pub_key_share", hex.EncodeToString(pubKeyShare),
 		"signature_len", len(signature),
 	)
-
-	// TODO: retrieve enclaveType from session instead of hardcoding
-	var enclaveType [32]byte
-	enclaveType[31] = 1 // bytes32(1) for SGX
 
 	participantsRoot32, err := cast.ToBytes32(participantsRoot)
 	if err != nil {

--- a/client/x/dkg/keeper/dkg_svc_finalization.go
+++ b/client/x/dkg/keeper/dkg_svc_finalization.go
@@ -139,7 +139,7 @@ func (k *Keeper) callContractFinalizeDKG(ctx context.Context, session *types.DKG
 	if _, err := k.contractClient.Finalize(
 		ctx,
 		session.Round,
-		session.CodeCommitment,
+		session.EnclaveType,
 		session.ParticipantsRoot,
 		session.GlobalPubKey,
 		session.PublicCoeffs,

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -36,7 +36,7 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 	// we still create a session. Old members do not generate new keys, but they still
 	// participate in later stages (especially dealing, and finalization).
 	// Therefore, a session must exist regardless of key generation eligibility.
-	session := types.NewDKGSession(dkgNetwork.CodeCommitment, dkgNetwork.Round, dkgNetwork.ActiveValSet, dkgNetwork.IsResharing)
+	session := types.NewDKGSession(dkgNetwork.CodeCommitment, dkgNetwork.Round, dkgNetwork.ActiveValSet, dkgNetwork.IsResharing, k.enclaveType)
 	if err := k.stateManager.CreateSession(ctx, session); err != nil {
 		log.Error(ctx, "Failed to create DKG session", err)
 		k.stateManager.MarkFailed(ctx, session)
@@ -149,7 +149,7 @@ func (k *Keeper) callContractRegister(ctx context.Context, session *types.DKGSes
 	if _, err := k.contractClient.Register(
 		ctx,
 		session.Round,
-		session.CodeCommitment,
+		session.EnclaveType,
 		uint64(session.StartBlockHeight),
 		session.StartBlockHash,
 		session.DKGPubKey,

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -41,7 +41,8 @@ type Keeper struct {
 	distributionKeeper types.DistributionKeeper
 
 	isDKGSvcEnabled  bool
-	validatorEVMAddr string // EVM address of the validator
+	validatorEVMAddr string   // EVM address of the validator
+	enclaveType      [32]byte // TEE enclave type identifier
 
 	Schema            collections.Schema
 	ParamsStore       collections.Item[types.Params]
@@ -108,9 +109,10 @@ func (k *Keeper) RegisterProposalService(server grpc.Server) {
 	types.RegisterMsgServiceServer(server, NewProposalServer(k))
 }
 
-func (k *Keeper) InitDKGService(stateDir string, addr common.Address) error {
+func (k *Keeper) InitDKGService(stateDir string, addr common.Address, enclaveType [32]byte) error {
 	k.setIsDKGSvcEnabled()
 	k.setValidatorAddress(addr)
+	k.enclaveType = enclaveType
 
 	stateManager, err := NewStateManager(stateDir)
 	if err != nil {

--- a/client/x/dkg/types/dkg.go
+++ b/client/x/dkg/types/dkg.go
@@ -62,6 +62,7 @@ type DKGSession struct {
 	PublicCoeffs       [][]byte  `json:"public_coeffs"`
 	PubKeyShare        []byte    `json:"pub_key_share"`
 	ParticipantsRoot   []byte    `json:"participants_root"`
+	EnclaveType        [32]byte  `json:"enclave_type"`
 
 	// Network information
 	ActiveValidators []string `json:"active_validators"`
@@ -80,7 +81,7 @@ type DKGSession struct {
 }
 
 // NewDKGSession creates a new DKG session from blockchain event data.
-func NewDKGSession(codeCommitment []byte, round uint32, activeValidators []string, isResharing bool) *DKGSession {
+func NewDKGSession(codeCommitment []byte, round uint32, activeValidators []string, isResharing bool, enclaveType [32]byte) *DKGSession {
 	now := time.Now()
 
 	return &DKGSession{
@@ -96,6 +97,7 @@ func NewDKGSession(codeCommitment []byte, round uint32, activeValidators []strin
 		Threshold:        0,
 		IsFinalized:      false,
 		IsResharing:      isResharing,
+		EnclaveType:      enclaveType,
 
 		DecryptRequests: make([]DecryptRequest, 0),
 	}


### PR DESCRIPTION
## Summary

  - Add `enc-type` config field to `[dkg]` section in `story.toml` (uint64, default: 1)
  - Add `--dkg-enc-type` CLI flag
  - Store enclave type in `DKGSession` and pass to `ContractClient.Register` / `Finalize`
  - Remove previously hardcoded `bytes32(1)` from `contract_client.go`

issue: none
