### PR TITLE
feat(dkg): add tls and mtls support for grpc connections to the kernel

### DIFF
--- a/client/app/start.go
+++ b/client/app/start.go
@@ -198,7 +198,16 @@ func CreateApp(ctx context.Context, cfg Config) (*App, *privval.FilePV, error) {
 	)
 
 	if cfg.DKG.Enable {
-		dkgKernelRouter = keeper.NewKernelRouter(cfg.DKG.KernelEndpoints)
+		var tlsCfg *keeper.TLSConfig
+		if cfg.DKG.KernelTLSCAFile != "" {
+			tlsCfg = &keeper.TLSConfig{
+				CAFile:   cfg.DKG.KernelTLSCAFile,
+				CertFile: cfg.DKG.KernelTLSCertFile,
+				KeyFile:  cfg.DKG.KernelTLSKeyFile,
+			}
+		}
+
+		dkgKernelRouter = keeper.NewKernelRouter(cfg.DKG.KernelEndpoints, tlsCfg)
 		for _, ep := range cfg.DKG.KernelEndpoints {
 			if err := dkgKernelRouter.ConnectAndDiscover(ctx, ep); err != nil {
 				log.Warn(ctx, "Failed to connect to kernel endpoint, continuing", err, "endpoint", ep)

--- a/client/config/dkg_config.go
+++ b/client/config/dkg_config.go
@@ -22,6 +22,16 @@ type DKGConfig struct {
 
 	// EnclaveType is the TEE enclave type identifier (e.g. 1 for SGX), stored as bytes32 on-chain
 	EnclaveType uint64
+
+	// TLS configuration for gRPC client connections to story-kernel.
+	// KernelTLSCAFile is the CA certificate to verify the server.
+	// When set, TLS is used for all kernel connections.
+	KernelTLSCAFile string
+
+	// KernelTLSCertFile and KernelTLSKeyFile are the client certificate and key
+	// for mutual TLS authentication. Both must be set for mTLS.
+	KernelTLSCertFile string
+	KernelTLSKeyFile  string
 }
 
 func DefaultDKGConfig() DKGConfig {
@@ -38,6 +48,9 @@ func BindDKGFlags(flags *pflag.FlagSet, cfg *DKGConfig) {
 	flags.StringSliceVar(&cfg.KernelEndpoints, "dkg-kernel-endpoints", cfg.KernelEndpoints, "Comma-separated list of story-kernel (TEE) endpoints for DKG")
 	flags.StringVar(&cfg.EngineRPCEndpoint, "dkg-engine-rpc-endpoint", cfg.EngineRPCEndpoint, "The RPC endpoint of execution layer")
 	flags.Uint64Var(&cfg.EnclaveType, "dkg-enc-type", cfg.EnclaveType, "TEE enclave type identifier (e.g. 1 for SGX)")
+	flags.StringVar(&cfg.KernelTLSCAFile, "dkg-kernel-tls-ca-file", cfg.KernelTLSCAFile, "CA certificate file to verify story-kernel server TLS")
+	flags.StringVar(&cfg.KernelTLSCertFile, "dkg-kernel-tls-cert-file", cfg.KernelTLSCertFile, "Client certificate file for mTLS to story-kernel")
+	flags.StringVar(&cfg.KernelTLSKeyFile, "dkg-kernel-tls-key-file", cfg.KernelTLSKeyFile, "Client private key file for mTLS to story-kernel")
 }
 
 func (c *DKGConfig) Validate() error {
@@ -59,6 +72,20 @@ func (c *DKGConfig) Validate() error {
 
 	if c.EnclaveType == 0 {
 		return errors.New("enc-type must not be zero")
+	}
+
+	// Validate TLS configuration consistency.
+	hasCert := c.KernelTLSCertFile != ""
+	hasKey := c.KernelTLSKeyFile != ""
+
+	if hasCert != hasKey {
+		return errors.New("dkg-kernel-tls-cert-file and dkg-kernel-tls-key-file must both be set or both be empty")
+	}
+
+	// Client cert/key without CA file is not useful — the CA file is needed
+	// to verify the server, and the cert/key are only for mTLS.
+	if hasCert && c.KernelTLSCAFile == "" {
+		return errors.New("dkg-kernel-tls-ca-file is required when client certificate is configured for mTLS")
 	}
 
 	return nil

--- a/client/x/dkg/keeper/dkg_handler_internal_test.go
+++ b/client/x/dkg/keeper/dkg_handler_internal_test.go
@@ -1174,7 +1174,7 @@ func setupDKGKeeperWithMocks(t *testing.T) (*Keeper, *dkgtestutil.MockBankKeeper
 	mockKernelServiceClient := dkgtestutil.NewMockKernelServiceClient(ctrl)
 
 	// Wrap mock TEE client in a KernelRouter for testing
-	kernelRouter := NewKernelRouter(nil)
+	kernelRouter := NewKernelRouter(nil, nil)
 	kernelRouter.RegisterClient([]byte("test"), mockKernelServiceClient)
 
 	k := NewKeeper(

--- a/client/x/dkg/keeper/kernel_client.go
+++ b/client/x/dkg/keeper/kernel_client.go
@@ -1,7 +1,10 @@
 package keeper
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/piplabs/story/client/x/dkg/types"
@@ -12,24 +15,45 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// TLSConfig holds the TLS certificate paths for gRPC client connections.
+// When CAFile is set, TLS is enabled with server certificate verification.
+// When CertFile and KeyFile are also set, mutual TLS (mTLS) is used.
+type TLSConfig struct {
+	CAFile   string // CA certificate to verify the server
+	CertFile string // Client certificate for mTLS
+	KeyFile  string // Client private key for mTLS
+}
+
 // CreateKernelClient creates a gRPC client for the story-kernel.
 // Returns the KernelClient and an io.Closer for the underlying gRPC connection.
-func CreateKernelClient(endpoint string) (types.KernelServiceClient, io.Closer, error) {
+//
+// TLS behavior:
+//   - tlsCfg nil or empty: insecure connection (no TLS)
+//   - tlsCfg.CAFile set: TLS with server cert verification against the provided CA
+//   - tlsCfg.CertFile+KeyFile also set: mutual TLS (client presents its certificate)
+func CreateKernelClient(endpoint string, tlsCfg *TLSConfig) (types.KernelServiceClient, io.Closer, error) {
 	if endpoint == "" {
 		return nil, nil, errors.New("the endpoint is required")
 	}
 
-	var creds credentials.TransportCredentials
-	if strings.HasPrefix(endpoint, "https://") || strings.HasPrefix(endpoint, "tls://") {
-		creds = credentials.NewTLS(nil) // TODO: use provided CA certs
-	} else {
-		creds = insecure.NewCredentials()
+	creds, err := buildTransportCredentials(endpoint, tlsCfg)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to build TLS credentials", "endpoint", endpoint)
 	}
 
-	// Use passthrough resolver for direct IP:port endpoints (grpc.NewClient defaults to DNS resolver)
+	// Strip scheme prefix (tls://, https://) for gRPC target resolution.
+	// gRPC does not understand these schemes — it uses passthrough resolver for direct IP:port.
 	target := endpoint
-	if !strings.Contains(endpoint, "://") {
-		target = "passthrough:///" + endpoint
+	for _, prefix := range []string{"tls://", "https://"} {
+		if strings.HasPrefix(target, prefix) {
+			target = strings.TrimPrefix(target, prefix)
+
+			break
+		}
+	}
+
+	if !strings.Contains(target, "://") {
+		target = "passthrough:///" + target
 	}
 
 	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(creds))
@@ -38,4 +62,55 @@ func CreateKernelClient(endpoint string) (types.KernelServiceClient, io.Closer, 
 	}
 
 	return types.NewKernelServiceClient(conn), conn, nil
+}
+
+// buildTransportCredentials returns the appropriate gRPC transport credentials
+// based on the endpoint scheme and TLS configuration.
+func buildTransportCredentials(endpoint string, tlsCfg *TLSConfig) (credentials.TransportCredentials, error) {
+	// Explicit TLS config takes precedence over endpoint scheme detection.
+	if tlsCfg != nil && tlsCfg.CAFile != "" {
+		return loadClientTLSCredentials(tlsCfg)
+	}
+
+	// Legacy behavior: detect TLS from endpoint URL scheme.
+	if strings.HasPrefix(endpoint, "https://") || strings.HasPrefix(endpoint, "tls://") {
+		// Use system CA pool for server verification when no explicit CA is provided.
+		return credentials.NewTLS(&tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}), nil
+	}
+
+	return insecure.NewCredentials(), nil
+}
+
+// loadClientTLSCredentials loads TLS credentials for gRPC client connections.
+// Requires a CA file for server verification. Optionally loads client cert/key for mTLS.
+func loadClientTLSCredentials(tlsCfg *TLSConfig) (credentials.TransportCredentials, error) {
+	caCert, err := os.ReadFile(tlsCfg.CAFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read CA cert file", "path", tlsCfg.CAFile)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caCert) {
+		return nil, errors.New("failed to parse CA cert", "path", tlsCfg.CAFile)
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs:    caPool,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	// Load client certificate for mTLS if both cert and key are provided.
+	if tlsCfg.CertFile != "" && tlsCfg.KeyFile != "" {
+		clientCert, err := tls.LoadX509KeyPair(tlsCfg.CertFile, tlsCfg.KeyFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load client cert/key",
+				"cert", tlsCfg.CertFile, "key", tlsCfg.KeyFile)
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{clientCert}
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
 }

--- a/client/x/dkg/keeper/kernel_router.go
+++ b/client/x/dkg/keeper/kernel_router.go
@@ -16,6 +16,7 @@ import (
 type KernelRouter struct {
 	mu        sync.RWMutex
 	endpoints []string                             // configured endpoints
+	tlsCfg    *TLSConfig                           // TLS configuration for client connections (nil = insecure)
 	clients   map[string]types.KernelServiceClient // codeCommitmentHex -> KernelServiceClient
 	closers   map[string]io.Closer                 // codeCommitmentHex -> underlying gRPC connection
 	ccByEP    map[string]string                    // endpoint -> codeCommitmentHex (reverse lookup)
@@ -23,15 +24,17 @@ type KernelRouter struct {
 
 const maxKernelEndpoints = 2
 
-// NewKernelRouter creates a new router with the given endpoint list.
+// NewKernelRouter creates a new router with the given endpoint list and optional TLS configuration.
 // At most 2 endpoints are supported (old + new binary for upgrade resharing).
-func NewKernelRouter(endpoints []string) *KernelRouter {
+// Pass nil for tlsCfg to use insecure connections.
+func NewKernelRouter(endpoints []string, tlsCfg *TLSConfig) *KernelRouter {
 	if len(endpoints) > maxKernelEndpoints {
 		panic(fmt.Sprintf("kernel router supports at most %d endpoints, got %d", maxKernelEndpoints, len(endpoints)))
 	}
 
 	return &KernelRouter{
 		endpoints: endpoints,
+		tlsCfg:    tlsCfg,
 		clients:   make(map[string]types.KernelServiceClient),
 		closers:   make(map[string]io.Closer),
 		ccByEP:    make(map[string]string),
@@ -41,7 +44,7 @@ func NewKernelRouter(endpoints []string) *KernelRouter {
 // ConnectAndDiscover connects to an endpoint, calls GetCodeCommitment to discover
 // the code commitment, and registers the client keyed by code commitment.
 func (r *KernelRouter) ConnectAndDiscover(ctx context.Context, endpoint string) error {
-	client, closer, err := CreateKernelClient(endpoint)
+	client, closer, err := CreateKernelClient(endpoint, r.tlsCfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to kernel endpoint", "endpoint", endpoint)
 	}

--- a/client/x/dkg/keeper/kernel_router_test.go
+++ b/client/x/dkg/keeper/kernel_router_test.go
@@ -18,7 +18,7 @@ func TestKernelRouter_RegisterAndGetClient(t *testing.T) {
 	mockClient := dkgtestutil.NewMockKernelServiceClient(ctrl)
 	cc := []byte{0x01, 0x02, 0x03}
 
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 	router.RegisterClient(cc, mockClient)
 
 	// Should find the client by exact code commitment
@@ -34,7 +34,7 @@ func TestKernelRouter_GetClientNoFallback(t *testing.T) {
 	mockClient := dkgtestutil.NewMockKernelServiceClient(ctrl)
 	cc := []byte{0x01, 0x02, 0x03}
 
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 	router.RegisterClient(cc, mockClient)
 
 	// Should return error when code commitment doesn't match — no fallback
@@ -45,7 +45,7 @@ func TestKernelRouter_GetClientNoFallback(t *testing.T) {
 }
 
 func TestKernelRouter_GetClientEmpty(t *testing.T) {
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 
 	// Should return error when no clients are available
 	_, err := router.GetClient([]byte{0x01})
@@ -58,7 +58,7 @@ func TestKernelRouter_HasClients(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockClient := dkgtestutil.NewMockKernelServiceClient(ctrl)
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 
 	require.False(t, router.HasClients())
 
@@ -73,7 +73,7 @@ func TestKernelRouter_Disconnect(t *testing.T) {
 	mockClient := dkgtestutil.NewMockKernelServiceClient(ctrl)
 	cc := []byte{0x01, 0x02, 0x03}
 
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 	router.RegisterClient(cc, mockClient)
 
 	require.True(t, router.HasClients())
@@ -91,7 +91,7 @@ func TestKernelRouter_GetAllCodeCommitments(t *testing.T) {
 	cc1 := []byte{0x01, 0x02}
 	cc2 := []byte{0x03, 0x04}
 
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 	router.RegisterClient(cc1, mock1)
 	router.RegisterClient(cc2, mock2)
 
@@ -117,7 +117,7 @@ func TestKernelRouter_MultipleClients(t *testing.T) {
 	cc1 := []byte{0x01, 0x02}
 	cc2 := []byte{0x03, 0x04}
 
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 	router.RegisterClient(cc1, mock1)
 	router.RegisterClient(cc2, mock2)
 
@@ -136,7 +136,7 @@ func TestKernelRouter_GetClientWithNilCodeCommitment(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockClient := dkgtestutil.NewMockKernelServiceClient(ctrl)
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 	router.RegisterClient([]byte{0x01}, mockClient)
 
 	// Nil code commitment should return error — no fallback
@@ -150,7 +150,7 @@ func TestKernelRouter_GetClientWithEmptyCodeCommitment(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockClient := dkgtestutil.NewMockKernelServiceClient(ctrl)
-	router := keeper.NewKernelRouter(nil)
+	router := keeper.NewKernelRouter(nil, nil)
 	router.RegisterClient([]byte{0x01}, mockClient)
 
 	// Empty code commitment should return error — no fallback


### PR DESCRIPTION
  ## Summary

  - Add TLS and mutual TLS (mTLS) support for gRPC connections between the Story consensus client and story-kernel
  - Introduce `TLSConfig` struct and `kernel-tls-ca-file`, `kernel-tls-cert-file`, `kernel-tls-key-file` configuration fields in `DKGConfig`
  - When CA file is provided, TLS is enabled with server certificate verification against the CA; when client cert/key are also provided, mTLS is used
  - Strip `tls://` and `https://` scheme prefixes from kernel endpoints before passing to gRPC (gRPC does not understand these schemes and requires `passthrough:///` resolver for direct IP:port targets)
  - Backward compatible: no TLS config means insecure connection (existing behavior unchanged)

issue: none
