### PR TITLE
fix(app): remove mounted stores filter from upgrade store loader

### DIFF
--- a/client/app/upgrades.go
+++ b/client/app/upgrades.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	"cosmossdk.io/store/rootmulti"
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
@@ -97,20 +96,6 @@ func UpgradeStoreLoader(storeUpgradesMap StoreUpgradesMap) baseapp.StoreLoader {
 			return baseapp.DefaultStoreLoader(ms)
 		}
 
-		// Build set of already-mounted store keys. Stores registered from
-		// genesis (via app_config.go) already exist and must NOT be re-added
-		// through StoreUpgrades — doing so would set an incorrect initial
-		// version and cause "initial version set to X, but found earlier
-		// version Y" errors on restart.
-		mountedStores := make(map[string]bool)
-		if rms, ok := ms.(*rootmulti.Store); ok {
-			for name := range rms.StoreKeysByName() {
-				mountedStores[name] = true
-			}
-		} else {
-			fmt.Println("WARN: CommitMultiStore is not *rootmulti.Store, cannot detect already-mounted stores")
-		}
-
 		// Sort heights for deterministic iteration order across all validators.
 		heights := make([]int64, 0, len(storeUpgradesMap))
 		for h := range storeUpgradesMap {
@@ -125,8 +110,13 @@ func UpgradeStoreLoader(storeUpgradesMap StoreUpgradesMap) baseapp.StoreLoader {
 			su := storeUpgradesMap[height]
 			if height == nextVersion {
 				// Exact upgrade height: apply all operations.
+				// Do NOT filter by mountedStores here — the new binary
+				// mounts modules at startup (via app_config.go), but the
+				// store does not yet exist on disk. We must include it in
+				// Added so LoadLatestVersionAndUpgrade creates it at the
+				// correct version.
 				for _, key := range su.Added {
-					if !addedSet[key] && !mountedStores[key] {
+					if !addedSet[key] {
 						merged.Added = append(merged.Added, key)
 						addedSet[key] = true
 					}
@@ -134,11 +124,11 @@ func UpgradeStoreLoader(storeUpgradesMap StoreUpgradesMap) baseapp.StoreLoader {
 				merged.Deleted = append(merged.Deleted, su.Deleted...)
 				merged.Renamed = append(merged.Renamed, su.Renamed...)
 			} else if height > nextVersion {
-				// Future upgrade only: pre-add new stores so the binary
-				// can load without crashing on missing stores. This
-				// covers rolling upgrades and late-joining validators.
+				// Future upgrade: pre-add new stores so the binary can
+				// load without crashing on missing stores. Same logic —
+				// the store is mounted in code but not yet on disk.
 				for _, key := range su.Added {
-					if !addedSet[key] && !mountedStores[key] {
+					if !addedSet[key] {
 						merged.Added = append(merged.Added, key)
 						addedSet[key] = true
 					}


### PR DESCRIPTION
## Summary

Remove the `mountedStores` filter from `UpgradeStoreLoader` that incorrectly prevents new module stores from being added during live network upgrades.

## Problem

When upgrading a live network to a binary that introduces a new module (e.g., DKG in v2.0.0), the node crashes with:

```
version of store dkg mismatch root store's version; expected  got 0;
new stores should be added using StoreUpgrades
```

The root cause is in `UpgradeStoreLoader`: it builds a `mountedStores` set from stores registered by the binary at startup, then filters out any store in `StoreUpgrades.Added` that is already mounted. Since the new binary registers the DKG module on startup (via `app_config.go`), `mountedStores["dkg"]` is `true`, and DKG gets excluded from the `Added` list. This means `LoadLatestVersionAndUpgrade` is never called for DKG, and `DefaultStoreLoader` tries to load a store that doesn't exist on disk yet — causing the version mismatch crash.

## Fix

Remove the `mountedStores` check entirely. The `addedSet` guard already prevents duplicate additions, and the `lastVersion == 0` early return already handles the fresh genesis case (where all modules exist from block 0).

## Affected scenarios

| Scenario | Before | After |
|----------|--------|-------|
| Fresh genesis | OK (early return at `lastVersion == 0`) | OK (unchanged) |
| Live upgrade at exact height | **CRASH** — new store filtered out | OK — store included in `Added` |
| Post-upgrade restart | OK (past upgrades skipped) | OK (unchanged) |

issue: #722 
