### PR TITLE
fix(dkg): invalidate dealer registration when justification verification failed

### DIFF
--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -87,11 +87,10 @@ func (k *Keeper) BeginDealing(ctx context.Context, latestRound *types.DKGNetwork
 
 // ProcessJustifications handles justifications from the Vote Extension.
 // Like ProcessDeals and ProcessResponses, it emits an event and then delegates
-// verification and story-kernel forwarding only when the DKG service is enabled.
-//
-// This function does NOT affect on-chain state. Invalid justifications are
-// silently dropped (logged but not returned as errors) to prevent consensus
-// divergence between validators running with different DKG service configurations.
+// Verification (signature, dedup, VSS) and dealer invalidation run synchronously
+// in FinalizeBlock regardless of whether the DKG service is enabled, because
+// invalidation is a consensus state change that all nodes must apply consistently.
+// Only the kernel gRPC forwarding is conditional on isDKGSvcEnabled and runs async.
 //
 // Replay protection is structural, not explicit:
 //   - Cross-round: kyber's DistKeyGenerator derives SessionID from (dealer pubkey +
@@ -99,7 +98,7 @@ func (k *Keeper) BeginDealing(ctx context.Context, latestRound *types.DKGNetwork
 //     unique SessionIDs. Since SessionID is embedded in Justification.Hash(), Schnorr
 //     signature verification implicitly rejects replayed justifications from other rounds.
 //   - Stage gating: justifications are only accepted during DKGStageDealing (checked
-//     in msg_server.go) and PhaseDealing (checked in handleDKGProcessJustifications).
+//     in msg_server.go).
 //   - Within-block: deduplication by (dealerIndex, recipientIndex) prevents redundant
 //     processing of the same justification broadcast by multiple validators.
 func (k *Keeper) ProcessJustifications(ctx context.Context, latestRound *types.DKGNetwork, justifications []types.Justification) error {
@@ -107,21 +106,86 @@ func (k *Keeper) ProcessJustifications(ctx context.Context, latestRound *types.D
 		return errors.Wrap(err, "failed to emit begin process justifications event")
 	}
 
-	if k.isDKGSvcEnabled {
-		// Pre-compute dealer pub key map while SDK context is available,
-		// because async goroutines cannot access the KV store.
-		suite := edwards25519.NewBlakeSHA256Ed25519()
-		dealerPubKeys, err := k.buildDealerPubKeyMap(ctx, latestRound, suite)
-		if err != nil {
-			return errors.Wrap(err, "build dealer pub key map")
+	suite := edwards25519.NewBlakeSHA256Ed25519()
+
+	dealerPubKeys, err := k.buildDealerPubKeyMap(ctx, latestRound, suite)
+	if err != nil {
+		return errors.Wrap(err, "build dealer pub key map")
+	}
+
+	// Cap justifications per block to prevent resource exhaustion.
+	if len(justifications) > MaxJustificationsPerBlock {
+		log.Warn(ctx, "Justification count exceeds max, truncating", nil,
+			"count", len(justifications),
+			"max", MaxJustificationsPerBlock,
+		)
+
+		justifications = justifications[:MaxJustificationsPerBlock]
+	}
+
+	// Step 1: Signature verification (deterministic, no kernel needed).
+	var signatureVerified []types.Justification
+
+	for _, j := range justifications {
+		if err := verifyJustificationSignature(suite, j, dealerPubKeys); err != nil {
+			log.Debug(ctx, "Dropping justification with invalid signature",
+				"dealer_index", j.Index,
+				"error", err,
+			)
+
+			continue
 		}
 
+		signatureVerified = append(signatureVerified, j)
+	}
+
+	// Step 2: Deduplicate by (dealerIndex, recipientIndex).
+	deduped := deduplicateJustifications(signatureVerified)
+
+	// Step 3: VSS verification + dealer invalidation (runs in SDK context so
+	// on-chain state can be updated). This MUST run regardless of isDKGSvcEnabled
+	// because invalidation is a consensus state change that all nodes must apply.
+	var validJustifications []types.Justification
+
+	for _, j := range deduped {
+		valid, err := verifyJustification(latestRound, j)
+		if err != nil {
+			log.Warn(ctx, "Justification VSS verification error, dropping", err,
+				"dealer_index", j.Index,
+			)
+
+			continue
+		}
+
+		if !valid {
+			// Deal was genuinely invalid — invalidate the dealer's on-chain registration
+			// so they cannot finalize or receive committee rewards.
+			log.Info(ctx, "Justification VSS verification failed, invalidating dealer",
+				"dealer_index", j.Index,
+				"round", latestRound.Round,
+			)
+
+			if err := k.invalidateDealerRegistration(ctx, latestRound, j.Index); err != nil {
+				log.Error(ctx, "Failed to invalidate dealer registration", err,
+					"dealer_index", j.Index,
+				)
+			}
+
+			continue
+		}
+
+		validJustifications = append(validJustifications, j)
+	}
+
+	// Step 4: Forward valid justifications to story-kernel for DKG state update.
+	// Only when DKG service is enabled (kernel gRPC is async).
+	if k.isDKGSvcEnabled && len(validJustifications) > 0 {
 		asyncCtx, cancel := dkgAsyncContext()
 
 		go func() {
 			defer cancel()
 
-			k.handleDKGProcessJustifications(asyncCtx, latestRound, justifications, dealerPubKeys)
+			k.handleDKGProcessJustifications(asyncCtx, latestRound, validJustifications)
 		}()
 	}
 

--- a/client/x/dkg/keeper/dkg_dealing_test.go
+++ b/client/x/dkg/keeper/dkg_dealing_test.go
@@ -430,7 +430,7 @@ func TestBuildDealerPubKeyMap(t *testing.T) {
 
 // TestMaxJustificationsPerBlock verifies that the truncation slice operation
 // correctly caps justifications to MaxJustificationsPerBlock, matching the
-// logic used inside handleDKGProcessJustifications.
+// logic used inside ProcessJustifications.
 func TestMaxJustificationsPerBlock(t *testing.T) {
 	const overCount = MaxJustificationsPerBlock + 50
 
@@ -448,7 +448,7 @@ func TestMaxJustificationsPerBlock(t *testing.T) {
 		}
 	}
 
-	// Apply the same truncation logic used in handleDKGProcessJustifications.
+	// Apply the same truncation logic used in ProcessJustifications.
 	if len(input) > MaxJustificationsPerBlock {
 		input = input[:MaxJustificationsPerBlock]
 	}
@@ -467,7 +467,7 @@ func TestMaxJustificationsPerBlock(t *testing.T) {
 
 // TestJustificationPipeline_SignatureThenDedupThenVSS verifies the full
 // signature → deduplication → VSS verification pipeline that mirrors the
-// logic inside handleDKGProcessJustifications.
+// logic inside ProcessJustifications.
 //
 // Three sub-scenarios exercise every branch of the pipeline:
 //  1. Valid-signature justifications pass through; invalid-signature ones are dropped.
@@ -583,7 +583,7 @@ func TestJustificationPipeline_SignatureThenDedupThenVSS(t *testing.T) {
 
 		input := []types.Justification{jValid, jBadSig, jBadVSS}
 
-		// Apply the same three-step pipeline used by handleDKGProcessJustifications.
+		// Apply the same three-step pipeline used by ProcessJustifications.
 
 		// Step 1: filter by Schnorr signature.
 		var sigVerified []types.Justification
@@ -614,5 +614,101 @@ func TestJustificationPipeline_SignatureThenDedupThenVSS(t *testing.T) {
 		require.Len(t, finalValid, 1, "only the VSS-valid justification should survive")
 		require.Equal(t, uint32(0), finalValid[0].Index,
 			"surviving justification must come from dealer 0")
+	})
+}
+
+// TestProcessJustifications_InvalidatesDealer verifies that ProcessJustifications
+// invalidates a dealer's on-chain registration when VSS verification fails,
+// while leaving valid dealers untouched. This is the core fix for issue #717:
+// previously, VSS failure only logged a message in the async goroutine and
+// could not update on-chain state.
+func TestProcessJustifications_InvalidatesDealer(t *testing.T) {
+	const n = 3
+
+	k, ctx := setupDKGKeeper(t)
+	k.isDKGSvcEnabled = true
+
+	// Initialize stateManager so handleDKGProcessJustifications doesn't panic
+	// when forwarding valid justifications to kernel in async goroutine.
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	k.stateManager = sm
+
+	round := uint32(1)
+
+	// Set up two dealers with real crypto keys
+	dealer0 := newDealerTestContext(t, n, dealingTestThreshold)
+	addr0 := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	setupDealerRegistrationWithKey(t, k, ctx, round, addr0, 0, dealer0.pubBytes)
+
+	dealer1 := newDealerTestContext(t, n, dealingTestThreshold)
+	addr1 := common.HexToAddress("0x0000000000000000000000000000000000000002")
+	setupDealerRegistrationWithKey(t, k, ctx, round, addr1, 1, dealer1.pubBytes)
+
+	network := &types.DKGNetwork{
+		Round:     round,
+		Total:     uint32(n),
+		Threshold: dealingTestThreshold,
+	}
+
+	t.Run("VSS failure invalidates dealer registration", func(t *testing.T) {
+		// dealer1 produces a justification with valid signature but invalid share
+		jBadVSS := dealer1.makeInvalidDealJustification(t, 1)
+
+		err := k.ProcessJustifications(ctx, network, []types.Justification{jBadVSS})
+		require.NoError(t, err)
+
+		// Dealer 1's registration must now be Invalidated
+		reg1, err := k.getDKGRegistration(ctx, round, addr1)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusInvalidated, reg1.Status,
+			"dealer with invalid VSS must be invalidated")
+
+		// Dealer 0's registration must remain Verified (unaffected)
+		reg0, err := k.getDKGRegistration(ctx, round, addr0)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg0.Status,
+			"uninvolved dealer must remain Verified")
+	})
+
+	t.Run("valid justification does not invalidate dealer", func(t *testing.T) {
+		// Reset dealer0 to Verified for a clean test
+		setupDealerRegistrationWithKey(t, k, ctx, round, addr0, 0, dealer0.pubBytes)
+
+		jValid := dealer0.makeSignedJustification(t, 0, 0)
+
+		err := k.ProcessJustifications(ctx, network, []types.Justification{jValid})
+		require.NoError(t, err)
+
+		// Dealer 0's registration must still be Verified
+		reg0, err := k.getDKGRegistration(ctx, round, addr0)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg0.Status,
+			"dealer with valid VSS must remain Verified")
+	})
+
+	t.Run("mixed valid and invalid justifications", func(t *testing.T) {
+		// Reset both dealers
+		setupDealerRegistrationWithKey(t, k, ctx, round, addr0, 0, dealer0.pubBytes)
+		setupDealerRegistrationWithKey(t, k, ctx, round, addr1, 1, dealer1.pubBytes)
+
+		jValid := dealer0.makeSignedJustification(t, 0, 0)
+		jBadVSS := dealer1.makeInvalidDealJustification(t, 1)
+
+		err := k.ProcessJustifications(ctx, network, []types.Justification{jValid, jBadVSS})
+		require.NoError(t, err)
+
+		// Dealer 0 (valid) must remain Verified
+		reg0, err := k.getDKGRegistration(ctx, round, addr0)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg0.Status,
+			"dealer with valid justification must remain Verified")
+
+		// Dealer 1 (invalid VSS) must be Invalidated
+		reg1, err := k.getDKGRegistration(ctx, round, addr1)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusInvalidated, reg1.Status,
+			"dealer with invalid VSS must be Invalidated")
 	})
 }

--- a/client/x/dkg/keeper/dkg_justification.go
+++ b/client/x/dkg/keeper/dkg_justification.go
@@ -200,9 +200,8 @@ func (k *Keeper) buildDealerPubKeyMap(ctx context.Context, latestRound *types.DK
 // Invalidated dealers cannot finalize. This is idempotent — re-invalidating
 // an already-invalidated dealer is a no-op.
 //
-// NOTE: This function is NOT called from ProcessJustifications because justification
-// processing must not affect on-chain state. It is retained as a utility for
-// potential future use (e.g., explicit slashing proposals).
+// Called from ProcessJustifications (FinalizeBlock) when VSS verification proves
+// a dealer's deal was genuinely invalid.
 func (k *Keeper) invalidateDealerRegistration(ctx context.Context, latestRound *types.DKGNetwork, dealerIndex uint32) error {
 	// Find the registration with this index
 	registrations, err := k.getDKGRegistrationsByRound(ctx, latestRound.Round)

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -9,9 +9,6 @@ import (
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
-
-	"go.dedis.ch/kyber/v4"
-	"go.dedis.ch/kyber/v4/group/edwards25519"
 )
 
 // handleDKGDealing handles the dealing phase event.
@@ -353,6 +350,57 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 	)
 }
 
+// handleDKGProcessJustifications sends already-verified justifications to the kernel.
+// Justifications have passed Schnorr signature and VSS verification in ProcessJustifications
+// (FinalizeBlock context). This function only forwards them to the kernel via gRPC.
+// Also used for replaying cached justifications that failed the kernel gRPC call.
+func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork *types.DKGNetwork, justifications []types.Justification) {
+	dkgKernelMu.Lock()
+	defer dkgKernelMu.Unlock()
+
+	session, err := k.stateManager.GetSession(dkgNetwork.Round)
+	if err != nil {
+		log.Error(ctx, "Failed to get DKG session for justification processing", err)
+
+		return
+	}
+
+	ccsToProcess := [][]byte{session.CodeCommitment}
+	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 && !bytes.Equal(session.CodeCommitment, session.OldCodeCommitment) {
+		ccsToProcess = append(ccsToProcess, session.OldCodeCommitment)
+	}
+
+	for _, cc := range ccsToProcess {
+		if err := retry(ctx, func(ctx context.Context) error {
+			req := &types.ProcessJustificationRequest{
+				CodeCommitment: cc,
+				Round:          session.Round,
+				Justifications: justifications,
+				IsResharing:    session.IsResharing,
+			}
+
+			client, cErr := k.kernelRouter.GetClient(cc)
+			if cErr != nil {
+				return errors.Wrap(cErr, "no kernel client for session")
+			}
+
+			if _, err := client.ProcessJustification(ctx, req); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			log.Error(ctx, "Failed to process justifications via kernel", err,
+				"code_commitment", hex.EncodeToString(cc),
+			)
+
+			cachePendingIncomingJustifications(justifications)
+
+			continue
+		}
+	}
+}
+
 func (k *Keeper) shouldDeal(ctx context.Context, dkgNetwork *types.DKGNetwork) (bool, error) {
 	inCurSet := slices.Contains(dkgNetwork.ActiveValSet, k.validatorEVMAddr)
 
@@ -370,165 +418,6 @@ func (k *Keeper) shouldDeal(ctx context.Context, dkgNetwork *types.DKGNetwork) (
 	inPrevSet := slices.Contains(prevActive.ActiveValSet, k.validatorEVMAddr)
 
 	return inPrevSet, nil
-}
-
-// handleDKGProcessJustifications verifies and forwards valid justifications to story-kernel
-// for DKG state restoration. This is the off-chain (goroutine) handler that performs:
-//  1. Empty check and MaxJustificationsPerBlock cap
-//  2. ActiveValSet / session / phase check
-//  3. Schnorr signature verification → deduplication → Pedersen VSS verification
-//  4. Forward only valid justifications to story-kernel
-func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork *types.DKGNetwork, justifications []types.Justification, dealerPubKeys map[uint32]kyber.Point) {
-	// Serialize kernel DKG operations to prevent concurrent DistKeyGenerator mutation.
-	dkgKernelMu.Lock()
-	defer dkgKernelMu.Unlock()
-
-	log.Info(ctx, "Handling DKG process justifications",
-		"round", dkgNetwork.Round,
-		"num_justifications", len(justifications),
-	)
-
-	if len(justifications) == 0 {
-		return
-	}
-
-	// Cap justifications per block to prevent resource exhaustion
-	if len(justifications) > MaxJustificationsPerBlock {
-		log.Warn(ctx, "Justification count exceeds max, truncating", nil,
-			"count", len(justifications),
-			"max", MaxJustificationsPerBlock,
-		)
-		justifications = justifications[:MaxJustificationsPerBlock]
-	}
-
-	if !slices.Contains(dkgNetwork.ActiveValSet, k.validatorEVMAddr) {
-		log.Info(ctx, "Skip processing justifications as the validator is not in current round set")
-
-		return
-	}
-
-	session, err := k.stateManager.GetSession(dkgNetwork.Round)
-	if err != nil {
-		log.Error(ctx, "Failed to get DKG session", err)
-
-		return
-	}
-
-	// Accept justifications in both Initialized and Dealing phases (same reasoning as deals).
-	if session.Phase != types.PhaseDealing && session.Phase != types.PhaseInitialized {
-		log.Warn(ctx, "Session not in dealing or initialized phase, skipping process justifications", nil,
-			"current_phase", session.Phase.String(),
-		)
-
-		return
-	}
-
-	suite := edwards25519.NewBlakeSHA256Ed25519()
-
-	// Step 1: Verify Schnorr signature FIRST, filter out unsigned/forged justifications.
-	// This MUST happen before deduplication so that an attacker cannot preempt a valid
-	// justification by broadcasting an unsigned one with the same (dealerIndex, recipientIndex).
-	var signatureVerified []types.Justification
-
-	for _, j := range justifications {
-		if err := verifyJustificationSignature(suite, j, dealerPubKeys); err != nil {
-			log.Debug(ctx, "Dropping justification with invalid signature",
-				"dealer_index", j.Index,
-				"error", err,
-			)
-
-			continue
-		}
-
-		signatureVerified = append(signatureVerified, j)
-	}
-
-	// Step 2: Deduplicate by (dealerIndex, recipientIndex) — now only signature-verified entries.
-	deduped := deduplicateJustifications(signatureVerified)
-
-	// Step 3: Perform Pedersen VSS verification on each deduplicated justification.
-	// Invalid justifications are silently dropped (not errors).
-	var validJustifications []types.Justification
-
-	for _, j := range deduped {
-		valid, err := verifyJustification(dkgNetwork, j)
-		if err != nil {
-			log.Warn(ctx, "Justification VSS verification error, dropping", err,
-				"dealer_index", j.Index,
-			)
-
-			continue
-		}
-
-		if !valid {
-			log.Info(ctx, "Justification VSS verification failed (deal was invalid), dropping",
-				"dealer_index", j.Index,
-			)
-
-			continue
-		}
-
-		validJustifications = append(validJustifications, j)
-	}
-
-	if len(validJustifications) == 0 {
-		log.Info(ctx, "No valid justifications after verification, skipping story-kernel call")
-
-		return
-	}
-
-	// During upgrade resharing, justifications must be forwarded to BOTH old and new
-	// binaries so each can update its DKG state accordingly.
-	ccsToProcess := [][]byte{session.CodeCommitment}
-	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 && !bytes.Equal(session.CodeCommitment, session.OldCodeCommitment) {
-		ccsToProcess = append(ccsToProcess, session.OldCodeCommitment)
-	}
-
-	for _, cc := range ccsToProcess {
-		if err := retry(ctx, func(ctx context.Context) error {
-			log.Info(ctx, "ProcessJustification batch call to story-kernel client",
-				"code_commitment", hex.EncodeToString(cc),
-				"round", session.Round,
-				"num_justifications", len(validJustifications),
-			)
-
-			req := &types.ProcessJustificationRequest{
-				CodeCommitment: cc,
-				Round:          session.Round,
-				Justifications: validJustifications,
-				IsResharing:    session.IsResharing,
-			}
-
-			client, cErr := k.kernelRouter.GetClient(cc)
-			if cErr != nil {
-				return errors.Wrap(cErr, "no kernel client for session")
-			}
-
-			if _, err := client.ProcessJustification(ctx, req); err != nil {
-				return err
-			}
-
-			return nil
-		}); err != nil {
-			log.Error(ctx, "Failed to process justifications", err,
-				"code_commitment", hex.EncodeToString(cc),
-			)
-
-			// Cache for retry when kernel recovers.
-			cachePendingIncomingJustifications(validJustifications)
-
-			log.Info(ctx, "Cached justifications for retry",
-				"round", session.Round,
-				"cached_responses", len(validJustifications),
-			)
-
-			continue
-		}
-	}
-
-	log.Info(ctx, "Process justifications complete",
-		"round", session.Round,
-	)
 }
 
 // cachePendingIncomingResponses saves responses that failed kernel processing for later retry.
@@ -644,7 +533,7 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 				"num_justifications", len(drainedJustifications),
 			)
 
