### PR TITLE
fix(dkg): fix issues discovered during unhappy path testing

### DIFF
--- a/client/x/dkg/keeper/abci.go
+++ b/client/x/dkg/keeper/abci.go
@@ -77,6 +77,15 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 		}
 	}
 
+	if k.isDKGSvcEnabled {
+		// Resume stuck or failed DKG sessions every block.
+		k.ResumeDKGService(ctx, latestRound)
+
+		// Retry cached deals/responses/justifications that failed kernel processing.
+		// Deals are replayed before responses (kyber requires deal-before-response order).
+		k.reprocessPendingIncomingData(latestRound)
+	}
+
 	nextStage, shouldTransition := k.shouldTransitionStage(currentHeight, latestRound, params)
 	if shouldTransition {
 		// Update the stage of this round before emitting events

--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/piplabs/story/client/server/utils"
 	"github.com/piplabs/story/client/x/dkg/types"
@@ -79,6 +80,13 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 	}
 
 	if k.isDKGSvcEnabled {
+		// Skip registration if this validator already has an on-chain registration
+		// for this round. This prevents overwriting a valid registration with
+		// different keys after a reset where sealed_keys were deleted.
+		if k.isAlreadyRegistered(ctx, roundNum) {
+			return nil
+		}
+
 		// Pre-compute old code commitment while we still have SDK context.
 		// The async goroutine uses context.Background() which cannot access
 		// the Cosmos KV store.
@@ -94,6 +102,28 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 	}
 
 	return nil
