### PR TITLE
fix(dkg): auto reconnect kernel client

### DIFF
--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -298,7 +298,7 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 
 // handleDecryptRequest attempts TDH2 partial decrypt for a single request.
 func (k *Keeper) handleDecryptRequest(ctx context.Context, session *types.DKGSession, req types.DecryptRequest) error {
-	if k.kernelRouter == nil || !k.kernelRouter.HasClients() {
+	if k.kernelRouter == nil {
 		return errors.New("kernel client not configured")
 	}
 
@@ -311,7 +311,7 @@ func (k *Keeper) handleDecryptRequest(ctx context.Context, session *types.DKGSes
 		return errors.New("missing global public key for session")
 	}
 
-	client, err := k.kernelRouter.GetClient(session.CodeCommitment)
+	client, err := k.getClientWithReconnect(session.CodeCommitment)
 	if err != nil {
 		return errors.Wrap(err, "no kernel client for session")
 	}
@@ -357,4 +357,18 @@ func labelToUUID(label []byte) (uint32, error) {
 		return 0, errors.New("label must be 32 bytes")
 	}
 	return binary.BigEndian.Uint32(label[28:]), nil
+}
+
+// getClientWithReconnect returns the kernel client for the given code commitment.
+// If the initial lookup fails, it attempts to reconnect any disconnected endpoints
+// and retries the lookup once. This handles the case where story started before kernel.
+func (k *Keeper) getClientWithReconnect(codeCommitment []byte) (types.KernelServiceClient, error) {
+	client, err := k.kernelRouter.GetClient(codeCommitment)
+	if err == nil {
+		return client, nil
+	}
+
+	k.kernelRouter.TryReconnect()
+
+	return k.kernelRouter.GetClient(codeCommitment)
 }

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -76,7 +76,7 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 			Round:          session.Round,
 			IsResharing:    session.IsResharing,
 		}
-		client, cErr := k.kernelRouter.GetClient(dealerCC)
+		client, cErr := k.getClientWithReconnect(dealerCC)
 		if cErr != nil {
 			return errors.Wrap(cErr, "no kernel client for session")
 		}
@@ -177,7 +177,7 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 			return nil
 		}
 
-		client, cErr := k.kernelRouter.GetClient(session.CodeCommitment)
+		client, cErr := k.getClientWithReconnect(session.CodeCommitment)
 		if cErr != nil {
 			return errors.Wrap(cErr, "no kernel client for session")
 		}
@@ -305,7 +305,7 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 				IsResharing:    session.IsResharing,
 			}
 
-			client, cErr := k.kernelRouter.GetClient(cc)
+			client, cErr := k.getClientWithReconnect(cc)
 			if cErr != nil {
 				return errors.Wrap(cErr, "no kernel client for session")
 			}
@@ -379,7 +379,7 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 				IsResharing:    session.IsResharing,
 			}
 
-			client, cErr := k.kernelRouter.GetClient(cc)
+			client, cErr := k.getClientWithReconnect(cc)
 			if cErr != nil {
 				return errors.Wrap(cErr, "no kernel client for session")
 			}
@@ -489,8 +489,17 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 		return
 	}
 
-	if k.kernelRouter == nil || !k.kernelRouter.HasClients() {
-		return // kernel still unavailable, wait
+	if k.kernelRouter == nil {
+		return // kernel router not configured
+	}
+
+	if !k.kernelRouter.HasClients() {
+		// No clients connected — attempt reconnection before giving up.
+		k.kernelRouter.TryReconnect()
+
+		if !k.kernelRouter.HasClients() {
+			return // kernel still unavailable, wait
+		}
 	}
 
 	asyncCtx, cancel := dkgAsyncContext()

--- a/client/x/dkg/keeper/dkg_svc_finalization.go
+++ b/client/x/dkg/keeper/dkg_svc_finalization.go
@@ -103,7 +103,7 @@ func (k *Keeper) callTEEFinalizeDKG(ctx context.Context, session *types.DKGSessi
 			IsResharing:    session.IsResharing,
 		}
 
-		client, cErr := k.kernelRouter.GetClient(session.CodeCommitment)
+		client, cErr := k.getClientWithReconnect(session.CodeCommitment)
 		if cErr != nil {
 			return errors.Wrap(cErr, "no kernel client for session")
 		}

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -128,9 +128,17 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 		return nil
 	}
 