-			k.forwardJustificationsToKernel(asyncCtx, dkgNetwork, drainedJustifications)
+			k.handleDKGProcessJustifications(asyncCtx, dkgNetwork, drainedJustifications)
 		}
 	}()
 }
@@ -691,56 +580,6 @@ func flushPendingIncoming() {
 	pendingIncomingJustificationsMu.Lock()
 	pendingIncomingJustifications = nil
 	pendingIncomingJustificationsMu.Unlock()
-}
-
-// forwardJustificationsToKernel sends already-verified justifications to the kernel.
-// Used for replaying cached justifications that passed Schnorr + VSS verification
-// before caching but failed the kernel gRPC call.
-func (k *Keeper) forwardJustificationsToKernel(ctx context.Context, dkgNetwork *types.DKGNetwork, justifications []types.Justification) {
-	dkgKernelMu.Lock()
-	defer dkgKernelMu.Unlock()
-
-	session, err := k.stateManager.GetSession(dkgNetwork.Round)
-	if err != nil {
-		log.Error(ctx, "Failed to get DKG session for justification replay", err)
-
-		return
-	}
-
-	ccsToProcess := [][]byte{session.CodeCommitment}
-	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 && !bytes.Equal(session.CodeCommitment, session.OldCodeCommitment) {
-		ccsToProcess = append(ccsToProcess, session.OldCodeCommitment)
-	}
-
-	for _, cc := range ccsToProcess {
-		if err := retry(ctx, func(ctx context.Context) error {
-			req := &types.ProcessJustificationRequest{
-				CodeCommitment: cc,
-				Round:          session.Round,
-				Justifications: justifications,
-				IsResharing:    session.IsResharing,
-			}
-
-			client, cErr := k.kernelRouter.GetClient(cc)
-			if cErr != nil {
-				return errors.Wrap(cErr, "no kernel client for session")
-			}
-
-			if _, err := client.ProcessJustification(ctx, req); err != nil {
-				return err
-			}
-
-			return nil
-		}); err != nil {
-			log.Error(ctx, "Failed to replay justifications", err,
-				"code_commitment", hex.EncodeToString(cc),
-			)
-
-			cachePendingIncomingJustifications(justifications)
-
-			continue
-		}
-	}
 }
 
 func (k *Keeper) shouldProcessResponses(ctx context.Context, dkgNetwork *types.DKGNetwork) (bool, error) {


### PR DESCRIPTION
## Summary

  - Move justification verification (Schnorr signature + VSS) from async goroutine into `ProcessJustifications` (FinalizeBlock context) so that dealer invalidation can update on-chain state
  - When VSS verification fails — proving the dealer sent a genuinely invalid deal — call `invalidateDealerRegistration` to mark the dealer as `Invalidated`, preventing them from finalizing or receiving committee rewards
  - Rename `forwardJustificationsToKernel` to `handleDKGProcessJustifications` for consistency with `handleDKGProcessDeals` and `handleDKGProcessResponses`, and relocate it adjacent to those functions
  - Verification and invalidation run regardless of `isDKGSvcEnabled` since invalidation is a consensus state change; only kernel gRPC forwarding is conditional on DKG service being enabled

issue: #717 