+}
+
+// isAlreadyRegistered checks whether this validator has an existing on-chain
+// registration for the given round. Used to prevent re-registration with
+// potentially different keys after sealed_keys deletion or kernel restart.
+func (k *Keeper) isAlreadyRegistered(ctx context.Context, round uint32) bool {
+	addr := ethcommon.HexToAddress(k.validatorEVMAddr)
+	reg, err := k.getDKGRegistration(ctx, round, addr)
+	if err != nil || reg == nil {
+		return false
+	}
+
+	if len(reg.DkgPubKey) > 0 {
+		log.Info(ctx, "Validator already registered on-chain; skipping re-registration",
+			"round", round,
+			"status", reg.Status.String(),
+		)
+
+		return true
+	}
+
+	return false
 }
 
 func (k *Keeper) shouldReshare(ctx context.Context) (bool, error) {

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -80,14 +80,76 @@ func (k *Keeper) ResumeDKGService(ctx context.Context, dkgNetwork *types.DKGNetw
 		return
 	}
 
-	if session.Phase != types.PhaseFailed {
-		log.Debug(ctx, "No failed DKG session found; skipping resume process", "round", dkgNetwork.Round)
+	if session.Phase == types.PhaseFailed {
+		k.resumeFailedSession(ctx, session, dkgNetwork)
 
 		return
 	}
 
+	// Recover sessions stuck in intermediate phases after an unexpected process crash.
+	// A session is stuck when its phase has NOT advanced to the expected completion
+	// state for the current stage AND no goroutine is actively processing it.
+	//
+	// Valid (non-stuck) completion states per stage:
+	//   Registration → PhaseInitialized (registration done, waiting for dealing)
+	//   Dealing      → PhaseDealing     (deals generated, processing responses via VE)
+	//   Finalization → PhaseFinalized   (finalization done, waiting for active)
+	//   Active       → PhaseCompleted
+	if isSessionStuckForStage(session.Phase, dkgNetwork.Stage) {
+		if tryAcquireDKGSvc(dkgNetwork.Round) {
+			releaseDKGSvc(dkgNetwork.Round)
+
+			log.Info(ctx, "Recovering stuck DKG session: no active goroutine for intermediate phase",
+				"round", dkgNetwork.Round,
+				"phase", session.Phase.String(),
+				"stage", dkgNetwork.Stage.String(),
+			)
+
+			k.stateManager.MarkFailed(ctx, session)
+			// Will be picked up as PhaseFailed on next block's ResumeDKGService call.
+		}
+	}
+}
+
+// isSessionStuckForStage returns true if the session phase is behind the expected
+// completion state for the current DKG stage. A session that reached the valid
+// completion phase for its stage is NOT stuck — it completed successfully and is
+// waiting for the next stage transition.
+func isSessionStuckForStage(phase types.DKGPhase, stage types.DKGStage) bool {
+	switch stage {
+	case types.DKGStageRegistration:
+		// PhaseInitialized = registration done → not stuck
+		return phase != types.PhaseInitialized && phase != types.PhaseCompleted
+	case types.DKGStageDealing:
+		// PhaseDealing = deals generated → not stuck
+		return phase != types.PhaseDealing && phase != types.PhaseCompleted
+	case types.DKGStageFinalization:
+		// PhaseFinalized = finalization done → not stuck
+		return phase != types.PhaseFinalized && phase != types.PhaseCompleted
+	case types.DKGStageActive:
+		return phase != types.PhaseCompleted
+	default:
+		return false
+	}
+}
+
+// resumeFailedSession dispatches a PhaseFailed session to the appropriate handler
+// based on the current DKG network stage.
+func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSession, dkgNetwork *types.DKGNetwork) {
 	switch dkgNetwork.Stage {
 	case types.DKGStageRegistration:
+		// Skip re-registration if already registered on-chain. Prevents overwriting
+		// a valid registration with different keys after sealed_keys deletion.
+		if k.isAlreadyRegistered(ctx, dkgNetwork.Round) {
+			session.UpdatePhase(types.PhaseInitialized)
+
+			if err := k.stateManager.UpdateSession(ctx, session); err != nil {
+				log.Error(ctx, "Failed to update session phase after existing registration check", err)
+			}
+
+			return
+		}
+
 		session.UpdatePhase(types.PhaseInitializing)
 
 		if err := k.stateManager.UpdateSession(ctx, session); err != nil {

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -192,7 +192,14 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 
 		return nil
 	}); err != nil {
-		log.Error(ctx, "Failed to process deals", err)
+		// Cache unprocessed deals in memory for retry when kernel recovers.
+		// Not persisted to disk — process restart loses them (round will fail and retry).
+		cached := cachePendingIncomingDeals(deals, session.Index)
+
+		log.Error(ctx, "Failed to process deals; cached for retry", err,
+			"round", dkgNetwork.Round,
+			"cached_deals", cached,
+		)
 
 		return
 	}
@@ -202,6 +209,28 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 	log.Info(ctx, "Process deals complete",
 		"round", session.Round,
 	)
+}
+
+// cachePendingIncomingDeals saves deals that failed kernel processing for later retry.
+// Only deals addressed to this validator (matching recipientIndex) are cached.
+// Returns the number of deals cached.
+func cachePendingIncomingDeals(allDeals []types.Deal, sessionIndex uint32) int {
+	pendingIncomingDealsMu.Lock()
+	defer pendingIncomingDealsMu.Unlock()
+
+	cached := 0
+	for _, deal := range allDeals {
+		if sessionIndex > 0 && deal.RecipientIndex == sessionIndex-1 {
+			if len(pendingIncomingDeals) >= maxPendingIncoming {
+				return cached
+			}
+
+			pendingIncomingDeals = append(pendingIncomingDeals, deal)
+			cached++
+		}
+	}
+
+	return cached
 }
 
 // handleDKGProcessResponses handles the responses of processDeals from other committee members.
@@ -292,6 +321,14 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 		}); err != nil {
 			log.Error(ctx, "Failed to process responses", err,
 				"code_commitment", hex.EncodeToString(cc),
+			)
+
+			// Cache unprocessed responses for retry when kernel recovers.
+			cachePendingIncomingResponses(filteredResponses)
+
+			log.Info(ctx, "Cached responses for retry",
+				"round", session.Round,
+				"cached_responses", len(filteredResponses),
 			)
 
 			continue
@@ -477,6 +514,14 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 				"code_commitment", hex.EncodeToString(cc),
 			)
 
+			// Cache for retry when kernel recovers.
+			cachePendingIncomingJustifications(validJustifications)
+
+			log.Info(ctx, "Cached justifications for retry",
+				"round", session.Round,
+				"cached_responses", len(validJustifications),
+			)
+
 			continue
 		}
 	}
@@ -484,6 +529,218 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 	log.Info(ctx, "Process justifications complete",
 		"round", session.Round,
 	)