-	// For upgrade rounds, route to the NEW binary's kernel client (CC != oldCC).
-	// For normal rounds, route to the previous active round's kernel client.
-	client, clientCC, cErr := k.getRegistrationKernelClient(isUpgrade, oldCC, session.OldCodeCommitment)
+	// Resolve kernel client by code commitment:
+	// - Normal rounds: use previous active round's CC to find the same binary.
+	// - Upgrade rounds: use old binary's CC to find the NEW binary (by exclusion).
+	var targetCC []byte
+	if isUpgrade {
+		targetCC = session.OldCodeCommitment
+	} else {
+		targetCC = oldCC
+	}
+
+	client, clientCC, cErr := k.getRegistrationKernelClient(isUpgrade, targetCC)
 	if cErr != nil {
 		return errors.Wrap(cErr, "no kernel client available for registration")
 	}
@@ -178,38 +186,33 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 	return nil
 }
 
-// getRegistrationKernelClient returns the appropriate kernel client and its code commitment for key generation.
-//
-// Non-upgrade: looks up the previous active round's code commitment from on-chain state
-// and returns the corresponding kernel client. For the very first round (no previous active
-// round exists), falls back to the first connected client.
-//
-// Upgrade: uses the provided upgradeOldCC to find the NEW binary — returns the connected client
-// whose code commitment differs from upgradeOldCC.
-//
-// prevRoundCC is the code commitment from the previous active DKG round (pre-computed
-// from SDK context before the async goroutine).
-func (k *Keeper) getRegistrationKernelClient(isUpgrade bool, prevRoundCC []byte, upgradeOldCC []byte) (types.KernelServiceClient, []byte, error) {
-	client, cc, err := k.resolveRegistrationKernelClient(isUpgrade, prevRoundCC, upgradeOldCC)
+// getRegistrationKernelClient returns the appropriate kernel client and its code commitment
+// for key generation. The cc parameter is interpreted differently based on isUpgrade:
+//   - Normal round: cc is the previous active round's code commitment — used to find the
+//     same kernel binary. nil cc (first round) falls back to first connected client.
+//   - Upgrade round: cc is the OLD binary's code commitment — used to find the NEW binary
+//     by returning a connected client whose CC differs from cc.
+func (k *Keeper) getRegistrationKernelClient(isUpgrade bool, cc []byte) (types.KernelServiceClient, []byte, error) {
+	client, resolvedCC, err := k.resolveRegistrationKernelClient(isUpgrade, cc)
 	if err == nil {
-		return client, cc, nil
+		return client, resolvedCC, nil
 	}
 
 	// First attempt failed — try reconnecting to any disconnected endpoints
 	// and resolve again. This handles the case where story started before kernel.
 	k.kernelRouter.TryReconnect()
 
-	return k.resolveRegistrationKernelClient(isUpgrade, prevRoundCC, upgradeOldCC)
+	return k.resolveRegistrationKernelClient(isUpgrade, cc)
 }
 
 // resolveRegistrationKernelClient looks up the appropriate kernel client without reconnection.
-func (k *Keeper) resolveRegistrationKernelClient(isUpgrade bool, prevRoundCC []byte, upgradeOldCC []byte) (types.KernelServiceClient, []byte, error) {
+func (k *Keeper) resolveRegistrationKernelClient(isUpgrade bool, cc []byte) (types.KernelServiceClient, []byte, error) {
 	if !isUpgrade {
 		// Use pre-computed CC from previous active round's registration.
-		if len(prevRoundCC) > 0 {
-			client, err := k.kernelRouter.GetClient(prevRoundCC)
+		if len(cc) > 0 {
+			client, err := k.kernelRouter.GetClient(cc)
 
-			return client, prevRoundCC, err
+			return client, cc, err
 		}
 
 		// First round: no previous active round exists. Use first connected client.
@@ -223,22 +226,22 @@ func (k *Keeper) resolveRegistrationKernelClient(isUpgrade bool, prevRoundCC []b
 		return client, allCCs[0], err
 	}
 
-	// Upgrade: upgradeOldCC must be provided so we can find the NEW binary.
-	if len(upgradeOldCC) == 0 {
+	// Upgrade: cc is the old binary's CC. Find a connected client with a DIFFERENT CC.
+	if len(cc) == 0 {
 		return nil, nil, errors.New("old code commitment required for upgrade registration")
 	}
 
 	allCCs := k.kernelRouter.GetAllCodeCommitments()
-	for _, cc := range allCCs {
-		if !bytes.Equal(cc, upgradeOldCC) {
-			client, err := k.kernelRouter.GetClient(cc)
+	for _, connCC := range allCCs {
+		if !bytes.Equal(connCC, cc) {
+			client, err := k.kernelRouter.GetClient(connCC)
 
-			return client, cc, err
+			return client, connCC, err
 		}
 	}
 
 	return nil, nil, errors.New("no new kernel client found for upgrade; ensure the new binary is running",
-		"old_code_commitment", hex.EncodeToString(upgradeOldCC),
+		"old_code_commitment", hex.EncodeToString(cc),
 		"connected_clients", len(allCCs),
 	)
 }

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -190,6 +190,20 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 // prevRoundCC is the code commitment from the previous active DKG round (pre-computed
 // from SDK context before the async goroutine).
 func (k *Keeper) getRegistrationKernelClient(isUpgrade bool, prevRoundCC []byte, upgradeOldCC []byte) (types.KernelServiceClient, []byte, error) {
+	client, cc, err := k.resolveRegistrationKernelClient(isUpgrade, prevRoundCC, upgradeOldCC)
+	if err == nil {
+		return client, cc, nil
+	}
+
+	// First attempt failed — try reconnecting to any disconnected endpoints
+	// and resolve again. This handles the case where story started before kernel.
+	k.kernelRouter.TryReconnect()
+
+	return k.resolveRegistrationKernelClient(isUpgrade, prevRoundCC, upgradeOldCC)
+}
+
+// resolveRegistrationKernelClient looks up the appropriate kernel client without reconnection.
+func (k *Keeper) resolveRegistrationKernelClient(isUpgrade bool, prevRoundCC []byte, upgradeOldCC []byte) (types.KernelServiceClient, []byte, error) {
 	if !isUpgrade {
 		// Use pre-computed CC from previous active round's registration.
 		if len(prevRoundCC) > 0 {

--- a/client/x/dkg/keeper/kernel_router.go
+++ b/client/x/dkg/keeper/kernel_router.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
@@ -178,4 +179,49 @@ func (r *KernelRouter) HasClients() bool {
 	defer r.mu.RUnlock()
 
 	return len(r.clients) > 0
+}
+
+// reconnectTimeout is the maximum duration for a single kernel reconnection
+// attempt (gRPC dial + GetCodeCommitment call).
+const reconnectTimeout = 10 * time.Second
+
+// TryReconnect attempts ConnectAndDiscover for any configured endpoints that
+// do not yet have an active client connection. It creates its own background
+// context with a short timeout so that reconnection is never tied to the
+// caller's context (e.g., CometBFT BeginBlocker which gets canceled after
+// block processing). Each endpoint is attempted once; failures are logged
+// but not returned so that the caller can continue with whatever clients
+// are available.
+func (r *KernelRouter) TryReconnect() {
+	disconnected := r.disconnectedEndpoints()
+	if len(disconnected) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), reconnectTimeout)
+	defer cancel()
+
+	for _, ep := range disconnected {
+		log.Info(ctx, "Attempting kernel reconnection", "endpoint", ep)
+
+		if err := r.ConnectAndDiscover(ctx, ep); err != nil {
+			log.Warn(ctx, "Kernel reconnection failed", err, "endpoint", ep)
+		}
+	}
+}
+
+// disconnectedEndpoints returns configured endpoints that do not have a
+// corresponding entry in the ccByEP map (i.e. no successful connection yet).
+func (r *KernelRouter) disconnectedEndpoints() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var out []string
+	for _, ep := range r.endpoints {
+		if _, ok := r.ccByEP[ep]; !ok {
+			out = append(out, ep)
+		}
+	}
+
+	return out
 }


### PR DESCRIPTION
## Summary

When story starts before kernel, the initial `ConnectAndDiscover` at startup fails and all subsequent DKG operations error with "no kernel clients available for registration". Previously the only fix was restarting story after kernel was up.

This PR adds on-demand reconnection: before each kernel gRPC call, if no client is connected, `TryReconnect` attempts `ConnectAndDiscover` for any unconfigured endpoints. Reconnection uses its own background context (10s timeout) so it never blocks or gets canceled by the CometBFT consensus context.

## Changes

**Auto-reconnect (`d16b653e`)**
- `KernelRouter.TryReconnect()`: attempts `ConnectAndDiscover` for endpoints without active connections, using a dedicated `context.Background()` with 10s timeout
- `getClientWithReconnect()`: wraps `GetClient` — on failure, calls `TryReconnect` then retries once
- `getRegistrationKernelClient()`: same pattern for registration client resolution
- `reprocessPendingIncomingData()`: attempts reconnection before giving up on pending deals/responses

**Refactor (`ed3bca9e`)**
- Simplified `getRegistrationKernelClient` signature: merged mutually exclusive `prevRoundCC` and `upgradeOldCC` into a single `cc` parameter, with the caller resolving the appropriate CC based on `isUpgrade`

issue: none
