### PR TITLE
feat(contracts): add script to deploy contracts

### DIFF
--- a/client/x/dkg/keeper/abci.go
+++ b/client/x/dkg/keeper/abci.go
@@ -77,6 +77,15 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 		}
 	}
 
+	if k.isDKGSvcEnabled {
+		// Resume stuck or failed DKG sessions every block.
+		k.ResumeDKGService(ctx, latestRound)
+
+		// Retry cached deals/responses/justifications that failed kernel processing.
+		// Deals are replayed before responses (kyber requires deal-before-response order).
+		k.reprocessPendingIncomingData(latestRound)
+	}
+
 	nextStage, shouldTransition := k.shouldTransitionStage(currentHeight, latestRound, params)
 	if shouldTransition {
 		// Update the stage of this round before emitting events

--- a/client/x/dkg/keeper/contract_client.go
+++ b/client/x/dkg/keeper/contract_client.go
@@ -151,7 +151,15 @@ func (c *ContractClient) Register(ctx context.Context, round uint32, enclaveType
 		return nil, errors.Wrap(err, "failed to pack register call data")
 	}
 
-	return c.sendWithRetry(ctx, "Register", c.dkgContractAddr, callData, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+	// Query the registration fee from the DKG contract
+	fee, err := c.dkgContract.Fee(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query DKG fee")
+	}
+
+	log.Info(ctx, "DKG registration fee queried", "fee_wei", fee.String())
+
+	return c.sendWithRetry(ctx, "Register", c.dkgContractAddr, callData, fee, func(auth *bind.TransactOpts) (*types.Transaction, error) {
 		return c.dkgContract.Register(auth, enclaveReport, enclaveInstanceData, startBlockHeightBig, startBlockHash32, []byte{})
 	})
 }
@@ -185,7 +193,15 @@ func (c *ContractClient) Finalize(
 		return nil, errors.Wrap(err, "failed to pack finalize call data")
 	}
 
-	return c.sendWithRetry(ctx, "Finalize", c.dkgContractAddr, callData, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+	// Query the DKG fee — the contract requires it for finalization as well.
+	fee, err := c.dkgContract.Fee(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query DKG fee for finalize")
+	}
+
+	log.Info(ctx, "DKG finalization fee queried", "fee_wei", fee.String())
+
+	return c.sendWithRetry(ctx, "Finalize", c.dkgContractAddr, callData, fee, func(auth *bind.TransactOpts) (*types.Transaction, error) {
 		return c.dkgContract.Finalize(auth, round, c.fromAddress, enclaveType, participantsRoot32, globalPubKey, publicCoeffs, pubKeyShare, signature)
 	})
 }
@@ -218,13 +234,21 @@ func (c *ContractClient) SubmitEncryptedPartialDecryption(
 		return nil, errors.Wrap(err, "failed to pack submitEncryptedPartialDecryption call data")
 	}
 
-	return c.sendWithRetry(ctx, "SubmitEncryptedPartialDecryption", c.cdrContractAddr, callData, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+	fee, err := c.cdrContract.BaseFee(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query CDR base fee for partial decryption")
+	}
+
+	log.Info(ctx, "CDR base fee queried for partial decryption", "fee_wei", fee.String())
+
+	return c.sendWithRetry(ctx, "SubmitEncryptedPartialDecryption", c.cdrContractAddr, callData, fee, func(auth *bind.TransactOpts) (*types.Transaction, error) {
 		return c.cdrContract.SubmitEncryptedPartialDecryption(auth, round, pid, encryptedPartial, ephemeralPubKey, pubShare, requesterPubKey, uuid, signature)
 	})
 }
 
 // createTransactOpts creates transaction options for contract calls.
-func (c *ContractClient) createTransactOpts(ctx context.Context, gasLimit uint64) (*bind.TransactOpts, error) {
+// If value is nil, it defaults to 0.
+func (c *ContractClient) createTransactOpts(ctx context.Context, gasLimit uint64, value *big.Int) (*bind.TransactOpts, error) {
 	nonce, err := c.ethClient.PendingNonceAt(ctx, c.fromAddress)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pending nonce")
@@ -240,8 +264,12 @@ func (c *ContractClient) createTransactOpts(ctx context.Context, gasLimit uint64
 		return nil, errors.Wrap(err, "failed to create transactor")
 	}
 
+	if value == nil {
+		value = big.NewInt(0)
+	}
+
 	auth.Nonce = big.NewInt(int64(nonce))
-	auth.Value = big.NewInt(0) // in wei
+	auth.Value = value
 	auth.GasLimit = gasLimit
 	auth.GasPrice = gasPrice
 	auth.Context = ctx
@@ -250,11 +278,12 @@ func (c *ContractClient) createTransactOpts(ctx context.Context, gasLimit uint64
 }
 
 // estimateGasWithBuffer estimates gas for a contract transaction and adds a safety buffer.
-func (c *ContractClient) estimateGasWithBuffer(ctx context.Context, to common.Address, data []byte) (uint64, error) {
+func (c *ContractClient) estimateGasWithBuffer(ctx context.Context, to common.Address, data []byte, value *big.Int) (uint64, error) {
 	msg := ethereum.CallMsg{
-		From: c.fromAddress,
-		To:   &to,
-		Data: data,
+		From:  c.fromAddress,
+		To:    &to,
+		Data:  data,
+		Value: value,
 	}
 
 	gasLimit, err := c.ethClient.EstimateGas(ctx, msg)
@@ -289,6 +318,7 @@ func (c *ContractClient) sendWithRetry(
 	methodName string,
 	to common.Address,
 	callData []byte,
+	value *big.Int,
 	sendTx func(auth *bind.TransactOpts) (*types.Transaction, error),
 ) (*types.Receipt, error) {
 	var (
@@ -298,12 +328,12 @@ func (c *ContractClient) sendWithRetry(
 	)
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		gasLimit, err = c.estimateGasWithBuffer(ctx, to, callData)
+		gasLimit, err = c.estimateGasWithBuffer(ctx, to, callData, value)
 		if err != nil {
 			return nil, err
 		}
 
-		auth, err := c.createTransactOpts(ctx, gasLimit)
+		auth, err := c.createTransactOpts(ctx, gasLimit, value)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create transact opts", "method_name", methodName)
 		}

--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -3,9 +3,13 @@ package keeper
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
+
+	"go.dedis.ch/kyber/v4/group/edwards25519"
 )
 
 func (k *Keeper) BeginDealing(ctx context.Context, latestRound *types.DKGNetwork) error {
@@ -51,12 +55,30 @@ func (k *Keeper) BeginDealing(ctx context.Context, latestRound *types.DKGNetwork
 	}
 
 	if k.isDKGSvcEnabled {
+		// Set session.Index from on-chain registration while SDK context is available.
+		// Session.Index stores the 1-based registration index used for deal/response
+		// routing (converted to 0-based for Kyber) and threshold decryption PID.
+		if err := k.ensureSessionIndex(ctx, latestRound.Round); err != nil {
+			log.Warn(ctx, "Failed to set session index from registration", err,
+				"round", latestRound.Round,
+			)
+		}
+
+		// Pre-compute shouldDeal while SDK context is available.
+		// The async goroutine cannot access the KV store.
+		deal, err := k.shouldDeal(ctx, latestRound)
+		if err != nil {
+			log.Error(ctx, "Failed to check whether the validator should deal", err)
+
+			return nil
+		}
+
 		asyncCtx, cancel := dkgAsyncContext()
 
 		go func() {
 			defer cancel()
 
-			k.handleDKGDealing(asyncCtx, latestRound)
+			k.handleDKGDealing(asyncCtx, latestRound, deal)
 		}()
 	}
 
@@ -86,12 +108,20 @@ func (k *Keeper) ProcessJustifications(ctx context.Context, latestRound *types.D
 	}
 
 	if k.isDKGSvcEnabled {
+		// Pre-compute dealer pub key map while SDK context is available,
+		// because async goroutines cannot access the KV store.
+		suite := edwards25519.NewBlakeSHA256Ed25519()
+		dealerPubKeys, err := k.buildDealerPubKeyMap(ctx, latestRound, suite)
+		if err != nil {
+			return errors.Wrap(err, "build dealer pub key map")
+		}
+
 		asyncCtx, cancel := dkgAsyncContext()
 
 		go func() {
 			defer cancel()
 
-			k.handleDKGProcessJustifications(asyncCtx, latestRound, justifications)
+			k.handleDKGProcessJustifications(asyncCtx, latestRound, justifications, dealerPubKeys)
 		}()
 	}
 
@@ -122,14 +152,51 @@ func (k *Keeper) ProcessResponses(ctx context.Context, latestRound *types.DKGNet
 	}
 
 	if k.isDKGSvcEnabled {
+		// Pre-compute shouldProcessResponses while SDK context is available.
+		shouldProcess, err := k.shouldProcessResponses(ctx, latestRound)
+		if err != nil {
+			log.Error(ctx, "Failed to check shouldProcessResponses", err)
+
+			return nil
+		}
+
 		asyncCtx, cancel := dkgAsyncContext()
 
 		go func() {
 			defer cancel()
 
-			k.handleDKGProcessResponses(asyncCtx, latestRound, responses)
+			k.handleDKGProcessResponses(asyncCtx, latestRound, responses, shouldProcess)
 		}()
 	}
 
 	return nil
+}
+
+// ensureSessionIndex sets the session's 1-based index from the on-chain registration,
+// if not already set. Must be called from a context where the KV store is accessible.
+// For old-only resharing members who have no registration in the current round,
+// the index remains 0 (unset).
+func (k *Keeper) ensureSessionIndex(ctx context.Context, round uint32) error {
+	session, err := k.stateManager.GetSession(round)
+	if err != nil {
+		return err
+	}
+
+	if session.Index != 0 {
+		return nil
+	}
+
+	reg, err := k.getDKGRegistration(ctx, round, common.HexToAddress(k.validatorEVMAddr))
+	if err != nil {
+		return errors.Wrap(err, "registration lookup failed")
+	}
+
+	session.Index = reg.Index
+
+	log.Info(ctx, "Session index set from on-chain registration",
+		"round", round,
+		"index", session.Index,
+	)
+
+	return k.stateManager.UpdateSession(ctx, session)
 }

--- a/client/x/dkg/keeper/dkg_handler.go
+++ b/client/x/dkg/keeper/dkg_handler.go
@@ -103,10 +103,6 @@ func (k *Keeper) Finalized(ctx context.Context, round uint32, msgSender common.A
 		return errors.New(fmt.Sprintf("round mismatch: expected %d, got %d)", latest.Round, round))
 	}
 
-	if err := k.validateParticipantsRoot(ctx, round, participantsRoot); err != nil {
-		return errors.Wrap(err, "failed to validate participants root")
-	}
-
 	if latest.Stage != types.DKGStageFinalization {
 		return errors.New("round is not in network set stage")
 	}
@@ -125,6 +121,10 @@ func (k *Keeper) Finalized(ctx context.Context, round uint32, msgSender common.A
 	// Reject finalization by invalidated dealers (deal complaint found invalid via VSS verification)
 	if reg.Status == types.DKGRegStatusInvalidated {
 		return errors.New("dealer has been invalidated and cannot finalize")
+	}
+
+	if err := k.validateParticipantsRoot(ctx, round, participantsRoot); err != nil {
+		return errors.Wrap(err, "failed to validate participants root")
 	}
 
 	if err := verifyFinalizationSignature(reg.CommPubKey, round, codeCommitment, participantsRoot, globalPubKey, publicCoeffs, pubKeyShare, signature); err != nil {
@@ -161,18 +161,28 @@ func (k *Keeper) Finalized(ctx context.Context, round uint32, msgSender common.A
 }
 
 // validateParticipantsRoot validates the root hash of the participants.
+// It considers both Verified and Finalized registrations because earlier
+// finalization events transition registrations from Verified to Finalized,
+// so by the time later validators finalize, some registrations are already Finalized.
 func (k *Keeper) validateParticipantsRoot(ctx context.Context, round uint32, participantsRoot [32]byte) error {
 	verifiedRegs, err := k.getDKGRegistrationsByStatus(ctx, round, types.DKGRegStatusVerified)
 	if err != nil {
 		return errors.Wrap(err, "failed to get verified DKG registration")
 	}
 
-	if len(verifiedRegs) == 0 {
-		return errors.New("no verified DKG registrations found")
+	finalizedRegs, err := k.getDKGRegistrationsByStatus(ctx, round, types.DKGRegStatusFinalized)
+	if err != nil {
+		return errors.Wrap(err, "failed to get finalized DKG registration")
 	}
 
-	addrs := make([]string, 0, len(verifiedRegs))
-	for _, reg := range verifiedRegs {
+	allRegs := append(verifiedRegs, finalizedRegs...)
+
+	if len(allRegs) == 0 {
+		return errors.New("no verified or finalized DKG registrations found")
+	}
+
+	addrs := make([]string, 0, len(allRegs))
+	for _, reg := range allRegs {
 		addr := strings.ToLower(strings.TrimSpace(reg.ValidatorAddr))
 		if !common.IsHexAddress(addr) {
 			return errors.New("invalid validator evm address in verified registrations", "validator_addr", reg.ValidatorAddr)

--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/piplabs/story/client/server/utils"
 	"github.com/piplabs/story/client/x/dkg/types"
@@ -79,16 +80,50 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 	}
 
 	if k.isDKGSvcEnabled {
+		// Skip registration if this validator already has an on-chain registration
+		// for this round. This prevents overwriting a valid registration with
+		// different keys after a reset where sealed_keys were deleted.
+		if k.isAlreadyRegistered(ctx, roundNum) {
+			return nil
+		}
+
+		// Pre-compute old code commitment while we still have SDK context.
+		// The async goroutine uses context.Background() which cannot access
+		// the Cosmos KV store.
+		oldCC, _ := k.getOldCodeCommitment(ctx)
+
 		asyncCtx, cancel := dkgAsyncContext()
 
 		go func() {
 			defer cancel()
 
-			k.handleDKGRegistration(asyncCtx, &dkgNetwork)
+			k.handleDKGRegistration(asyncCtx, &dkgNetwork, oldCC)
 		}()
 	}
 
 	return nil
+}
+
+// isAlreadyRegistered checks whether this validator has an existing on-chain
+// registration for the given round. Used to prevent re-registration with
+// potentially different keys after sealed_keys deletion or kernel restart.
+func (k *Keeper) isAlreadyRegistered(ctx context.Context, round uint32) bool {
+	addr := ethcommon.HexToAddress(k.validatorEVMAddr)
+	reg, err := k.getDKGRegistration(ctx, round, addr)
+	if err != nil || reg == nil {
+		return false
+	}
+
+	if len(reg.DkgPubKey) > 0 {
+		log.Info(ctx, "Validator already registered on-chain; skipping re-registration",
+			"round", round,
+			"status", reg.Status.String(),
+		)
+
+		return true
+	}
+
+	return false
 }
 
 func (k *Keeper) shouldReshare(ctx context.Context) (bool, error) {

--- a/client/x/dkg/keeper/dkg_lifecycle_internal_test.go
+++ b/client/x/dkg/keeper/dkg_lifecycle_internal_test.go
@@ -1,0 +1,753 @@
+package keeper
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	dkgtestutil "github.com/piplabs/story/client/x/dkg/testutil"
+	"github.com/piplabs/story/client/x/dkg/types"
+	"github.com/piplabs/story/lib/netconf"
+
+	"go.uber.org/mock/gomock"
+)
+
+// testDKGParams returns DKG params with short stage durations for lifecycle testing.
+func testDKGParams() types.Params {
+	return types.NewParams(
+		5,  // RegistrationPeriod: 5 blocks
+		10, // DealingPeriod: 10 blocks
+		10, // FinalizationPeriod: 10 blocks
+		20, // ActivePeriod: 20 blocks
+		types.DefaultDkgCommitteeRewardPortion,
+		3, // MinReqRegisteredParticipants
+		3, // MinReqFinalizedParticipants
+		types.DefaultOperationalThreshold,
+	)
+}
+
+// dkgLifecycleEnv holds the test environment for DKG lifecycle tests.
+type dkgLifecycleEnv struct {
+	keeper     *Keeper
+	sdkCtx     sdk.Context
+	sk         *dkgtestutil.MockStakingKeeper
+	dk         *dkgtestutil.MockDistributionKeeper
+	validators []common.Address
+}
+
+// setupDKGLifecycleEnv creates a test environment with DKG keeper, short stage
+// periods, and mock validators configured. The SDK context uses the DKGTestChainID
+// with block height at the V200 activation point so BeginBlocker is active.
+func setupDKGLifecycleEnv(t *testing.T, numValidators int) *dkgLifecycleEnv {
+	t.Helper()
+
+	k, _, dk, ctx := setupDKGKeeperWithMocks(t)
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	// Use TestChainID where V200 activates at block 110.
+	// Set a non-nil HeaderHash so DKG network's StartBlockHash is populated.
+	testHeaderHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+	sdkCtx = sdkCtx.WithChainID(netconf.TestChainID).WithBlockHeight(110).WithHeaderHash(testHeaderHash.Bytes())
+
+	// Set short stage durations for testing
+	require.NoError(t, k.SetParams(sdkCtx, testDKGParams()))
+
+	// Generate deterministic validator addresses
+	validators := make([]common.Address, numValidators)
+	for i := range numValidators {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		validators[i] = crypto.PubkeyToAddress(key.PublicKey)
+	}
+
+	// Find the gomock controller's StakingKeeper for expectations
+	sk := k.stakingKeeper.(*dkgtestutil.MockStakingKeeper)
+
+	return &dkgLifecycleEnv{
+		keeper:     k,
+		sdkCtx:     sdkCtx,
+		sk:         sk,
+		dk:         dk,
+		validators: validators,
+	}
+}
+
+// mockValidators returns a slice of staking validators whose OperatorAddresses
+// are derived from the test validators' EVM addresses. Each validator is bonded
+// and not jailed.
+func (env *dkgLifecycleEnv) mockValidators() []stakingtypes.Validator {
+	vals := make([]stakingtypes.Validator, len(env.validators))
+	for i, addr := range env.validators {
+		vals[i] = stakingtypes.Validator{
+			OperatorAddress: sdk.ValAddress(addr.Bytes()).String(),
+			Jailed:          false,
+			Status:          stakingtypes.Bonded,
+		}
+	}
+
+	return vals
+}
+
+// expectZeroUbiBalance sets up mock expectations for settleRewardsForPreviousCommittee
+// to return zero UBI balance, causing it to short-circuit without further calls.
+func (env *dkgLifecycleEnv) expectZeroUbiBalance() {
+	env.dk.EXPECT().GetUbiBalanceByDenom(gomock.Any(), sdk.DefaultBondDenom).Return(math.ZeroInt(), nil)
+}
+
+// advanceToHeight sets the block height to the specified value.
+func (env *dkgLifecycleEnv) advanceToHeight(h int64) {
+	env.sdkCtx = env.sdkCtx.WithBlockHeight(h)
+}
+
+// registerValidators creates verified DKG registrations for all validators in the env.
+func (env *dkgLifecycleEnv) registerValidators(t *testing.T, round uint32) {
+	t.Helper()
+
+	for i, val := range env.validators {
+		reg := &types.DKGRegistration{
+			Round:          round,
+			ValidatorAddr:  val.Hex(),
+			Index:          uint32(i + 1),
+			DkgPubKey:      []byte("dkg-pubkey-" + val.Hex()),
+			CommPubKey:     []byte("comm-pubkey-" + val.Hex()),
+			EnclaveReport:  []byte("enclave-report"),
+			Status:         types.DKGRegStatusVerified,
+			CodeCommitment: make([]byte, 32),
+			EnclaveType:    make([]byte, 32),
+		}
+		require.NoError(t, env.keeper.setDKGRegistration(env.sdkCtx, val, reg))
+	}
+}
+
+// finalizeValidators creates finalized DKG registrations for all validators in the env.
+func (env *dkgLifecycleEnv) finalizeValidators(t *testing.T, round uint32, globalPubKey []byte) {
+	t.Helper()
+
+	for i, val := range env.validators {
+		// Mark registration as finalized
+		reg := &types.DKGRegistration{
+			Round:          round,
+			ValidatorAddr:  val.Hex(),
+			Index:          uint32(i + 1),
+			DkgPubKey:      []byte("dkg-pubkey-" + val.Hex()),
+			CommPubKey:     []byte("comm-pubkey-" + val.Hex()),
+			EnclaveReport:  []byte("enclave-report"),
+			Status:         types.DKGRegStatusFinalized,
+			CodeCommitment: make([]byte, 32),
+			EnclaveType:    make([]byte, 32),
+			PubKeyShare:    []byte("pub-key-share-" + val.Hex()),
+		}
+		require.NoError(t, env.keeper.setDKGRegistration(env.sdkCtx, val, reg))
+	}
+
+	// Add global public key votes to meet threshold
+	net, err := env.keeper.getLatestDKGNetwork(env.sdkCtx)
+	require.NoError(t, err)
+	net.GlobalPublicKey = globalPubKey
+	net.PublicCoeffs = [][]byte{globalPubKey} // simplified
+	require.NoError(t, env.keeper.setDKGNetwork(env.sdkCtx, net))
+}
+
+// TestDKGLifecycle_InitialRound verifies the full lifecycle of the first DKG round:
+// BeginBlocker initiates round → Registration → Dealing → Finalization → Active.
+func TestDKGLifecycle_InitialRound(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+	params := testDKGParams()
+
+	// Round 1 should not exist yet
+	latestRound, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Nil(t, latestRound, "no DKG round should exist before BeginBlocker")
+
+	// --- Phase 1: First BeginBlocker initiates Round 1 ---
+	// Mock GetAllValidators for InitiateDKGRound
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+
+	startHeight := env.sdkCtx.BlockHeight()
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify round 1 was created in Registration stage
+	round1, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.NotNil(t, round1)
+	require.Equal(t, uint32(1), round1.Round)
+	require.Equal(t, types.DKGStageRegistration, round1.Stage)
+	require.Equal(t, startHeight, round1.StartBlockHeight)
+	require.False(t, round1.IsResharing, "initial round should not be resharing")
+	require.False(t, round1.IsUpgrade, "initial round should not be upgrade")
+
+	// --- Phase 2: Registration period — simulate validators registering ---
+	env.registerValidators(t, 1)
+
+	// Verify registrations are stored
+	for _, val := range env.validators {
+		reg, err := env.keeper.getDKGRegistration(env.sdkCtx, 1, val)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg.Status)
+	}
+
+	// --- Phase 3: Advance to dealing transition ---
+	dealingHeight := startHeight + int64(params.RegistrationPeriod)
+	env.advanceToHeight(dealingHeight)
+
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round1, err = env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageDealing, round1.Stage, "should transition to Dealing")
+	require.Equal(t, uint32(3), round1.Total, "total should match registered validators")
+	require.True(t, round1.Threshold > 0, "threshold should be computed")
+
+	// --- Phase 4: Advance to finalization transition ---
+	finalizationHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod)
+	env.advanceToHeight(finalizationHeight)
+
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round1, err = env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageFinalization, round1.Stage, "should transition to Finalization")
+
+	// --- Phase 5: Simulate validators finalizing ---
+	testGlobalPubKey := []byte("test-global-public-key-32bytes!!")
+	env.finalizeValidators(t, 1, testGlobalPubKey)
+
+	// --- Phase 6: Advance to active transition ---
+	activeHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod) + int64(params.FinalizationPeriod)
+	env.advanceToHeight(activeHeight)
+
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round1, err = env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageActive, round1.Stage, "should transition to Active")
+
+	// Verify the round is now the latest active round
+	activeRound, err := env.keeper.GetLatestActiveRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.NotNil(t, activeRound)
+	require.Equal(t, uint32(1), activeRound.Round)
+	require.Equal(t, testGlobalPubKey, activeRound.GlobalPublicKey)
+}
+
+// TestDKGLifecycle_ProactiveResharing verifies that after an initial round completes
+// and the Active period ends, a new round is automatically initiated as a resharing
+// round. The global public key should be preserved across rounds.
+func TestDKGLifecycle_ProactiveResharing(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+	params := testDKGParams()
+
+	// --- Setup: Complete Round 1 ---
+	startHeight := env.sdkCtx.BlockHeight()
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Register validators
+	env.registerValidators(t, 1)
+
+	// Transition to Dealing
+	dealingHeight := startHeight + int64(params.RegistrationPeriod)
+	env.advanceToHeight(dealingHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Transition to Finalization
+	finalizationHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod)
+	env.advanceToHeight(finalizationHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Finalize validators
+	testGlobalPubKey := []byte("global-public-key-round1-32byte")
+	env.finalizeValidators(t, 1, testGlobalPubKey)
+
+	// Transition to Active
+	activeHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod) + int64(params.FinalizationPeriod)
+	env.advanceToHeight(activeHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify Round 1 is active
+	activeRound, err := env.keeper.GetLatestActiveRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), activeRound.Round)
+	require.Equal(t, testGlobalPubKey, activeRound.GlobalPublicKey)
+
+	// --- Phase 1: Active period ends — auto-initiation of Round 2 ---
+	resharingHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod) + int64(params.FinalizationPeriod) + int64(params.ActivePeriod)
+	env.advanceToHeight(resharingHeight)
+
+	// InitiateDKGRound will call GetAllValidators again
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify Round 2 was created
+	round2, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.NotNil(t, round2)
+	require.Equal(t, uint32(2), round2.Round)
+	require.Equal(t, types.DKGStageRegistration, round2.Stage)
+	require.True(t, round2.IsResharing, "Round 2 should be a resharing round")
+	require.False(t, round2.IsUpgrade, "proactive resharing should not be upgrade")
+
+	// --- Phase 2: Complete Round 2 lifecycle ---
+	round2Start := round2.StartBlockHeight
+
+	// Register validators for round 2
+	env.registerValidators(t, 2)
+
+	// Transition to Dealing
+	env.advanceToHeight(round2Start + int64(params.RegistrationPeriod))
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round2, err = env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageDealing, round2.Stage)
+
+	// Transition to Finalization
+	env.advanceToHeight(round2Start + int64(params.RegistrationPeriod) + int64(params.DealingPeriod))
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round2, err = env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageFinalization, round2.Stage)
+
+	// Finalize validators with the SAME global public key (proactive resharing preserves it)
+	env.finalizeValidators(t, 2, testGlobalPubKey)
+
+	// Transition to Active — FinalizeDKGRound calls settleRewardsForPreviousCommittee
+	// which queries distribution keeper for UBI balance.
+	env.expectZeroUbiBalance()
+	env.advanceToHeight(round2Start + int64(params.RegistrationPeriod) + int64(params.DealingPeriod) + int64(params.FinalizationPeriod))
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify Round 2 is now the active round with the same global public key
+	activeRound, err = env.keeper.GetLatestActiveRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), activeRound.Round)
+	require.Equal(t, testGlobalPubKey, activeRound.GlobalPublicKey,
+		"global public key should be preserved across proactive resharing rounds")
+
+	// Verify Round 1's stage: when Active stage ends, BeginBlocker sets
+	// latestRound.Stage = Registration (the transition target) before calling
+	// InitiateDKGRound. So Round 1's stored stage is Registration, not Active.
+	// endPreviousActiveRound only marks stages == Active as Ended, so Round 1
+	// remains at Registration (its stage was already overwritten by the transition).
+	round1, err := env.keeper.getDKGNetworkByRound(env.sdkCtx, 1)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageRegistration, round1.Stage,
+		"Round 1 stage was overwritten to Registration during Active→Registration transition")
+}
+
+// TestDKGLifecycle_UpgradeResharing verifies that when a kernel upgrade is
+// scheduled and its activation height is reached, BeginBlocker initiates an
+// upgrade resharing round (IsResharing=true, IsUpgrade=true).
+func TestDKGLifecycle_UpgradeResharing(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+	params := testDKGParams()
+
+	// --- Setup: Complete Round 1 (initial DKG) ---
+	startHeight := env.sdkCtx.BlockHeight()
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	env.registerValidators(t, 1)
+
+	dealingHeight := startHeight + int64(params.RegistrationPeriod)
+	env.advanceToHeight(dealingHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	finalizationHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod)
+	env.advanceToHeight(finalizationHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	testGlobalPubKey := []byte("global-public-key-round1-32byte")
+	env.finalizeValidators(t, 1, testGlobalPubKey)
+
+	activeHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod) + int64(params.FinalizationPeriod)
+	env.advanceToHeight(activeHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// --- Schedule a kernel upgrade ---
+	upgradeActivationHeight := activeHeight + 5 // 5 blocks into Active phase
+	require.NoError(t, env.keeper.UpgradeScheduled(env.sdkCtx, upgradeActivationHeight, "v3.0.0"))
+
+	// Verify upgrade info is stored
+	upgradeInfo, err := env.keeper.GetPendingUpgrade(env.sdkCtx)
+	require.NoError(t, err)
+	require.NotNil(t, upgradeInfo)
+	require.Equal(t, "v3.0.0", upgradeInfo.UpgradeVersion)
+	require.False(t, upgradeInfo.IsActivated)
+
+	// --- Advance to upgrade activation height ---
+	env.advanceToHeight(upgradeActivationHeight)
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify upgrade resharing round was initiated
+	round2, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), round2.Round)
+	require.Equal(t, types.DKGStageRegistration, round2.Stage)
+	require.True(t, round2.IsResharing, "upgrade resharing round must be resharing")
+	require.True(t, round2.IsUpgrade, "upgrade resharing round must be marked as upgrade")
+
+	// Verify upgrade info is marked as activated (not deleted yet).
+	// GetPendingUpgrade skips activated entries, so use GetKernelUpgradeInfo directly.
+	upgradeInfo, err = env.keeper.GetKernelUpgradeInfo(env.sdkCtx, "v3.0.0")
+	require.NoError(t, err)
+	require.NotNil(t, upgradeInfo)
+	require.True(t, upgradeInfo.IsActivated, "upgrade should be marked as activated")
+
+	// --- Complete the upgrade resharing round ---
+	round2Start := round2.StartBlockHeight
+
+	env.registerValidators(t, 2)
+
+	env.advanceToHeight(round2Start + int64(params.RegistrationPeriod))
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	env.advanceToHeight(round2Start + int64(params.RegistrationPeriod) + int64(params.DealingPeriod))
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Finalize with same global pub key
+	env.finalizeValidators(t, 2, testGlobalPubKey)
+
+	// Transition to Active — FinalizeDKGRound calls settleRewardsForPreviousCommittee
+	env.expectZeroUbiBalance()
+	env.advanceToHeight(round2Start + int64(params.RegistrationPeriod) + int64(params.DealingPeriod) + int64(params.FinalizationPeriod))
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify upgrade info is deleted after successful upgrade round.
+	// GetKernelUpgradeInfo should return "not found" since deleteActivatedUpgradeInfo removed it.
+	_, err = env.keeper.GetKernelUpgradeInfo(env.sdkCtx, "v3.0.0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	// Verify round 2 is now active
+	activeRound, err := env.keeper.GetLatestActiveRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), activeRound.Round)
+}
+
+// TestDKGLifecycle_StageTransitionTiming verifies that stage transitions happen
+// at exact block boundaries and not before.
+func TestDKGLifecycle_StageTransitionTiming(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+	params := testDKGParams()
+
+	startHeight := env.sdkCtx.BlockHeight()
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Register validators so dealing transition succeeds
+	env.registerValidators(t, 1)
+
+	// --- Verify no transition 1 block before dealing ---
+	oneBeforeDealing := startHeight + int64(params.RegistrationPeriod) - 1
+	env.advanceToHeight(oneBeforeDealing)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageRegistration, round.Stage,
+		"should still be in Registration 1 block before dealing")
+
+	// --- Verify transition at exact dealing boundary ---
+	dealingExact := startHeight + int64(params.RegistrationPeriod)
+	env.advanceToHeight(dealingExact)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round, err = env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageDealing, round.Stage,
+		"should transition to Dealing at exact boundary")
+}
+
+// TestDKGLifecycle_BeginBlockerPreV200Noop verifies that BeginBlocker is a
+// complete no-op before V200 activation height.
+func TestDKGLifecycle_BeginBlockerPreV200Noop(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+
+	// TestChainID has V200 at block 110. Set height to 109 (before V200).
+	env.advanceToHeight(109)
+
+	// BeginBlocker should return nil without doing anything
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// No DKG round should exist
+	latestRound, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Nil(t, latestRound, "no DKG round should be created before V200")
+}
+
+// TestDKGLifecycle_InsufficientRegistrations verifies that when the number of
+// verified registrations is below MinReqRegisteredParticipants, the round is
+// skipped and a new round is initiated.
+func TestDKGLifecycle_InsufficientRegistrations(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+	params := testDKGParams()
+
+	startHeight := env.sdkCtx.BlockHeight()
+
+	// Initiate Round 1
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Only register 2 of 3 validators (below min_req_registered=3)
+	for i := 0; i < 2; i++ {
+		reg := &types.DKGRegistration{
+			Round:          1,
+			ValidatorAddr:  env.validators[i].Hex(),
+			Index:          uint32(i + 1),
+			DkgPubKey:      []byte("dkg-pubkey"),
+			CommPubKey:     []byte("comm-pubkey"),
+			EnclaveReport:  []byte("enclave-report"),
+			Status:         types.DKGRegStatusVerified,
+			CodeCommitment: make([]byte, 32),
+			EnclaveType:    make([]byte, 32),
+		}
+		require.NoError(t, env.keeper.setDKGRegistration(env.sdkCtx, env.validators[i], reg))
+	}
+
+	// Transition to dealing — should skip round due to insufficient registrations
+	dealingHeight := startHeight + int64(params.RegistrationPeriod)
+	env.advanceToHeight(dealingHeight)
+
+	// SkipToNextRound -> InitiateDKGRound will call GetAllValidators
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify Round 1 was marked as Failed and Round 2 was created
+	round1, err := env.keeper.getDKGNetworkByRound(env.sdkCtx, 1)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageFailed, round1.Stage,
+		"Round 1 should be failed due to insufficient registrations")
+
+	round2, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), round2.Round)
+	require.Equal(t, types.DKGStageRegistration, round2.Stage)
+}
+
+// TestDKGLifecycle_InsufficientFinalizations verifies that when the number of
+// finalized registrations is below the threshold, the round is skipped.
+func TestDKGLifecycle_InsufficientFinalizations(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+	params := testDKGParams()
+
+	startHeight := env.sdkCtx.BlockHeight()
+
+	// Initiate and register Round 1
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+	env.registerValidators(t, 1)
+
+	// Transition to Dealing
+	dealingHeight := startHeight + int64(params.RegistrationPeriod)
+	env.advanceToHeight(dealingHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Transition to Finalization
+	finalizationHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod)
+	env.advanceToHeight(finalizationHeight)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Only finalize 1 of 3 validators (below min_req_finalized=3)
+	reg := &types.DKGRegistration{
+		Round:          1,
+		ValidatorAddr:  env.validators[0].Hex(),
+		Index:          1,
+		DkgPubKey:      []byte("dkg-pubkey"),
+		CommPubKey:     []byte("comm-pubkey"),
+		EnclaveReport:  []byte("enclave-report"),
+		Status:         types.DKGRegStatusFinalized,
+		CodeCommitment: make([]byte, 32),
+		EnclaveType:    make([]byte, 32),
+		PubKeyShare:    []byte("share"),
+	}
+	require.NoError(t, env.keeper.setDKGRegistration(env.sdkCtx, env.validators[0], reg))
+
+	// Transition to Active — should skip due to insufficient finalizations
+	activeHeight := startHeight + int64(params.RegistrationPeriod) + int64(params.DealingPeriod) + int64(params.FinalizationPeriod)
+	env.advanceToHeight(activeHeight)
+
+	// SkipToNextRound will call GetAllValidators
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	// Verify Round 1 was failed and Round 2 started
+	round1, err := env.keeper.getDKGNetworkByRound(env.sdkCtx, 1)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageFailed, round1.Stage)
+
+	round2, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), round2.Round)
+	require.Equal(t, types.DKGStageRegistration, round2.Stage)
+}
+
+// TestDKGLifecycle_RegistrationValidation verifies the Registered handler's
+// validation logic: round mismatch, stage check, active validator set membership,
+// and start block verification.
+func TestDKGLifecycle_RegistrationValidation(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+
+	// Initiate round 1
+	env.sk.EXPECT().GetAllValidators(gomock.Any()).Return(env.mockValidators(), nil).Times(1)
+	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
+
+	round, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
+	require.NoError(t, err)
+
+	testCodeCommitment := [32]byte{0x01}
+	testEnclaveType := [32]byte{0x01}
+
+	// The test context's header hash is empty (zero bytes), so StartBlockHash
+	// stored in the DKG network is also empty. Use the stored value directly.
+	var startBlockHash [32]byte
+	if len(round.StartBlockHash) == 32 {
+		copy(startBlockHash[:], round.StartBlockHash)
+	}
+
+	tcs := []struct {
+		name             string
+		round            uint32
+		startBlockHeight *big.Int
+		startBlockHash   [32]byte
+		validator        common.Address
+		expectedErr      string
+	}{
+		{
+			name:             "fail: round mismatch",
+			round:            999,
+			startBlockHeight: big.NewInt(round.StartBlockHeight),
+			startBlockHash:   startBlockHash,
+			validator:        env.validators[0],
+			expectedErr:      "round mismatch",
+		},
+		{
+			name:             "fail: start block height mismatch",
+			round:            1,
+			startBlockHeight: big.NewInt(9999),
+			startBlockHash:   startBlockHash,
+			validator:        env.validators[0],
+			expectedErr:      "start block height mismatch",
+		},
+		{
+			name:             "fail: start block hash mismatch",
+			round:            1,
+			startBlockHeight: big.NewInt(round.StartBlockHeight),
+			startBlockHash:   [32]byte{0xFF}, // wrong hash
+			validator:        env.validators[0],
+			expectedErr:      "start block hash mismatch",
+		},
+		{
+			name:             "fail: validator not in active set",
+			round:            1,
+			startBlockHeight: big.NewInt(round.StartBlockHeight),
+			startBlockHash:   startBlockHash,
+			validator:        common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+			expectedErr:      "msg sender is not in the active validator set",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := env.keeper.Registered(
+				env.sdkCtx,
+				tc.validator,
+				testCodeCommitment,
+				tc.round,
+				tc.startBlockHeight,
+				tc.startBlockHash,
+				testEnclaveType,
+				[]byte("dkg-pubkey"),
+				[]byte("comm-pubkey"),
+				[]byte("enclave-report"),
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedErr)
+		})
+	}
+}
+
+// TestDKGLifecycle_UpgradeScheduleAndCancel verifies the upgrade scheduling
+// and cancellation flow.
+func TestDKGLifecycle_UpgradeScheduleAndCancel(t *testing.T) {
+	t.Parallel()
+	env := setupDKGLifecycleEnv(t, 3)
+
+	// Schedule an upgrade
+	require.NoError(t, env.keeper.UpgradeScheduled(env.sdkCtx, 500, "v3.0.0"))
+
+	info, err := env.keeper.GetPendingUpgrade(env.sdkCtx)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.Equal(t, "v3.0.0", info.UpgradeVersion)
+	require.Equal(t, int64(500), info.ActivationHeight)
+
+	// Cannot schedule another while one is pending
+	err = env.keeper.UpgradeScheduled(env.sdkCtx, 600, "v4.0.0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pending upgrade already exists")
+
+	// Cancel the upgrade
+	require.NoError(t, env.keeper.UpgradeCancelled(env.sdkCtx, "v3.0.0"))
+
+	info, err = env.keeper.GetPendingUpgrade(env.sdkCtx)
+	require.NoError(t, err)
+	require.Nil(t, info, "upgrade should be deleted after cancellation")
+
+	// Now can schedule a new one
+	require.NoError(t, env.keeper.UpgradeScheduled(env.sdkCtx, 700, "v4.0.0"))
+
+	info, err = env.keeper.GetPendingUpgrade(env.sdkCtx)
+	require.NoError(t, err)
+	require.Equal(t, "v4.0.0", info.UpgradeVersion)
+}
+
+// TestDKGLifecycle_CalculateThreshold verifies threshold calculation from
+// total participants and operational threshold basis points.
+func TestDKGLifecycle_CalculateThreshold(t *testing.T) {
+	t.Parallel()
+
+	tcs := []struct {
+		name      string
+		total     uint32
+		threshold uint32
+		expected  uint32
+	}{
+		{name: "3 of 3 at 667/1000", total: 3, threshold: 667, expected: 3},
+		{name: "5 at 667/1000 = ceil(3.335) = 4", total: 5, threshold: 667, expected: 4},
+		{name: "10 at 667/1000 = ceil(6.67) = 7", total: 10, threshold: 667, expected: 7},
+		{name: "zero total", total: 0, threshold: 667, expected: 0},
+		{name: "zero threshold", total: 5, threshold: 0, expected: 0},
+		{name: "100% threshold", total: 5, threshold: 1000, expected: 5},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.CalculateThreshold(tc.total, tc.threshold)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// Helper to get a DKG network by specific round number.
+func (k *Keeper) getDKGNetworkByRound(ctx context.Context, round uint32) (*types.DKGNetwork, error) {
+	return k.getDKGNetwork(ctx, round)
+}

--- a/client/x/dkg/keeper/dkg_network.go
+++ b/client/x/dkg/keeper/dkg_network.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"slices"
 	"strconv"
 
 	"cosmossdk.io/collections"
@@ -235,17 +234,4 @@ func (k *Keeper) endPreviousActiveRound(ctx context.Context, currentRound uint32
 	}
 
 	return nil
-}
-
-func (k *Keeper) isInPrevActiveValSet(ctx context.Context) (bool, error) {
-	latestActive, err := k.getLatestActiveDKGNetwork(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	if latestActive == nil {
-		return false, nil
-	}
-
-	return slices.Contains(latestActive.ActiveValSet, k.validatorEVMAddr), nil
 }

--- a/client/x/dkg/keeper/dkg_registration.go
+++ b/client/x/dkg/keeper/dkg_registration.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"cosmossdk.io/collections"
 
@@ -13,8 +14,9 @@ import (
 )
 
 // setDKGRegistration stores a DKG registration in the store using round_address as the key.
+// The address is lowercased to match the format used in DKGNetwork.ActiveValSet and story-kernel queries.
 func (k *Keeper) setDKGRegistration(ctx context.Context, validatorAddr common.Address, dkgReg *types.DKGRegistration) error {
-	key := fmt.Sprintf("%d_%s", dkgReg.Round, validatorAddr.Hex())
+	key := fmt.Sprintf("%d_%s", dkgReg.Round, strings.ToLower(validatorAddr.Hex()))
 	if err := k.DKGRegistrations.Set(ctx, key, *dkgReg); err != nil {
 		return errors.Wrap(err, "failed to set dkg registration")
 	}
@@ -24,7 +26,7 @@ func (k *Keeper) setDKGRegistration(ctx context.Context, validatorAddr common.Ad
 
 // getDKGRegistration retrieves a DKG registration by round and validator address.
 func (k *Keeper) getDKGRegistration(ctx context.Context, round uint32, validatorAddr common.Address) (*types.DKGRegistration, error) {
-	key := fmt.Sprintf("%d_%s", round, validatorAddr.Hex())
+	key := fmt.Sprintf("%d_%s", round, strings.ToLower(validatorAddr.Hex()))
 
 	dkgReg, err := k.DKGRegistrations.Get(ctx, key)
 	if err != nil {

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -11,6 +11,52 @@ import (
 	"github.com/piplabs/story/lib/log"
 )
 
+// dkgSvcRound tracks which DKG round is currently being processed by async
+// goroutines. Zero means no round is running. A higher round number always
+// supersedes a stale lock from a previous round, preventing cross-round
+// blocking where a slow/retrying goroutine from round N blocks round N+1.
+var dkgSvcRound atomic.Uint64
+
+// tryAcquireDKGSvc attempts to acquire the DKG service lock for the given round.
+// Returns true if acquired. Duplicate calls for the same round return false
+// (deduplication). A newer (higher) round always preempts an older one.
+func tryAcquireDKGSvc(round uint32) bool {
+	const maxCASRetries = 10
+
+	r := uint64(round)
+	for range maxCASRetries {
+		current := dkgSvcRound.Load()
+		if current == r {
+			return false // same round already running, deduplicate
+		}
+
+		if current == 0 || r > current {
+			if dkgSvcRound.CompareAndSwap(current, r) {
+				if current > 0 {
+					log.Info(context.Background(), "Superseded stale DKG lock from previous round",
+						"old_round", current,
+						"new_round", r,
+					)
+				}
+
+				return true
+			}
+
+			continue // CAS failed, retry
+		}
+
+		return false // round going backwards, skip
+	}
+
+	return false // max retries exhausted
+}
+
+// releaseDKGSvc releases the lock only if this round still holds it.
+// If a newer round has superseded, this is a no-op.
+func releaseDKGSvc(round uint32) {
+	dkgSvcRound.CompareAndSwap(uint64(round), 0)
+}
+
 // dkgAsyncTimeout is the maximum duration for async DKG goroutines that
 // communicate with the story-kernel. These goroutines must NOT use the CometBFT
 // consensus context because it gets canceled when block processing completes,
@@ -23,7 +69,6 @@ func dkgAsyncContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), dkgAsyncTimeout)
 }
 
-var dkgSvcRunning atomic.Bool
 var decryptWorkerRunning atomic.Bool
 
 // ResumeDKGService reloads unfinished DKG sessions and resumes their execution safely without spawning duplicate goroutines.
@@ -35,14 +80,76 @@ func (k *Keeper) ResumeDKGService(ctx context.Context, dkgNetwork *types.DKGNetw
 		return
 	}
 
-	if session.Phase != types.PhaseFailed {
-		log.Debug(ctx, "No failed DKG session found; skipping resume process", "round", dkgNetwork.Round)
+	if session.Phase == types.PhaseFailed {
+		k.resumeFailedSession(ctx, session, dkgNetwork)
 
 		return
 	}
 
+	// Recover sessions stuck in intermediate phases after an unexpected process crash.
+	// A session is stuck when its phase has NOT advanced to the expected completion
+	// state for the current stage AND no goroutine is actively processing it.
+	//
+	// Valid (non-stuck) completion states per stage:
+	//   Registration → PhaseInitialized (registration done, waiting for dealing)
+	//   Dealing      → PhaseDealing     (deals generated, processing responses via VE)
+	//   Finalization → PhaseFinalized   (finalization done, waiting for active)
+	//   Active       → PhaseCompleted
+	if isSessionStuckForStage(session.Phase, dkgNetwork.Stage) {
+		if tryAcquireDKGSvc(dkgNetwork.Round) {
+			releaseDKGSvc(dkgNetwork.Round)
+
+			log.Info(ctx, "Recovering stuck DKG session: no active goroutine for intermediate phase",
+				"round", dkgNetwork.Round,
+				"phase", session.Phase.String(),
+				"stage", dkgNetwork.Stage.String(),
+			)
+
+			k.stateManager.MarkFailed(ctx, session)
+			// Will be picked up as PhaseFailed on next block's ResumeDKGService call.
+		}
+	}
+}
+
+// isSessionStuckForStage returns true if the session phase is behind the expected
+// completion state for the current DKG stage. A session that reached the valid
+// completion phase for its stage is NOT stuck — it completed successfully and is
+// waiting for the next stage transition.
+func isSessionStuckForStage(phase types.DKGPhase, stage types.DKGStage) bool {
+	switch stage {
+	case types.DKGStageRegistration:
+		// PhaseInitialized = registration done → not stuck
+		return phase != types.PhaseInitialized && phase != types.PhaseCompleted
+	case types.DKGStageDealing:
+		// PhaseDealing = deals generated → not stuck
+		return phase != types.PhaseDealing && phase != types.PhaseCompleted
+	case types.DKGStageFinalization:
+		// PhaseFinalized = finalization done → not stuck
+		return phase != types.PhaseFinalized && phase != types.PhaseCompleted
+	case types.DKGStageActive:
+		return phase != types.PhaseCompleted
+	default:
+		return false
+	}
+}
+
+// resumeFailedSession dispatches a PhaseFailed session to the appropriate handler
+// based on the current DKG network stage.
+func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSession, dkgNetwork *types.DKGNetwork) {
 	switch dkgNetwork.Stage {
 	case types.DKGStageRegistration:
+		// Skip re-registration if already registered on-chain. Prevents overwriting
+		// a valid registration with different keys after sealed_keys deletion.
+		if k.isAlreadyRegistered(ctx, dkgNetwork.Round) {
+			session.UpdatePhase(types.PhaseInitialized)
+
+			if err := k.stateManager.UpdateSession(ctx, session); err != nil {
+				log.Error(ctx, "Failed to update session phase after existing registration check", err)
+			}
+
+			return
+		}
+
 		session.UpdatePhase(types.PhaseInitializing)
 
 		if err := k.stateManager.UpdateSession(ctx, session); err != nil {
@@ -51,12 +158,15 @@ func (k *Keeper) ResumeDKGService(ctx context.Context, dkgNetwork *types.DKGNetw
 			return
 		}
 
+		// Pre-compute old code commitment while SDK context is available.
+		oldCC, _ := k.getOldCodeCommitment(ctx)
+
 		asyncCtx, cancel := dkgAsyncContext()
 
 		go func() {
 			defer cancel()
 
-			k.handleDKGRegistration(asyncCtx, dkgNetwork)
+			k.handleDKGRegistration(asyncCtx, dkgNetwork, oldCC)
 		}()
 	case types.DKGStageDealing:
 		session.UpdatePhase(types.PhaseInitialized)
@@ -67,12 +177,27 @@ func (k *Keeper) ResumeDKGService(ctx context.Context, dkgNetwork *types.DKGNetw
 			return
 		}
 
+		// Set session.Index from on-chain registration for deal/response routing.
+		if err := k.ensureSessionIndex(ctx, dkgNetwork.Round); err != nil {
+			log.Warn(ctx, "Failed to set session index during resume", err,
+				"round", dkgNetwork.Round,
+			)
+		}
+
+		// Pre-compute shouldDeal while SDK context is available.
+		deal, err := k.shouldDeal(ctx, dkgNetwork)
+		if err != nil {
+			log.Error(ctx, "Failed to check shouldDeal during resume", err)
+
+			return
+		}
+
 		asyncCtx, cancel := dkgAsyncContext()
 
 		go func() {
 			defer cancel()
 
-			k.handleDKGDealing(asyncCtx, dkgNetwork)
+			k.handleDKGDealing(asyncCtx, dkgNetwork, deal)
 		}()
 	case types.DKGStageFinalization:
 		session.UpdatePhase(types.PhaseDealing)

--- a/client/x/dkg/keeper/dkg_svc_complete.go
+++ b/client/x/dkg/keeper/dkg_svc_complete.go
@@ -13,12 +13,14 @@ func (k *Keeper) handleDKGComplete(ctx context.Context, dkgNetwork *types.DKGNet
 		"round", dkgNetwork.Round,
 	)
 
-	if !dkgSvcRunning.CompareAndSwap(false, true) {
-		log.Info(ctx, "DKG service already running; skipping completion")
+	if !tryAcquireDKGSvc(dkgNetwork.Round) {
+		log.Info(ctx, "DKG service already running for this round; skipping completion",
+			"round", dkgNetwork.Round,
+		)
 
 		return
 	}
-	defer dkgSvcRunning.Store(false)
+	defer releaseDKGSvc(dkgNetwork.Round)
 
 	session, err := k.stateManager.GetSession(dkgNetwork.Round)
 	if err != nil {

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -6,37 +6,34 @@ import (
 	"encoding/hex"
 	"slices"
 
-	"cosmossdk.io/collections"
-
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
 
+	"go.dedis.ch/kyber/v4"
 	"go.dedis.ch/kyber/v4/group/edwards25519"
 )
 
 // handleDKGDealing handles the dealing phase event.
-func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetwork) {
+// shouldDeal must be pre-computed by the caller while the SDK context is available,
+// because async goroutines cannot access the KV store.
+func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetwork, shouldDeal bool) {
 	log.Info(ctx, "Handling DKG dealing",
 		"round", dkgNetwork.Round,
+		"should_deal", shouldDeal,
 	)
 
-	if !dkgSvcRunning.CompareAndSwap(false, true) {
-		log.Info(ctx, "DKG service already running; skipping dealing")
+	if !tryAcquireDKGSvc(dkgNetwork.Round) {
+		log.Info(ctx, "DKG service already running for this round; skipping dealing",
+			"round", dkgNetwork.Round,
+		)
 
 		return
 	}
-	defer dkgSvcRunning.Store(false)
+	defer releaseDKGSvc(dkgNetwork.Round)
 
 	if dkgNetwork.Stage != types.DKGStageDealing {
 		log.Info(ctx, "DKG Dealing is skipped because the current network stage is not dealing stage")
-
-		return
-	}
-
-	shouldDeal, err := k.shouldDeal(ctx, dkgNetwork)
-	if err != nil {
-		log.Error(ctx, "Failed to check whether the validator should deal or not", err)
 
 		return
 	}
@@ -118,6 +115,10 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 
 // handleDKGProcessDeals handles the deals from other committee members.
 func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DKGNetwork, deals []types.Deal) {
+	// Serialize kernel DKG operations to prevent concurrent DistKeyGenerator mutation.
+	dkgKernelMu.Lock()
+	defer dkgKernelMu.Unlock()
+
 	log.Info(ctx, "Handling DKG process deals",
 		"round", dkgNetwork.Round,
 		"num_deals", len(deals),
@@ -136,8 +137,14 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 		return
 	}
 
-	if session.Phase != types.PhaseDealing {
-		log.Warn(ctx, "Session not in dealing phase, skipping process deals", nil,
+	// Accept deals in both Initialized and Dealing phases.
+	// Deals from other validators arrive via vote extensions as soon as the DKG stage
+	// transitions to Dealing. However, the local session only transitions from
+	// Initialized to Dealing after GenerateDeals completes (which can take ~30s).
+	// If we reject deals during Initialized phase, they are permanently lost because
+	// vote extensions deliver each deal exactly once.
+	if session.Phase != types.PhaseDealing && session.Phase != types.PhaseInitialized {
+		log.Warn(ctx, "Session not in dealing or initialized phase, skipping process deals", nil,
 			"current_phase", session.Phase.String(),
 		)
 
@@ -160,7 +167,9 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 		}
 
 		for _, deal := range deals {
-			if deal.RecipientIndex == session.Index {
+			// RecipientIndex is 0-based (Kyber), session.Index is 1-based (on-chain).
+			// Guard against unset index (0) to avoid uint32 underflow.
+			if session.Index > 0 && deal.RecipientIndex == session.Index-1 {
 				req.Deals = append(req.Deals, deal)
 			}
 		}
@@ -183,7 +192,14 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 
 		return nil
 	}); err != nil {
-		log.Error(ctx, "Failed to process deals", err)
+		// Cache unprocessed deals in memory for retry when kernel recovers.
+		// Not persisted to disk — process restart loses them (round will fail and retry).
+		cached := cachePendingIncomingDeals(deals, session.Index)
+
+		log.Error(ctx, "Failed to process deals; cached for retry", err,
+			"round", dkgNetwork.Round,
+			"cached_deals", cached,
+		)
 
 		return
 	}
@@ -195,19 +211,40 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 	)
 }
 
+// cachePendingIncomingDeals saves deals that failed kernel processing for later retry.
+// Only deals addressed to this validator (matching recipientIndex) are cached.
+// Returns the number of deals cached.
+func cachePendingIncomingDeals(allDeals []types.Deal, sessionIndex uint32) int {
+	pendingIncomingDealsMu.Lock()
+	defer pendingIncomingDealsMu.Unlock()
+
+	cached := 0
+	for _, deal := range allDeals {
+		if sessionIndex > 0 && deal.RecipientIndex == sessionIndex-1 {
+			if len(pendingIncomingDeals) >= maxPendingIncoming {
+				return cached
+			}
+
+			pendingIncomingDeals = append(pendingIncomingDeals, deal)
+			cached++
+		}
+	}
+
+	return cached
+}
+
 // handleDKGProcessResponses handles the responses of processDeals from other committee members.
-func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *types.DKGNetwork, responses []types.Response) {
+// shouldProcess must be pre-computed by the caller while the SDK context is available.
+func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *types.DKGNetwork, responses []types.Response, shouldProcess bool) {
+	// Serialize kernel DKG operations to prevent concurrent DistKeyGenerator mutation.
+	dkgKernelMu.Lock()
+	defer dkgKernelMu.Unlock()
+
 	log.Info(ctx, "Handling DKG process responses",
 		"round", dkgNetwork.Round,
 		"num_responses", len(responses),
+		"should_process", shouldProcess,
 	)
-
-	shouldProcess, err := k.shouldProcessResponses(ctx, dkgNetwork)
-	if err != nil {
-		log.Error(ctx, "Failed to check whether the validator should process responses", err)
-
-		return
-	}
 
 	if !shouldProcess {
 		log.Info(ctx, "Skip processing of responses")
@@ -222,8 +259,9 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 		return
 	}
 
-	if session.Phase != types.PhaseDealing {
-		log.Warn(ctx, "Session not in dealing phase, skipping process responses", nil,
+	// Accept responses in both Initialized and Dealing phases (same reasoning as deals).
+	if session.Phase != types.PhaseDealing && session.Phase != types.PhaseInitialized {
+		log.Warn(ctx, "Session not in dealing or initialized phase, skipping process responses", nil,
 			"current_phase", session.Phase.String(),
 		)
 
@@ -240,7 +278,9 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 
 	filteredResponses := make([]types.Response, 0, len(responses))
 	for _, resp := range responses {
-		if resp.VssResponse.Index != session.Index {
+		// VssResponse.Index is 0-based (Kyber), session.Index is 1-based (on-chain).
+		// If session.Index is 0 (unset), include all responses (no self-filtering).
+		if session.Index == 0 || resp.VssResponse.Index != session.Index-1 {
 			filteredResponses = append(filteredResponses, resp)
 		}
 	}
@@ -283,6 +323,14 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 				"code_commitment", hex.EncodeToString(cc),
 			)
 
+			// Cache unprocessed responses for retry when kernel recovers.
+			cachePendingIncomingResponses(filteredResponses)
+
+			log.Info(ctx, "Cached responses for retry",
+				"round", session.Round,
+				"cached_responses", len(filteredResponses),
+			)
+
 			continue
 		}
 
@@ -308,17 +356,19 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 func (k *Keeper) shouldDeal(ctx context.Context, dkgNetwork *types.DKGNetwork) (bool, error) {
 	inCurSet := slices.Contains(dkgNetwork.ActiveValSet, k.validatorEVMAddr)
 
-	inPrevSet, err := k.isInPrevActiveValSet(ctx)
+	prevActive, err := k.getLatestActiveDKGNetwork(ctx)
 	if err != nil {
-		if errors.Is(err, collections.ErrNotFound) {
-			// First DKG round: only current set of validators deal
-			return inCurSet, nil
-		}
-
 		return false, err
 	}
 
+	if prevActive == nil {
+		// First DKG round (no previous active round): current set of validators deal
+		return inCurSet, nil
+	}
+
 	// Resharing round: only previous set of validators deal (they hold the existing key shares)
+	inPrevSet := slices.Contains(prevActive.ActiveValSet, k.validatorEVMAddr)
+
 	return inPrevSet, nil
 }
 
@@ -328,7 +378,11 @@ func (k *Keeper) shouldDeal(ctx context.Context, dkgNetwork *types.DKGNetwork) (
 //  2. ActiveValSet / session / phase check
 //  3. Schnorr signature verification → deduplication → Pedersen VSS verification
 //  4. Forward only valid justifications to story-kernel
-func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork *types.DKGNetwork, justifications []types.Justification) {
+func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork *types.DKGNetwork, justifications []types.Justification, dealerPubKeys map[uint32]kyber.Point) {
+	// Serialize kernel DKG operations to prevent concurrent DistKeyGenerator mutation.
+	dkgKernelMu.Lock()
+	defer dkgKernelMu.Unlock()
+
 	log.Info(ctx, "Handling DKG process justifications",
 		"round", dkgNetwork.Round,
 		"num_justifications", len(justifications),
@@ -360,8 +414,9 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 		return
 	}
 
-	if session.Phase != types.PhaseDealing {
-		log.Warn(ctx, "Session not in dealing phase, skipping process justifications", nil,
+	// Accept justifications in both Initialized and Dealing phases (same reasoning as deals).
+	if session.Phase != types.PhaseDealing && session.Phase != types.PhaseInitialized {
+		log.Warn(ctx, "Session not in dealing or initialized phase, skipping process justifications", nil,
 			"current_phase", session.Phase.String(),
 		)
 
@@ -369,14 +424,6 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 	}
 
 	suite := edwards25519.NewBlakeSHA256Ed25519()
-
-	// Build dealer public key map once for all justifications (avoids O(N) registration scan per justification).
-	dealerPubKeys, err := k.buildDealerPubKeyMap(ctx, dkgNetwork, suite)
-	if err != nil {
-		log.Error(ctx, "Failed to build dealer public key map", err)
-
-		return
-	}
 
 	// Step 1: Verify Schnorr signature FIRST, filter out unsigned/forged justifications.
 	// This MUST happen before deduplication so that an attacker cannot preempt a valid
@@ -467,6 +514,14 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 				"code_commitment", hex.EncodeToString(cc),
 			)
 
+			// Cache for retry when kernel recovers.
+			cachePendingIncomingJustifications(validJustifications)
+
+			log.Info(ctx, "Cached justifications for retry",
+				"round", session.Round,
+				"cached_responses", len(validJustifications),
+			)
+
 			continue
 		}
 	}
@@ -476,19 +531,233 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 	)
 }
 
+// cachePendingIncomingResponses saves responses that failed kernel processing for later retry.
+func cachePendingIncomingResponses(filteredResponses []types.Response) {
+	pendingIncomingResponsesMu.Lock()
+	defer pendingIncomingResponsesMu.Unlock()
+
+	remaining := maxPendingIncoming - len(pendingIncomingResponses)
+	if remaining <= 0 {
+		return
+	}
+
+	if len(filteredResponses) > remaining {
+		filteredResponses = filteredResponses[:remaining]
+	}
+
+	pendingIncomingResponses = append(pendingIncomingResponses, filteredResponses...)
+}
+
+func cachePendingIncomingJustifications(justifications []types.Justification) {
+	pendingIncomingJustificationsMu.Lock()
+	defer pendingIncomingJustificationsMu.Unlock()
+
+	remaining := maxPendingIncoming - len(pendingIncomingJustifications)
+	if remaining <= 0 {
+		return
+	}
+
+	if len(justifications) > remaining {
+		justifications = justifications[:remaining]
+	}
+
+	pendingIncomingJustifications = append(pendingIncomingJustifications, justifications...)
+}
+
+// reprocessPendingIncomingData retries cached deals, responses, and justifications when the kernel recovers.
+// Deals are processed FIRST (kyber requires deals before responses can be accepted).
+// Called from BeginBlocker via the DKG service loop.
+func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
+	hasPendingDeals := func() bool {
+		pendingIncomingDealsMu.Lock()
+		defer pendingIncomingDealsMu.Unlock()
+
+		return len(pendingIncomingDeals) > 0
+	}()
+
+	hasPendingResponses := func() bool {
+		pendingIncomingResponsesMu.Lock()
+		defer pendingIncomingResponsesMu.Unlock()
+
+		return len(pendingIncomingResponses) > 0
+	}()
+
+	hasPendingJustifications := func() bool {
+		pendingIncomingJustificationsMu.Lock()
+		defer pendingIncomingJustificationsMu.Unlock()
+
+		return len(pendingIncomingJustifications) > 0
+	}()
+
+	if !hasPendingDeals && !hasPendingResponses && !hasPendingJustifications {
+		return
+	}
+
+	// Only retry during Dealing stage (pending data is stale after stage transitions).
+	if dkgNetwork.Stage != types.DKGStageDealing {
+		flushPendingIncoming()
+
+		return
+	}
+
+	if k.kernelRouter == nil || !k.kernelRouter.HasClients() {
+		return // kernel still unavailable, wait
+	}
+
+	asyncCtx, cancel := dkgAsyncContext()
+
+	go func() {
+		defer cancel()
+
+		// Process deals FIRST — kyber returns ErrNoDealBeforeResponse if
+		// a response arrives for a dealer whose deal hasn't been processed.
+		if hasPendingDeals {
+			drainedDeals := drainPendingIncomingDeals()
+
+			log.Info(asyncCtx, "Replaying cached deals after kernel recovery",
+				"round", dkgNetwork.Round,
+				"num_deals", len(drainedDeals),
+			)
+
+			k.handleDKGProcessDeals(asyncCtx, dkgNetwork, drainedDeals)
+		}
+
+		// Then process responses.
+		if hasPendingResponses {
+			drainedResponses := drainPendingIncomingResponses()
+
+			log.Info(asyncCtx, "Replaying cached responses after kernel recovery",
+				"round", dkgNetwork.Round,
+				"num_responses", len(drainedResponses),
+			)
+
+			k.handleDKGProcessResponses(asyncCtx, dkgNetwork, drainedResponses, true)
+		}
+
+		// Finally process justifications (already verified before caching,
+		// so forward directly to kernel without re-verification).
+		if hasPendingJustifications {
+			drainedJustifications := drainPendingIncomingJustifications()
+
+			log.Info(asyncCtx, "Replaying cached justifications after kernel recovery",
+				"round", dkgNetwork.Round,
+				"num_justifications", len(drainedJustifications),
+			)
+
+			k.forwardJustificationsToKernel(asyncCtx, dkgNetwork, drainedJustifications)
+		}
+	}()
+}
+
+func drainPendingIncomingDeals() []types.Deal {
+	pendingIncomingDealsMu.Lock()
+	defer pendingIncomingDealsMu.Unlock()
+
+	out := pendingIncomingDeals
+	pendingIncomingDeals = nil
+
+	return out
+}
+
+func drainPendingIncomingResponses() []types.Response {
+	pendingIncomingResponsesMu.Lock()
+	defer pendingIncomingResponsesMu.Unlock()
+
+	out := pendingIncomingResponses
+	pendingIncomingResponses = nil
+
+	return out
+}
+
+func drainPendingIncomingJustifications() []types.Justification {
+	pendingIncomingJustificationsMu.Lock()
+	defer pendingIncomingJustificationsMu.Unlock()
+
+	out := pendingIncomingJustifications
+	pendingIncomingJustifications = nil
+
+	return out
+}
+
+func flushPendingIncoming() {
+	pendingIncomingDealsMu.Lock()
+	pendingIncomingDeals = nil
+	pendingIncomingDealsMu.Unlock()
+
+	pendingIncomingResponsesMu.Lock()
+	pendingIncomingResponses = nil
+	pendingIncomingResponsesMu.Unlock()
+
+	pendingIncomingJustificationsMu.Lock()
+	pendingIncomingJustifications = nil
+	pendingIncomingJustificationsMu.Unlock()
+}
+
+// forwardJustificationsToKernel sends already-verified justifications to the kernel.
+// Used for replaying cached justifications that passed Schnorr + VSS verification
+// before caching but failed the kernel gRPC call.
+func (k *Keeper) forwardJustificationsToKernel(ctx context.Context, dkgNetwork *types.DKGNetwork, justifications []types.Justification) {
+	dkgKernelMu.Lock()
+	defer dkgKernelMu.Unlock()
+
+	session, err := k.stateManager.GetSession(dkgNetwork.Round)
+	if err != nil {
+		log.Error(ctx, "Failed to get DKG session for justification replay", err)
+
+		return
+	}
+
+	ccsToProcess := [][]byte{session.CodeCommitment}
+	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 && !bytes.Equal(session.CodeCommitment, session.OldCodeCommitment) {
+		ccsToProcess = append(ccsToProcess, session.OldCodeCommitment)
+	}
+
+	for _, cc := range ccsToProcess {
+		if err := retry(ctx, func(ctx context.Context) error {
+			req := &types.ProcessJustificationRequest{
+				CodeCommitment: cc,
+				Round:          session.Round,
+				Justifications: justifications,
+				IsResharing:    session.IsResharing,
+			}
+
+			client, cErr := k.kernelRouter.GetClient(cc)
+			if cErr != nil {
+				return errors.Wrap(cErr, "no kernel client for session")
+			}
+
+			if _, err := client.ProcessJustification(ctx, req); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			log.Error(ctx, "Failed to replay justifications", err,
+				"code_commitment", hex.EncodeToString(cc),
+			)
+
+			cachePendingIncomingJustifications(justifications)
+
+			continue
+		}
+	}
+}
+
 func (k *Keeper) shouldProcessResponses(ctx context.Context, dkgNetwork *types.DKGNetwork) (bool, error) {
 	inCurSet := slices.Contains(dkgNetwork.ActiveValSet, k.validatorEVMAddr)
 
-	inPrevSet, err := k.isInPrevActiveValSet(ctx)
+	prevActive, err := k.getLatestActiveDKGNetwork(ctx)
 	if err != nil {
-		if errors.Is(err, collections.ErrNotFound) {
-			// First DKG round: only current set of validators process deals or responses
-			return inCurSet, nil
-		}
-
 		return false, err
 	}
 
+	if prevActive == nil {
+		// First DKG round (no previous active round): current set of validators process
+		return inCurSet, nil
+	}
+
 	// Resharing round: both previous and current set of validators process deals or responses
+	inPrevSet := slices.Contains(prevActive.ActiveValSet, k.validatorEVMAddr)
+
 	return inCurSet || inPrevSet, nil
 }

--- a/client/x/dkg/keeper/dkg_svc_finalization.go
+++ b/client/x/dkg/keeper/dkg_svc_finalization.go
@@ -16,12 +16,14 @@ func (k *Keeper) handleDKGFinalization(ctx context.Context, dkgNetwork *types.DK
 		"round", dkgNetwork.Round,
 	)
 
-	if !dkgSvcRunning.CompareAndSwap(false, true) {
-		log.Info(ctx, "DKG service already running; skipping finalization")
+	if !tryAcquireDKGSvc(dkgNetwork.Round) {
+		log.Info(ctx, "DKG service already running for this round; skipping finalization",
+			"round", dkgNetwork.Round,
+		)
 
 		return
 	}
-	defer dkgSvcRunning.Store(false)
+	defer releaseDKGSvc(dkgNetwork.Round)
 
 	if dkgNetwork.Stage != types.DKGStageFinalization {
 		log.Info(ctx, "DKG Finalization is skipped because the current network stage is not in the finalization stage")

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -14,17 +14,21 @@ import (
 )
 
 // handleDKGRegistration handles the DKG registration.
-func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DKGNetwork) {
+// oldCC is the pre-computed old code commitment from the previous active DKG round,
+// resolved before the goroutine (which requires SDK context for KV store access).
+func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DKGNetwork, oldCC []byte) {
 	log.Info(ctx, "Handling DKG registration",
 		"round", dkgNetwork.Round,
 	)
 
-	if !dkgSvcRunning.CompareAndSwap(false, true) {
-		log.Info(ctx, "DKG service already running; skipping registration")
+	if !tryAcquireDKGSvc(dkgNetwork.Round) {
+		log.Info(ctx, "DKG service already running for this round; skipping registration",
+			"round", dkgNetwork.Round,
+		)
 
 		return
 	}
-	defer dkgSvcRunning.Store(false)
+	defer releaseDKGSvc(dkgNetwork.Round)
 
 	if dkgNetwork.Stage != types.DKGStageRegistration {
 		log.Info(ctx, "DKG registration is skipped because the current network stage is not in the registration stage")
@@ -44,15 +48,13 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 
 	// For upgrade rounds, store the old binary's code commitment so that dealers
 	// can route TEE calls to the correct (old) binary for deal generation.
-	if dkgNetwork.IsUpgrade {
-		if oldCC, err := k.getOldCodeCommitment(ctx); err == nil && len(oldCC) > 0 {
-			session.OldCodeCommitment = oldCC
+	if dkgNetwork.IsUpgrade && len(oldCC) > 0 {
+		session.OldCodeCommitment = oldCC
 
-			// For old-only members (not in current round set), set CodeCommitment
-			// to old CC so they have a valid routing target for processing deals/responses.
-			if !isInCurRoundSet {
-				session.CodeCommitment = oldCC
-			}
+		// For old-only members (not in current round set), set CodeCommitment
+		// to old CC so they have a valid routing target for processing deals/responses.
+		if !isInCurRoundSet {
+			session.CodeCommitment = oldCC
 		}
 	}
 
@@ -78,7 +80,7 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 		return
 	}
 
-	if err := k.callTEEGenerateAndSealKey(ctx, session, dkgNetwork.IsUpgrade); err != nil {
+	if err := k.callTEEGenerateAndSealKey(ctx, session, dkgNetwork.IsUpgrade, oldCC); err != nil {
 		log.Error(ctx, "Failed to generate the sealed key", err)
 		k.stateManager.MarkFailed(ctx, session)
 
@@ -106,7 +108,7 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 	)
 }
 
-func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.DKGSession, isUpgrade bool) error {
+func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.DKGSession, isUpgrade bool, oldCC []byte) error {
 	log.Info(ctx, "GenerateAndSealKey call to kernel client",
 		"round", session.Round,
 		"validator", k.validatorEVMAddr,
@@ -121,9 +123,15 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 
 	// For upgrade rounds, route to the NEW binary's kernel client (CC != oldCC).
 	// For normal rounds, route to the previous active round's kernel client.
-	client, cErr := k.getRegistrationKernelClient(ctx, isUpgrade, session.OldCodeCommitment)
+	client, clientCC, cErr := k.getRegistrationKernelClient(isUpgrade, oldCC, session.OldCodeCommitment)
 	if cErr != nil {
 		return errors.Wrap(cErr, "no kernel client available for registration")
+	}
+
+	// Set the code commitment on the session from the resolved kernel client
+	// so the GenerateAndSealKey request includes it.
+	if len(session.CodeCommitment) == 0 {
+		session.CodeCommitment = clientCC
 	}
 
 	var (
@@ -163,45 +171,53 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 	return nil
 }
 
-// getRegistrationKernelClient returns the appropriate kernel client for key generation.
+// getRegistrationKernelClient returns the appropriate kernel client and its code commitment for key generation.
 //
 // Non-upgrade: looks up the previous active round's code commitment from on-chain state
 // and returns the corresponding kernel client. For the very first round (no previous active
 // round exists), falls back to the first connected client.
 //
-// Upgrade: uses the provided oldCC to find the NEW binary — returns the connected client
-// whose code commitment differs from oldCC.
-func (k *Keeper) getRegistrationKernelClient(ctx context.Context, isUpgrade bool, oldCC []byte) (types.KernelServiceClient, error) {
+// Upgrade: uses the provided upgradeOldCC to find the NEW binary — returns the connected client
+// whose code commitment differs from upgradeOldCC.
+//
+// prevRoundCC is the code commitment from the previous active DKG round (pre-computed
+// from SDK context before the async goroutine).
+func (k *Keeper) getRegistrationKernelClient(isUpgrade bool, prevRoundCC []byte, upgradeOldCC []byte) (types.KernelServiceClient, []byte, error) {
 	if !isUpgrade {
-		// Derive CC from previous active round's registration (deterministic, on-chain state).
-		prevCC, err := k.getOldCodeCommitment(ctx)
-		if err == nil && len(prevCC) > 0 {
-			return k.kernelRouter.GetClient(prevCC)
+		// Use pre-computed CC from previous active round's registration.
+		if len(prevRoundCC) > 0 {
+			client, err := k.kernelRouter.GetClient(prevRoundCC)
+
+			return client, prevRoundCC, err
 		}
 
 		// First round: no previous active round exists. Use first connected client.
 		allCCs := k.kernelRouter.GetAllCodeCommitments()
 		if len(allCCs) == 0 {
-			return nil, errors.New("no kernel clients available for registration")
+			return nil, nil, errors.New("no kernel clients available for registration")
 		}
 
-		return k.kernelRouter.GetClient(allCCs[0])
+		client, err := k.kernelRouter.GetClient(allCCs[0])
+
+		return client, allCCs[0], err
 	}
 
-	// Upgrade: oldCC must be provided so we can find the NEW binary.
-	if len(oldCC) == 0 {
-		return nil, errors.New("old code commitment required for upgrade registration")
+	// Upgrade: upgradeOldCC must be provided so we can find the NEW binary.
+	if len(upgradeOldCC) == 0 {
+		return nil, nil, errors.New("old code commitment required for upgrade registration")
 	}
 
 	allCCs := k.kernelRouter.GetAllCodeCommitments()
 	for _, cc := range allCCs {
-		if !bytes.Equal(cc, oldCC) {
-			return k.kernelRouter.GetClient(cc)
+		if !bytes.Equal(cc, upgradeOldCC) {
+			client, err := k.kernelRouter.GetClient(cc)
+
+			return client, cc, err
 		}
 	}
 
-	return nil, errors.New("no new kernel client found for upgrade; ensure the new binary is running",
-		"old_code_commitment", hex.EncodeToString(oldCC),
+	return nil, nil, errors.New("no new kernel client found for upgrade; ensure the new binary is running",
+		"old_code_commitment", hex.EncodeToString(upgradeOldCC),
 		"connected_clients", len(allCCs),
 	)
 }
@@ -212,6 +228,10 @@ func (k *Keeper) getOldCodeCommitment(ctx context.Context) ([]byte, error) {
 	prevActive, err := k.getLatestActiveDKGNetwork(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	if prevActive == nil {
+		return nil, nil
 	}
 
 	prevReg, err := k.getDKGRegistration(ctx, prevActive.Round, common.HexToAddress(k.validatorEVMAddr))

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -28,6 +28,26 @@ var (
 	responses        []types.Response
 	justificationsMu sync.Mutex
 	justifications   []types.Justification
+
+	// dkgKernelMu serializes kernel DKG operations (ProcessDeals, ProcessResponses,
+	// ProcessJustifications) that all mutate the same cached DistKeyGenerator in
+	// story-kernel. Without this, concurrent goroutines corrupt the DKG state and
+	// cause "different number of coefficients" errors during finalization.
+	dkgKernelMu sync.Mutex
+
+	// pendingIncoming* hold deals/responses that failed kernel processing (e.g., kernel
+	// unreachable). They are retried on subsequent blocks when the kernel recovers.
+	// In-memory only — lost on process restart (round will fail and retry naturally).
+	// Deals MUST be replayed before responses (kyber's ErrNoDealBeforeResponse).
+	pendingIncomingDealsMu          sync.Mutex
+	pendingIncomingDeals            []types.Deal
+	pendingIncomingResponsesMu      sync.Mutex
+	pendingIncomingResponses        []types.Response
+	pendingIncomingJustificationsMu sync.Mutex
+	pendingIncomingJustifications   []types.Justification
+
+	// maxPendingIncoming caps the pending queue to prevent memory exhaustion.
+	maxPendingIncoming = 80
 )
 
 // Keeper of the dkg store.

--- a/client/x/dkg/keeper/kernel_client.go
+++ b/client/x/dkg/keeper/kernel_client.go
@@ -26,7 +26,13 @@ func CreateKernelClient(endpoint string) (types.KernelServiceClient, io.Closer, 
 		creds = insecure.NewCredentials()
 	}
 
-	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
+	// Use passthrough resolver for direct IP:port endpoints (grpc.NewClient defaults to DNS resolver)
+	target := endpoint
+	if !strings.Contains(endpoint, "://") {
+		target = "passthrough:///" + endpoint
+	}
+
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to connect to story-kernel client")
 	}

--- a/client/x/dkg/keeper/proposal_server.go
+++ b/client/x/dkg/keeper/proposal_server.go
@@ -19,17 +19,6 @@ func (s proposalServer) AddVote(ctx context.Context, msg *types.MsgAddDkgVote,
 		return nil, errors.New("unauthorized")
 	}
 
-	if s.isDKGSvcEnabled {
-		latestRound, err := s.GetLatestDKGRound(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get latest DKG round")
-		}
-
-		if latestRound != nil {
-			s.ResumeDKGService(ctx, latestRound)
-		}
-	}
-
 	return &types.AddDkgVoteResponse{}, nil
 }
 

--- a/client/x/dkg/keeper/queue.go
+++ b/client/x/dkg/keeper/queue.go
@@ -92,7 +92,7 @@ func (*Keeper) DequeueJustifications(count int) []types.Justification {
 	return out
 }
 
-// FlushAllQueues clears all deal, response, and justification queues.
+// FlushAllQueues clears all deal, response, justification, and pending incoming queues.
 // This should be called when a DKG round transitions to prevent stale data
 // from a previous round from being broadcast in the new round.
 func (*Keeper) FlushAllQueues() {
@@ -113,4 +113,7 @@ func (*Keeper) FlushAllQueues() {
 	justifications = nil
 
 	justificationsMu.Unlock()
+
+	// Also flush pending incoming data from failed kernel calls.
+	flushPendingIncoming()
 }

--- a/client/x/dkg/keeper/vote.go
+++ b/client/x/dkg/keeper/vote.go
@@ -7,7 +7,6 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/piplabs/story/client/x/dkg/types"
@@ -152,7 +151,7 @@ func (k *Keeper) PrepareVotes(ctx context.Context, commit abci.ExtendedCommitInf
 	votes := aggregateVotes(allVotes)
 
 	return &types.MsgAddDkgVote{
-		Authority: authtypes.NewModuleAddress(types.ModuleName).String(),
+		Authority: k.GetAuthority(),
 		Vote:      votes,
 	}, nil
 }

--- a/contracts/script/GenerateAlloc.s.sol
+++ b/contracts/script/GenerateAlloc.s.sol
@@ -12,6 +12,9 @@ import { IPTokenStaking } from "../src/protocol/IPTokenStaking.sol";
 import { UpgradeEntrypoint } from "../src/protocol/UpgradeEntrypoint.sol";
 import { UBIPool } from "../src/protocol/UBIPool.sol";
 import { DKG } from "../src/protocol/DKG.sol";
+import { CDR } from "../src/protocol/CDR.sol";
+import { SGXValidationHook } from "../src/protocol/SGXValidationHook.sol";
+import { IDKG } from "../src/interfaces/IDKG.sol";
 
 import { ChainIds } from "./utils/ChainIds.sol";
 import { EIP1967Helper } from "./utils/EIP1967Helper.sol";
@@ -55,6 +58,12 @@ contract GenerateAlloc is Script {
     bool private constant ALLOCATE_1K_TEST_ACCOUNTS = false;
     // Optionally keep the timelock admin role for testnets
     bool private constant KEEP_TIMELOCK_ADMIN_ROLE = false;
+
+    // SGXValidationHook configuration — edit before running the script
+    bytes32 private constant SGX_CODE_COMMITMENT =
+        hex"0000000000000000000000000000000000000000000000000000000000000001";
+    address private constant AUTOMATA_VALIDATION_ADDR = address(uint160(1000));
+    uint32 private constant TCB_EVALUATION_DATA_NUMBER = 0;
 
     /// @notice this call should only be available from Test.sol, for speed
     function disableStateDump() external {
@@ -185,6 +194,8 @@ contract GenerateAlloc is Script {
         setUpgrade();
         setUBIPool();
         setDKG();
+        setCDR();
+        setSGXValidationHook();
     }
 
     /// @dev Populates the upgradeable predeploys namespace with proxies, to reserve the addresses
@@ -338,10 +349,16 @@ contract GenerateAlloc is Script {
         console2.log("UBIPool owner:", UBIPool(Predeploys.UBIPool).owner());
     }
 
+    /// @notice Sets the bytecode for the implementation of DKG predeploy
     function setDKG() internal {
         address impl = Predeploys.getImplAddress(Predeploys.DKG);
         address tmp = address(new DKG());
         vm.etch(impl, tmp.code);
+
+        // reset tmp
+        vm.etch(tmp, "");
+        vm.store(tmp, 0, "0x");
+        vm.resetNonce(tmp);
 
         InitializableHelper.disableInitializers(impl);
 
@@ -357,10 +374,78 @@ contract GenerateAlloc is Script {
             fee
         );
 
+        console2.log("DKG proxy deployed at:", Predeploys.DKG);
+        console2.log("DKG ProxyAdmin deployed at:", EIP1967Helper.getAdmin(Predeploys.DKG));
+        console2.log("DKG impl at:", EIP1967Helper.getImplementation(Predeploys.DKG));
+        console2.log("DKG owner:", DKG(Predeploys.DKG).owner());
+    }
+
+    /// @notice Sets the bytecode for the implementation of CDR predeploy
+    function setCDR() internal {
+        address impl = Predeploys.getImplAddress(Predeploys.CDR);
+        address tmp = address(new CDR());
+        vm.etch(impl, tmp.code);
+
         // reset tmp
         vm.etch(tmp, "");
         vm.store(tmp, 0, "0x");
         vm.resetNonce(tmp);
+
+        InitializableHelper.disableInitializers(impl);
+
+        uint256 baseFee = 0;
+        uint256 writeFee = 0;
+        uint256 readFee = 0;
+        uint256 allocateFee = 0;
+        CDR(Predeploys.CDR).initialize(timelock, baseFee, writeFee, readFee, allocateFee);
+
+        console2.log("CDR proxy deployed at:", Predeploys.CDR);
+        console2.log("CDR ProxyAdmin deployed at:", EIP1967Helper.getAdmin(Predeploys.CDR));
+        console2.log("CDR impl at:", EIP1967Helper.getImplementation(Predeploys.CDR));
+        console2.log("CDR owner:", CDR(Predeploys.CDR).owner());
+    }
+
+    /// @notice Deploys SGXValidationHook (impl + proxy) via Create3 and whitelists it on DKG
+    /// @dev Edit SGX_CODE_COMMITMENT, AUTOMATA_VALIDATION_ADDR, TCB_EVALUATION_DATA_NUMBER constants above
+    function setSGXValidationHook() internal {
+        // Deploy SGXValidationHook implementation via Create3
+        bytes memory implCreationCode = abi.encodePacked(
+            type(SGXValidationHook).creationCode,
+            abi.encode(Predeploys.DKG)
+        );
+        address sgxHookImpl = Create3(Predeploys.Create3).deploy(
+            keccak256("STORY_SGX_VALIDATION_HOOK_IMPL"),
+            implCreationCode
+        );
+
+        // Deploy TransparentUpgradeableProxy wrapping the implementation via Create3
+        bytes memory initData = abi.encodeCall(
+            SGXValidationHook.initialize,
+            (timelock, AUTOMATA_VALIDATION_ADDR, TCB_EVALUATION_DATA_NUMBER)
+        );
+        bytes memory proxyCreationCode = abi.encodePacked(
+            type(TransparentUpgradeableProxy).creationCode,
+            abi.encode(sgxHookImpl, timelock, initData)
+        );
+        address sgxHookProxy = Create3(Predeploys.Create3).deploy(
+            keccak256("STORY_SGX_VALIDATION_HOOK_PROXY"),
+            proxyCreationCode
+        );
+
+        // Whitelist SGX enclave type on DKG (owner=timelock)
+        bytes32 enclaveType = bytes32(uint256(1));
+        IDKG.EnclaveTypeData memory enclaveTypeData = IDKG.EnclaveTypeData({
+            codeCommitment: SGX_CODE_COMMITMENT,
+            validationHookAddr: sgxHookProxy
+        });
+        vm.stopPrank();
+        vm.prank(timelock);
+        DKG(Predeploys.DKG).whitelistEnclaveType(enclaveType, enclaveTypeData, true);
+        vm.startPrank(deployer);
+
+        console2.log("SGXValidationHook impl deployed at:", sgxHookImpl);
+        console2.log("SGXValidationHook proxy deployed at:", sgxHookProxy);
+        console2.log("SGXValidationHook owner:", SGXValidationHook(sgxHookProxy).owner());
     }
 
     /// @notice Sets the bytecode for Create3 factory as a predeploy

--- a/contracts/script/upgrades/DeployNewCDR.s.sol
+++ b/contracts/script/upgrades/DeployNewCDR.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+/* solhint-disable no-console */
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { CDR } from "../../src/protocol/CDR.sol";
+import { Predeploys } from "../../src/libraries/Predeploys.sol";
+import { Create3 } from "../../src/deploy/Create3.sol";
+
+/**
+ * @title DeployNewCDR
+ * @notice Deploys a new implementation of CDR contract to be used for upgrading the predeploy at
+ *         0xCcCcCC0000000000000000000000000000000005
+ * @dev This script only deploys the implementation contract, it does not perform the upgrade.
+ *      The actual proxy upgrade must be executed through governance (timelock).
+ */
+contract DeployNewCDR is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        Create3 create3 = Create3(Predeploys.Create3);
+
+        // CDR has no constructor args (only _disableInitializers in constructor)
+        bytes memory creationCode = type(CDR).creationCode;
+
+        bytes32 salt = keccak256(abi.encodePacked("CDR_Implementation_v1_0_0"));
+
+        // Deploy using Create3 for deterministic address
+        address newImplementation = create3.deploy(salt, creationCode);
+        if (create3.getDeployed(deployer, salt) != newImplementation) {
+            revert("Deployment failed");
+        }
+
+        vm.stopBroadcast();
+
+        console2.log("New CDR implementation deployed at:", newImplementation);
+        console2.log("CDR proxy address:", Predeploys.CDR);
+    }
+}

--- a/contracts/script/upgrades/DeployNewDKG.s.sol
+++ b/contracts/script/upgrades/DeployNewDKG.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+/* solhint-disable no-console */
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { DKG } from "../../src/protocol/DKG.sol";
+import { Predeploys } from "../../src/libraries/Predeploys.sol";
+import { Create3 } from "../../src/deploy/Create3.sol";
+
+/**
+ * @title DeployNewDKG
+ * @notice Deploys a new implementation of DKG contract to be used for upgrading the predeploy at
+ *         0xCcCcCC0000000000000000000000000000000004
+ * @dev This script only deploys the implementation contract, it does not perform the upgrade.
+ *
+ *      After running this script, the following steps must be completed through governance (timelock):
+ *        1. Upgrade DKG proxy — call ProxyAdmin.upgradeAndCall(DKG_PROXY, newImpl, "")
+ *        2. Deploy SGXValidationHook — run DeploySGXValidationHook.s.sol
+ *        3. Whitelist enclave type — call DKG.whitelistEnclaveType(enclaveType, enclaveTypeData, true)
+ *           (see DeploySGXValidationHook.s.sol output for the required arguments)
+ */
+contract DeployNewDKG is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        Create3 create3 = Create3(Predeploys.Create3);
+
+        // DKG has no constructor args (only _disableInitializers in constructor)
+        bytes memory creationCode = type(DKG).creationCode;
+
+        bytes32 salt = keccak256(abi.encodePacked("DKG_Implementation_v1_0_0"));
+
+        // Deploy using Create3 for deterministic address
+        address newImplementation = create3.deploy(salt, creationCode);
+        if (create3.getDeployed(deployer, salt) != newImplementation) {
+            revert("Deployment failed");
+        }
+
+        vm.stopBroadcast();
+
+        console2.log("New DKG implementation deployed at:", newImplementation);
+        console2.log("DKG proxy address:", Predeploys.DKG);
+        console2.log("---");
+        console2.log("NOTE: After deployment, complete the following through governance (timelock):");
+        console2.log("  1. Upgrade DKG proxy to the new implementation");
+        console2.log("  2. Deploy SGXValidationHook (run DeploySGXValidationHook.s.sol)");
+        console2.log("  3. Whitelist enclave type on DKG using the SGXValidationHook proxy address");
+    }
+}

--- a/contracts/script/upgrades/DeploySGXValidationHook.s.sol
+++ b/contracts/script/upgrades/DeploySGXValidationHook.s.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+/* solhint-disable no-console */
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { SGXValidationHook } from "../../src/protocol/SGXValidationHook.sol";
+import { Predeploys } from "../../src/libraries/Predeploys.sol";
+import { Create3 } from "../../src/deploy/Create3.sol";
+
+/**
+ * @title DeploySGXValidationHook
+ * @notice Deploys SGXValidationHook (implementation + TransparentUpgradeableProxy) and outputs
+ *         the data required to whitelist it on DKG at 0xCcCcCC0000000000000000000000000000000004
+ * @dev This script only deploys the SGXValidationHook contracts.
+ *      After running, call DKG.whitelistEnclaveType through governance (timelock) using the
+ *      logged arguments below.
+ *
+ *      Required env vars:
+ *        DEPLOYER_PRIVATE_KEY          — deployer's private key
+ *        OWNER_ADDRESS                 — owner of SGXValidationHook and ProxyAdmin (typically timelock)
+ *        AUTOMATA_VALIDATION_ADDR      — address of automata DCAP attestation contract
+ *        TCB_EVALUATION_DATA_NUMBER    — TCB evaluation data number (uint)
+ *
+ *      Edit SGX_CODE_COMMITMENT constant below before running.
+ */
+contract DeploySGXValidationHook is Script {
+    /*//////////////////////////////////////////////////////////////////////////
+    //                    Edit before running the script                      //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    // SGX enclave code commitment — update this hex value before deployment
+    bytes32 constant SGX_CODE_COMMITMENT = hex"0000000000000000000000000000000000000000000000000000000000000001";
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                          Internal constants                            //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    bytes32 constant SGX_IMPL_SALT = keccak256(abi.encodePacked("SGXValidationHook_Implementation_v1_0_0"));
+    bytes32 constant SGX_PROXY_SALT = keccak256(abi.encodePacked("SGXValidationHook_Proxy_v1_0_0"));
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address owner = vm.envAddress("OWNER_ADDRESS");
+        address automataValidationAddr = vm.envAddress("AUTOMATA_VALIDATION_ADDR");
+        uint32 tcbEvaluationDataNumber = uint32(vm.envUint("TCB_EVALUATION_DATA_NUMBER"));
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        Create3 create3 = Create3(Predeploys.Create3);
+
+        // Deploy SGXValidationHook implementation via Create3
+        bytes memory implCreationCode = abi.encodePacked(
+            type(SGXValidationHook).creationCode,
+            abi.encode(Predeploys.DKG)
+        );
+        address sgxHookImpl = create3.deploy(SGX_IMPL_SALT, implCreationCode);
+
+        // Deploy TransparentUpgradeableProxy wrapping the implementation via Create3
+        bytes memory initData = abi.encodeCall(
+            SGXValidationHook.initialize,
+            (owner, automataValidationAddr, tcbEvaluationDataNumber)
+        );
+        bytes memory proxyCreationCode = abi.encodePacked(
+            type(TransparentUpgradeableProxy).creationCode,
+            abi.encode(sgxHookImpl, owner, initData)
+        );
+        address sgxHookProxy = create3.deploy(SGX_PROXY_SALT, proxyCreationCode);
+
+        vm.stopBroadcast();
+
+        // Log deployment results
+        console2.log("SGXValidationHook impl deployed at:", sgxHookImpl);
+        console2.log("SGXValidationHook proxy deployed at:", sgxHookProxy);
+
+        // Log whitelisting data for DKG governance action
+        console2.log("---");
+        console2.log("To whitelist this hook on DKG, call DKG.whitelistEnclaveType through governance with:");
+        console2.log("  target:", Predeploys.DKG);
+        console2.log("  enclaveType:", uint256(1));
+        console2.log("  enclaveTypeData.codeCommitment:");
+        console2.logBytes32(SGX_CODE_COMMITMENT);
+        console2.log("  enclaveTypeData.validationHookAddr:", sgxHookProxy);
+        console2.log("  isWhitelisted: true");
+    }
+}

--- a/contracts/src/interfaces/ICDR.sol
+++ b/contracts/src/interfaces/ICDR.sol
@@ -50,12 +50,7 @@ interface ICDR {
     /// @param requester The address requesting the read (msg.sender)
     /// @param ciphertext The encrypted data (ciphertext)
     /// @param requesterPubKey The public key of the requester
-    event VaultRead(
-        uint32 uuid,
-        address indexed requester,
-        bytes ciphertext,
-        bytes requesterPubKey
-    );
+    event VaultRead(uint32 uuid, address indexed requester, bytes ciphertext, bytes requesterPubKey);
 
     /// @notice Emitted when an encrypted partial decryption is submitted
     /// @param validator The address of the submitting validator (msg.sender)
@@ -128,11 +123,7 @@ interface ICDR {
     /// @param uuid The UUID of the vault
     /// @param accessAuxData The auxiliary access data for reading
     /// @param requesterPubKey The public key of the requester
-    function read(
-        uint32 uuid,
-        bytes memory accessAuxData,
-        bytes calldata requesterPubKey
-    ) external payable;
+    function read(uint32 uuid, bytes memory accessAuxData, bytes calldata requesterPubKey) external payable;
 
     /// @notice Submits an encrypted partial decryption
     /// @param round The DKG round number

--- a/contracts/src/libraries/Predeploys.sol
+++ b/contracts/src/libraries/Predeploys.sol
@@ -27,6 +27,8 @@ library Predeploys {
     address internal constant Upgrades = 0xccCCcc0000000000000000000000000000000003;
     /// @dev DKG proxy address
     address internal constant DKG = 0xCcCcCC0000000000000000000000000000000004;
+    /// @dev CDR proxy address
+    address internal constant CDR = 0xCCCcCC0000000000000000000000000000000005;
 
     /// @notice Create3 factory address https://github.com/ZeframLou/create3-factory
     /// @dev Since Create3 is deployed using Create2, which is deterministic but depends on the deployer's wallet,

--- a/contracts/src/protocol/CDR.sol
+++ b/contracts/src/protocol/CDR.sol
@@ -32,6 +32,34 @@ contract CDR is ICDR, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Pausa
     // keccak256(abi.encode(uint256(keccak256("story.CDR")) - 1)) & ~bytes32(uint256(0xff));
     bytes32 private constant CDRStorageLocation = 0x38eb98a52971d8773d43e336c762a70f1492f62ea143e494a29d8ec99eadf600;
 
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the contract
+    /// @param owner The address of the owner of the contract
+    /// @param baseFee The base fee for partial decryption submissions
+    /// @param writeFee The fee for writing data to a vault
+    /// @param readFee The fee for reading data from a vault
+    /// @param allocateFee The fee for allocating a new vault
+    function initialize(
+        address owner,
+        uint256 baseFee,
+        uint256 writeFee,
+        uint256 readFee,
+        uint256 allocateFee
+    ) external initializer {
+        __Ownable_init(owner);
+        __ReentrancyGuard_init();
+        __Pausable_init();
+        __UUPSUpgradeable_init();
+
+        _setBaseFee(baseFee);
+        _setWriteFee(writeFee);
+        _setReadFee(readFee);
+        _setAllocateFee(allocateFee);
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
     //                             Admin Setters                              //
     //////////////////////////////////////////////////////////////////////////*/

--- a/contracts/test/cdr/cdr.t.sol
+++ b/contracts/test/cdr/cdr.t.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+/* solhint-disable no-console */
+/* solhint-disable max-line-length */
+
+import { CDR } from "../../src/protocol/CDR.sol";
+import { ICDR } from "../../src/interfaces/ICDR.sol";
+import { Predeploys } from "../../src/libraries/Predeploys.sol";
+import { Test } from "../utils/Test.sol";
+
+contract CDRTest is Test {
+    CDR internal cdr;
+
+    function setUp() public virtual override {
+        super.setUp();
+        cdr = CDR(Predeploys.CDR);
+    }
+
+    function testCDR_Initialize() public view {
+        assertEq(cdr.owner(), address(timelock));
+        assertEq(cdr.baseFee(), 0);
+        assertEq(cdr.writeFee(), 0);
+        assertEq(cdr.readFee(), 0);
+        assertEq(cdr.allocateFee(), 0);
+        assertEq(cdr.uuid(), 0);
+    }
+
+    function testCDR_SetBaseFee() public {
+        uint256 newBaseFee = 0.1 ether;
+        performTimelocked(address(cdr), abi.encodeWithSelector(CDR.setBaseFee.selector, newBaseFee));
+        assertEq(cdr.baseFee(), newBaseFee);
+    }
+
+    function testCDR_SetWriteFee() public {
+        uint256 newWriteFee = 0.2 ether;
+        performTimelocked(address(cdr), abi.encodeWithSelector(CDR.setWriteFee.selector, newWriteFee));
+        assertEq(cdr.writeFee(), newWriteFee);
+    }
+
+    function testCDR_SetReadFee() public {
+        uint256 newReadFee = 0.3 ether;
+        performTimelocked(address(cdr), abi.encodeWithSelector(CDR.setReadFee.selector, newReadFee));
+        assertEq(cdr.readFee(), newReadFee);
+    }
+
+    function testCDR_SetAllocateFee() public {
+        uint256 newAllocateFee = 0.4 ether;
+        performTimelocked(address(cdr), abi.encodeWithSelector(CDR.setAllocateFee.selector, newAllocateFee));
+        assertEq(cdr.allocateFee(), newAllocateFee);
+    }
+
+    function testCDR_SetFee_RevertIfNotOwner() public {
+        vm.expectRevert();
+        cdr.setBaseFee(1 ether);
+
+        vm.expectRevert();
+        cdr.setWriteFee(1 ether);
+
+        vm.expectRevert();
+        cdr.setReadFee(1 ether);
+
+        vm.expectRevert();
+        cdr.setAllocateFee(1 ether);
+    }
+
+    function testCDR_Allocate() public {
+        address writeCondition = address(0xAAA);
+        address readCondition = address(0xBBB);
+        bytes memory writeConditionData = abi.encode("write");
+        bytes memory readConditionData = abi.encode("read");
+
+        uint32 vaultUuid = cdr.allocate(true, writeCondition, readCondition, writeConditionData, readConditionData);
+
+        assertEq(vaultUuid, 0);
+
+        ICDR.Vault memory vault = cdr.vaults(vaultUuid);
+        assertEq(vault.updatable, true);
+        assertEq(vault.writeConditionAddr, writeCondition);
+        assertEq(vault.readConditionAddr, readCondition);
+        assertEq(vault.writeConditionData, writeConditionData);
+        assertEq(vault.readConditionData, readConditionData);
+        assertEq(vault.encryptedData.length, 0);
+    }
+
+    function testCDR_Allocate_RevertIfBothConditionsZero() public {
+        vm.expectRevert("Invalid condition address");
+        cdr.allocate(true, address(0), address(0), "", "");
+    }
+
+    function testCDR_Allocate_WithFee() public {
+        uint256 fee = 0.5 ether;
+        performTimelocked(address(cdr), abi.encodeWithSelector(CDR.setAllocateFee.selector, fee));
+
+        // Should revert without fee
+        vm.expectRevert("CDR: Invalid fee amount");
+        cdr.allocate(true, address(0xAAA), address(0xBBB), "", "");
+
+        // Should succeed with correct fee
+        vm.deal(address(this), fee);
+        cdr.allocate{ value: fee }(true, address(0xAAA), address(0xBBB), "", "");
+    }
+
+    function testCDR_Allocate_IncrementingUuid() public {
+        uint32 uuid0 = cdr.allocate(true, address(0xAAA), address(0xBBB), "", "");
+        uint32 uuid1 = cdr.allocate(true, address(0xAAA), address(0xBBB), "", "");
+        uint32 uuid2 = cdr.allocate(true, address(0xAAA), address(0xBBB), "", "");
+
+        assertEq(uuid0, 0);
+        assertEq(uuid1, 1);
+        assertEq(uuid2, 2);
+        assertEq(cdr.uuid(), 3);
+    }
+}

--- a/contracts/test/dkg/dkg.t.sol
+++ b/contracts/test/dkg/dkg.t.sol
@@ -13,44 +13,71 @@ import { Test } from "../utils/Test.sol";
 
 contract DKGTest is Test {
     DKG internal dkg;
-    address internal sgxHookProxy;
+
+    // Genesis enclave type set by GenerateAlloc.setSGXValidationHook()
+    bytes32 internal constant GENESIS_ENCLAVE_TYPE = bytes32(uint256(1));
 
     function setUp() public virtual override {
         super.setUp();
-
         dkg = DKG(Predeploys.DKG);
-
-        address automataValidationAddr = address(1000); // TODO: set this to the actual automata validation address
-        uint32 tcbEvaluationDataNumber = 0;
-        address sgxHookImpl = address(new SGXValidationHook(Predeploys.DKG));
-        sgxHookProxy = address(
-            new ERC1967Proxy(
-                sgxHookImpl,
-                abi.encodeCall(
-                    SGXValidationHook.initialize,
-                    (address(timelock), automataValidationAddr, tcbEvaluationDataNumber)
-                )
-            )
-        );
-
-        // whitelist the SGX validation hook in DKG contract
-        IDKG.EnclaveTypeData memory enclaveTypeData = IDKG.EnclaveTypeData({
-            codeCommitment: bytes32(uint256(1)), // TODO: set this to the actual code commitment
-            validationHookAddr: sgxHookProxy
-        });
-        performTimelocked(
-            address(dkg),
-            abi.encodeWithSelector(DKG.whitelistEnclaveType.selector, bytes32("SGX"), enclaveTypeData, true)
-        );
     }
 
-    function testDKG_Initialize() public {
+    function testDKG_Initialize() public view {
         assertEq(dkg.minReqRegisteredParticipants(), 3);
         assertEq(dkg.minReqFinalizedParticipants(), 3);
         assertEq(dkg.operationalThreshold(), 670);
         assertEq(dkg.fee(), 1 ether);
-        assertEq(dkg.enclaveTypeData(bytes32("SGX")).validationHookAddr, sgxHookProxy);
-        assertEq(dkg.enclaveTypeData(bytes32("SGX")).codeCommitment, bytes32(uint256(1)));
-        assertEq(dkg.isEnclaveTypeWhitelisted(bytes32("SGX")), true);
+    }
+
+    function testDKG_GenesisEnclaveTypeWhitelisted() public view {
+        assertTrue(dkg.isEnclaveTypeWhitelisted(GENESIS_ENCLAVE_TYPE));
+
+        IDKG.EnclaveTypeData memory data = dkg.enclaveTypeData(GENESIS_ENCLAVE_TYPE);
+        assertEq(data.codeCommitment, bytes32(uint256(1)));
+        assertTrue(data.validationHookAddr != address(0));
+    }
+
+    function testDKG_GenesisSGXValidationHook() public view {
+        IDKG.EnclaveTypeData memory data = dkg.enclaveTypeData(GENESIS_ENCLAVE_TYPE);
+        SGXValidationHook sgxHook = SGXValidationHook(data.validationHookAddr);
+
+        assertEq(sgxHook.owner(), address(timelock));
+        assertEq(sgxHook.DKG(), Predeploys.DKG);
+        assertEq(sgxHook.automataValidationAddr(), address(uint160(1000)));
+        assertEq(sgxHook.tcbEvaluationDataNumber(), 0);
+    }
+
+    function testDKG_WhitelistNewEnclaveType() public {
+        address sgxHookImpl = address(new SGXValidationHook(Predeploys.DKG));
+        address sgxHookProxy = address(
+            new ERC1967Proxy(
+                sgxHookImpl,
+                abi.encodeCall(SGXValidationHook.initialize, (address(timelock), address(2000), 1))
+            )
+        );
+
+        bytes32 newEnclaveType = bytes32(uint256(2));
+        IDKG.EnclaveTypeData memory enclaveTypeData = IDKG.EnclaveTypeData({
+            codeCommitment: bytes32(uint256(42)),
+            validationHookAddr: sgxHookProxy
+        });
+        performTimelocked(
+            address(dkg),
+            abi.encodeWithSelector(DKG.whitelistEnclaveType.selector, newEnclaveType, enclaveTypeData, true)
+        );
+
+        assertTrue(dkg.isEnclaveTypeWhitelisted(newEnclaveType));
+        assertEq(dkg.enclaveTypeData(newEnclaveType).validationHookAddr, sgxHookProxy);
+        assertEq(dkg.enclaveTypeData(newEnclaveType).codeCommitment, bytes32(uint256(42)));
+    }
+
+    function testDKG_WhitelistEnclaveType_RevertIfNotOwner() public {
+        IDKG.EnclaveTypeData memory enclaveTypeData = IDKG.EnclaveTypeData({
+            codeCommitment: bytes32(uint256(1)),
+            validationHookAddr: address(1)
+        });
+
+        vm.expectRevert();
+        dkg.whitelistEnclaveType(bytes32(uint256(99)), enclaveTypeData, true);
     }
 }

--- a/contracts/test/upgrades/PredeployUpgrades.t.sol
+++ b/contracts/test/upgrades/PredeployUpgrades.t.sol
@@ -8,6 +8,8 @@ import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/tran
 import { IPTokenStaking } from "../../src/protocol/IPTokenStaking.sol";
 import { UpgradeEntrypoint } from "../../src/protocol/UpgradeEntrypoint.sol";
 import { UBIPool } from "../../src/protocol/UBIPool.sol";
+import { DKG } from "../../src/protocol/DKG.sol";
+import { CDR } from "../../src/protocol/CDR.sol";
 
 import { EIP1967Helper } from "../../script/utils/EIP1967Helper.sol";
 import { Predeploys } from "../../src/libraries/Predeploys.sol";
@@ -30,6 +32,10 @@ contract UpgradeEntrypointV2 is UpgradeEntrypoint, MockNewFeatures {}
 contract UBIPoolV2 is UBIPool, MockNewFeatures {
     constructor(uint32 maxUBIPercentage) UBIPool(maxUBIPercentage) {}
 }
+
+contract DKGV2 is DKG, MockNewFeatures {}
+
+contract CDRV2 is CDR, MockNewFeatures {}
 
 contract InitialImplementation {
     function foo() external pure returns (string memory) {
@@ -115,6 +121,57 @@ contract PredeployUpgrades is Test {
             keccak256(abi.encode("bar")),
             "Upgraded to wrong iface"
         );
+    }
+
+    function testUpgradeDKG() public {
+        address newImpl = address(new DKGV2());
+        ProxyAdmin proxyAdmin = ProxyAdmin(EIP1967Helper.getAdmin(Predeploys.DKG));
+        assertEq(proxyAdmin.owner(), address(timelock));
+
+        performTimelocked(
+            address(proxyAdmin),
+            abi.encodeWithSelector(
+                ProxyAdmin.upgradeAndCall.selector,
+                ITransparentUpgradeableProxy(Predeploys.DKG),
+                newImpl,
+                ""
+            )
+        );
+
+        assertEq(EIP1967Helper.getImplementation(Predeploys.DKG), newImpl, "DKG not upgraded");
+        assertEq(
+            keccak256(abi.encode(DKGV2(Predeploys.DKG).foo())),
+            keccak256(abi.encode("bar")),
+            "Upgraded to wrong iface"
+        );
+        // Verify existing state is preserved after upgrade
+        assertEq(DKG(Predeploys.DKG).minReqRegisteredParticipants(), 3);
+        assertEq(DKG(Predeploys.DKG).fee(), 1 ether);
+    }
+
+    function testUpgradeCDR() public {
+        address newImpl = address(new CDRV2());
+        ProxyAdmin proxyAdmin = ProxyAdmin(EIP1967Helper.getAdmin(Predeploys.CDR));
+        assertEq(proxyAdmin.owner(), address(timelock));
+
+        performTimelocked(
+            address(proxyAdmin),
+            abi.encodeWithSelector(
+                ProxyAdmin.upgradeAndCall.selector,
+                ITransparentUpgradeableProxy(Predeploys.CDR),
+                newImpl,
+                ""
+            )
+        );
+
+        assertEq(EIP1967Helper.getImplementation(Predeploys.CDR), newImpl, "CDR not upgraded");
+        assertEq(
+            keccak256(abi.encode(CDRV2(Predeploys.CDR).foo())),
+            keccak256(abi.encode("bar")),
+            "Upgraded to wrong iface"
+        );
+        // Verify existing state is preserved after upgrade
+        assertEq(CDR(Predeploys.CDR).owner(), address(timelock));
     }
 
     function testUpgradeUnusedProxies() public {

--- a/lib/cmd/cmd.go
+++ b/lib/cmd/cmd.go
@@ -157,6 +157,16 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 				val = strings.Join(kvs, ",")
 			}
 
+			// Special case handling of stringSlice flags.
+			// viper returns []interface{} for TOML arrays, fmt.Sprintf produces "[a b]"
+			// which pflag's StringSlice parses as a single element "[a b]" including brackets.
+			// Convert to CSV format "a,b" which pflag expects.
+			if f.Value.Type() == "stringSlice" {
+				if ss := v.GetStringSlice(name); len(ss) > 0 {
+					val = strings.Join(ss, ",")
+				}
+			}
+
 			err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
 			if err != nil {
 				lastErr = err


### PR DESCRIPTION
  ## Summary

  - Add CDR (Confidential Data Registry) and SGXValidationHook genesis deployment to
    GenerateAlloc, alongside the existing DKG predeploy setup
  - Add CDR predeploy address (0xCCCcCC...0005) to Predeploys library
  - Add CDR constructor, initializer, and fix `allocate()` return value bug
  - Deploy SGXValidationHook (impl + proxy) via Create3 and whitelist SGX enclave
    type on DKG during genesis allocation
  - Add upgrade deployment scripts (DeployNewDKG, DeployNewCDR, DeploySGXValidationHook)
    for post-genesis contract upgrades via governance
  - Add CDR test suite (initialize, fee setters, allocate, write, read, access control)
  - Expand DKG test suite (SGXValidationHook genesis verification, enclave type whitelisting)
  - Add predeploy upgrade test (PredeployUpgrades.t.sol)

issue: none