+}
+
+// cachePendingIncomingResponses saves responses that failed kernel processing for later retry.
+func cachePendingIncomingResponses(filteredResponses []types.Response) {
+	pendingIncomingResponsesMu.Lock()
+	defer pendingIncomingResponsesMu.Unlock()
+
+	remaining := maxPendingIncoming - len(pendingIncomingResponses)
+	if remaining <= 0 {
+		return
+	}
+
+	if len(filteredResponses) > remaining {
+		filteredResponses = filteredResponses[:remaining]
+	}
+
+	pendingIncomingResponses = append(pendingIncomingResponses, filteredResponses...)
+}
+
+func cachePendingIncomingJustifications(justifications []types.Justification) {
+	pendingIncomingJustificationsMu.Lock()
+	defer pendingIncomingJustificationsMu.Unlock()
+
+	remaining := maxPendingIncoming - len(pendingIncomingJustifications)
+	if remaining <= 0 {
+		return
+	}
+
+	if len(justifications) > remaining {
+		justifications = justifications[:remaining]
+	}
+
+	pendingIncomingJustifications = append(pendingIncomingJustifications, justifications...)
+}
+
+// reprocessPendingIncomingData retries cached deals, responses, and justifications when the kernel recovers.
+// Deals are processed FIRST (kyber requires deals before responses can be accepted).
+// Called from BeginBlocker via the DKG service loop.
+func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
+	hasPendingDeals := func() bool {
+		pendingIncomingDealsMu.Lock()
+		defer pendingIncomingDealsMu.Unlock()
+
+		return len(pendingIncomingDeals) > 0
+	}()
+
+	hasPendingResponses := func() bool {
+		pendingIncomingResponsesMu.Lock()
+		defer pendingIncomingResponsesMu.Unlock()
+
+		return len(pendingIncomingResponses) > 0
+	}()
+
+	hasPendingJustifications := func() bool {
+		pendingIncomingJustificationsMu.Lock()
+		defer pendingIncomingJustificationsMu.Unlock()
+
+		return len(pendingIncomingJustifications) > 0
+	}()
+
+	if !hasPendingDeals && !hasPendingResponses && !hasPendingJustifications {
+		return
+	}
+
+	// Only retry during Dealing stage (pending data is stale after stage transitions).
+	if dkgNetwork.Stage != types.DKGStageDealing {
+		flushPendingIncoming()
+
+		return
+	}
+
+	if k.kernelRouter == nil || !k.kernelRouter.HasClients() {
+		return // kernel still unavailable, wait
+	}
+
+	asyncCtx, cancel := dkgAsyncContext()
+
+	go func() {
+		defer cancel()
+
+		// Process deals FIRST — kyber returns ErrNoDealBeforeResponse if
+		// a response arrives for a dealer whose deal hasn't been processed.
+		if hasPendingDeals {
+			drainedDeals := drainPendingIncomingDeals()
+
+			log.Info(asyncCtx, "Replaying cached deals after kernel recovery",
+				"round", dkgNetwork.Round,
+				"num_deals", len(drainedDeals),
+			)
+
+			k.handleDKGProcessDeals(asyncCtx, dkgNetwork, drainedDeals)
+		}
+
+		// Then process responses.
+		if hasPendingResponses {
+			drainedResponses := drainPendingIncomingResponses()
+
+			log.Info(asyncCtx, "Replaying cached responses after kernel recovery",
+				"round", dkgNetwork.Round,
+				"num_responses", len(drainedResponses),
+			)
+
+			k.handleDKGProcessResponses(asyncCtx, dkgNetwork, drainedResponses, true)
+		}
+
+		// Finally process justifications (already verified before caching,
+		// so forward directly to kernel without re-verification).
+		if hasPendingJustifications {
+			drainedJustifications := drainPendingIncomingJustifications()
+
+			log.Info(asyncCtx, "Replaying cached justifications after kernel recovery",
+				"round", dkgNetwork.Round,
+				"num_justifications", len(drainedJustifications),
+			)
+
+			k.forwardJustificationsToKernel(asyncCtx, dkgNetwork, drainedJustifications)
+		}
+	}()
+}
+
+func drainPendingIncomingDeals() []types.Deal {
+	pendingIncomingDealsMu.Lock()
+	defer pendingIncomingDealsMu.Unlock()
+
+	out := pendingIncomingDeals
+	pendingIncomingDeals = nil
+
+	return out
+}
+
+func drainPendingIncomingResponses() []types.Response {
+	pendingIncomingResponsesMu.Lock()
+	defer pendingIncomingResponsesMu.Unlock()
+
+	out := pendingIncomingResponses
+	pendingIncomingResponses = nil
+
+	return out
+}
+
+func drainPendingIncomingJustifications() []types.Justification {
+	pendingIncomingJustificationsMu.Lock()
+	defer pendingIncomingJustificationsMu.Unlock()
+
+	out := pendingIncomingJustifications
+	pendingIncomingJustifications = nil
+
+	return out
+}
+
+func flushPendingIncoming() {
+	pendingIncomingDealsMu.Lock()
+	pendingIncomingDeals = nil
+	pendingIncomingDealsMu.Unlock()
+
+	pendingIncomingResponsesMu.Lock()
+	pendingIncomingResponses = nil
+	pendingIncomingResponsesMu.Unlock()
+
+	pendingIncomingJustificationsMu.Lock()
+	pendingIncomingJustifications = nil
+	pendingIncomingJustificationsMu.Unlock()
+}
+
+// forwardJustificationsToKernel sends already-verified justifications to the kernel.
+// Used for replaying cached justifications that passed Schnorr + VSS verification
+// before caching but failed the kernel gRPC call.
+func (k *Keeper) forwardJustificationsToKernel(ctx context.Context, dkgNetwork *types.DKGNetwork, justifications []types.Justification) {
+	dkgKernelMu.Lock()
+	defer dkgKernelMu.Unlock()
+
+	session, err := k.stateManager.GetSession(dkgNetwork.Round)
+	if err != nil {
+		log.Error(ctx, "Failed to get DKG session for justification replay", err)
+
+		return
+	}
+
+	ccsToProcess := [][]byte{session.CodeCommitment}
+	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 && !bytes.Equal(session.CodeCommitment, session.OldCodeCommitment) {
+		ccsToProcess = append(ccsToProcess, session.OldCodeCommitment)
+	}
+
+	for _, cc := range ccsToProcess {
+		if err := retry(ctx, func(ctx context.Context) error {
+			req := &types.ProcessJustificationRequest{
+				CodeCommitment: cc,
+				Round:          session.Round,
+				Justifications: justifications,
+				IsResharing:    session.IsResharing,
+			}
+
+			client, cErr := k.kernelRouter.GetClient(cc)
+			if cErr != nil {
+				return errors.Wrap(cErr, "no kernel client for session")
+			}
+
+			if _, err := client.ProcessJustification(ctx, req); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			log.Error(ctx, "Failed to replay justifications", err,
+				"code_commitment", hex.EncodeToString(cc),
+			)
+
+			cachePendingIncomingJustifications(justifications)
+
+			continue
+		}
+	}
 }
 
 func (k *Keeper) shouldProcessResponses(ctx context.Context, dkgNetwork *types.DKGNetwork) (bool, error) {

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -34,6 +34,20 @@ var (
 	// story-kernel. Without this, concurrent goroutines corrupt the DKG state and
 	// cause "different number of coefficients" errors during finalization.
 	dkgKernelMu sync.Mutex
+
+	// pendingIncoming* hold deals/responses that failed kernel processing (e.g., kernel
+	// unreachable). They are retried on subsequent blocks when the kernel recovers.
+	// In-memory only — lost on process restart (round will fail and retry naturally).
+	// Deals MUST be replayed before responses (kyber's ErrNoDealBeforeResponse).
+	pendingIncomingDealsMu          sync.Mutex
+	pendingIncomingDeals            []types.Deal
+	pendingIncomingResponsesMu      sync.Mutex
+	pendingIncomingResponses        []types.Response
+	pendingIncomingJustificationsMu sync.Mutex
+	pendingIncomingJustifications   []types.Justification
+
+	// maxPendingIncoming caps the pending queue to prevent memory exhaustion.
+	maxPendingIncoming = 80
 )
 
 // Keeper of the dkg store.

--- a/client/x/dkg/keeper/proposal_server.go
+++ b/client/x/dkg/keeper/proposal_server.go
@@ -19,17 +19,6 @@ func (s proposalServer) AddVote(ctx context.Context, msg *types.MsgAddDkgVote,
 		return nil, errors.New("unauthorized")
 	}
 
-	if s.isDKGSvcEnabled {
-		latestRound, err := s.GetLatestDKGRound(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get latest DKG round")
-		}
-
-		if latestRound != nil {
-			s.ResumeDKGService(ctx, latestRound)
-		}
-	}
-
 	return &types.AddDkgVoteResponse{}, nil
 }
 

--- a/client/x/dkg/keeper/queue.go
+++ b/client/x/dkg/keeper/queue.go
@@ -92,7 +92,7 @@ func (*Keeper) DequeueJustifications(count int) []types.Justification {
 	return out
 }
 
-// FlushAllQueues clears all deal, response, and justification queues.
+// FlushAllQueues clears all deal, response, justification, and pending incoming queues.
 // This should be called when a DKG round transitions to prevent stale data
 // from a previous round from being broadcast in the new round.
 func (*Keeper) FlushAllQueues() {
@@ -113,4 +113,7 @@ func (*Keeper) FlushAllQueues() {
 	justifications = nil
 
 	justificationsMu.Unlock()
+
+	// Also flush pending incoming data from failed kernel calls.
+	flushPendingIncoming()
 }


### PR DESCRIPTION
## Summary

  Fix DKG resilience issues discovered during unhappy path e2e testing on a 3-validator devnet. These fixes address scenarios where kernel (TEE) crashes, story client restarts, and network disruptions cause DKG rounds to fail or get stuck.

  ### fix(dkg): prevent re-registration when on-chain registration exists
  After a devnet reset where sealed_keys are deleted, the kernel generates a new key pair. If story re-registers with the new key, it overwrites the on-chain registration that other validators already used to build their DKG instances, causing schnorr signature mismatches. Add `isAlreadyRegistered()` check before registration in both `InitiateDKGRound` and `resumeFailedSession`.

  ### fix(dkg): recover stuck DKG sessions after crashes
  Two issues fixed:
  - **Cross-round blocking**: The boolean `dkgSvcRunning` lock allowed a slow goroutine from round N to block round N+1. Replaced with a round-based atomic lock (`tryAcquireDKGSvc`/`releaseDKGSvc`) with bounded CAS retry (max 10 attempts). A higher round always preempts stale locks.
  - **Stuck intermediate phases**: When a process crash occurred before `MarkFailed` ran, the session remained in an intermediate phase (e.g., `PhaseInitializing`) with no goroutine running. Added `isSessionStuckForStage()` to detect these cases and mark them as failed for recovery.
   `ResumeDKGService` is now called from `BeginBlocker` for reliable per-block execution, and the redundant call from `AddVote` is removed.

  ### fix(dkg): cache deals/responses/justifications in memory for kernel recovery
  Vote extensions deliver DKG deals, responses, and justifications exactly once. When the kernel is temporarily unreachable, this data is permanently lost, causing `dkg: distributed key not certified` errors and round failure.
  - Add in-memory pending queues for failed deals/responses/justifications
  - Replay cached data when kernel recovers, respecting kyber's ordering requirements (deals → responses → justifications)
  - Justifications are forwarded directly to kernel on replay (already verified before caching, and `dealerPubKeys` from KV store is unavailable in async goroutine)
  - Flush pending data on stage transitions and round changes
  - Cap at 80 items to prevent memory exhaustion

  ## Test Plan

  - [x] TC-01: Registration phase kernel crash → `ResumeDKGService` recovery
  - [x] TC-02: Dealing phase kernel crash → round completion after kernel restart
  - [x] TC-03: Finalization phase kernel crash → 3/3 finalized
  - [x] TC-04: Process crash before `MarkFailed` → `isSessionStuckForStage` recovery
  - [x] TC-05: Justification flow verified via kernel-side deal corruption mock (complaint → justification → Schnorr + VSS verification)
  - [x] TC-06: Story client restart during dealing → resync processes VE deals/responses/justifications via block replay
  - [x] TC-07: Kernel blocked via iptables during dealing → deals cached → unblock → `Replaying cached deals` → round completes
  - [x] Build and existing unit tests pass

issue: none
