### PR TITLE
fix(dkg): add defense in depth guard against duplicate registration

### DIFF
--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -80,16 +80,15 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 	}
 
 	if k.isDKGSvcEnabled {
-		// Skip registration if this validator already has an on-chain registration
-		// for this round. This prevents overwriting a valid registration with
-		// different keys after a reset where sealed_keys were deleted.
-		if k.isAlreadyRegistered(ctx, roundNum) {
+		// Pre-compute registration check while we still have SDK context.
+		// The async goroutine uses context.Background() which cannot access
+		// the Cosmos KV store.
+		alreadyRegistered := k.isAlreadyRegistered(ctx, roundNum)
+		if alreadyRegistered {
 			return nil
 		}
 
 		// Pre-compute old code commitment while we still have SDK context.
-		// The async goroutine uses context.Background() which cannot access
-		// the Cosmos KV store.
 		oldCC, _ := k.getOldCodeCommitment(ctx)
 
 		asyncCtx, cancel := dkgAsyncContext()
@@ -97,7 +96,7 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 		go func() {
 			defer cancel()
 
-			k.handleDKGRegistration(asyncCtx, &dkgNetwork, oldCC)
+			k.handleDKGRegistration(asyncCtx, &dkgNetwork, oldCC, alreadyRegistered)
 		}()
 	}
 

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -138,9 +138,9 @@ func isSessionStuckForStage(phase types.DKGPhase, stage types.DKGStage) bool {
 func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSession, dkgNetwork *types.DKGNetwork) {
 	switch dkgNetwork.Stage {
 	case types.DKGStageRegistration:
-		// Skip re-registration if already registered on-chain. Prevents overwriting
-		// a valid registration with different keys after sealed_keys deletion.
-		if k.isAlreadyRegistered(ctx, dkgNetwork.Round) {
+		// Pre-compute registration check while SDK context is available.
+		alreadyRegistered := k.isAlreadyRegistered(ctx, dkgNetwork.Round)
+		if alreadyRegistered {
 			session.UpdatePhase(types.PhaseInitialized)
 
 			if err := k.stateManager.UpdateSession(ctx, session); err != nil {
@@ -166,7 +166,7 @@ func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSess
 		go func() {
 			defer cancel()
 
-			k.handleDKGRegistration(asyncCtx, dkgNetwork, oldCC)
+			k.handleDKGRegistration(asyncCtx, dkgNetwork, oldCC, alreadyRegistered)
 		}()
 	case types.DKGStageDealing:
 		session.UpdatePhase(types.PhaseInitialized)

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -16,7 +16,10 @@ import (
 // handleDKGRegistration handles the DKG registration.
 // oldCC is the pre-computed old code commitment from the previous active DKG round,
 // resolved before the goroutine (which requires SDK context for KV store access).
-func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DKGNetwork, oldCC []byte) {
+// alreadyRegistered indicates whether this validator already has an on-chain
+// registration for this round (pre-computed with SDK context before the goroutine).
+// When true, the contract call is skipped and the session advances directly.
+func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DKGNetwork, oldCC []byte, alreadyRegistered bool) {
 	log.Info(ctx, "Handling DKG registration",
 		"round", dkgNetwork.Round,
 	)
@@ -87,7 +90,11 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 		return
 	}
 
-	if err := k.callContractRegister(ctx, session); err != nil {
+	if alreadyRegistered {
+		log.Info(ctx, "Validator already registered on-chain; skipping contract call",
+			"round", session.Round,
+		)
+	} else if err := k.callContractRegister(ctx, session); err != nil {
 		log.Error(ctx, "Failed to call register method", err)
 		k.stateManager.MarkFailed(ctx, session)
 


### PR DESCRIPTION
  ## Summary

  - Add defense-in-depth guard against duplicate DKG registration in `handleDKGRegistration` by passing a pre-computed `alreadyRegistered` flag from the SDK context into the async goroutine
  - When the validator is already registered on-chain, `callContractRegister` is skipped and the session advances directly to `PhaseInitialized`, preventing key material from being overwritten with different keys
  - Both callers (`InitiateDKGRound` and `resumeFailedSession`) now pre-compute the registration check in the SDK context and pass it to the goroutine, since the async context cannot access the Cosmos KV store

issue: #703 
