### PR TITLE
refactor(dkg): remove redundant checks and support on chain upgrade scheduling

### DIFF
--- a/client/app/prouter.go
+++ b/client/app/prouter.go
@@ -18,7 +18,6 @@ import (
 	evmenginetypes "github.com/piplabs/story/client/x/evmengine/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
-	"github.com/piplabs/story/lib/netconf"
 )
 
 // processTimeout is the maximum time to process a proposal.
@@ -76,16 +75,7 @@ func makeProcessProposalHandler(router *baseapp.MsgServiceRouter, txConfig clien
 		// Ensure only expected messages types are included the expected number of times.
 		expectedMsgCounts := map[string]int{
 			sdk.MsgTypeURL(&evmenginetypes.MsgExecutionPayload{}): 1, // Only a single EVM execution payload is allowed.
-		}
-
-		// MsgAddDkgVote is only expected after v2.0.0 activation (+2 blocks
-		// for vote extensions to propagate through LocalLastCommit).
-		v200Height, v200Err := netconf.GetUpgradeHeight(ctx.ChainID(), netconf.V200)
-		if v200Err != nil {
-			return rejectProposal(ctx, errors.Wrap(v200Err, "get v2.0.0 upgrade height"))
-		}
-		if req.Height > v200Height+1 {
-			expectedMsgCounts[sdk.MsgTypeURL(&dkgtypes.MsgAddDkgVote{})] = 1
+			sdk.MsgTypeURL(&dkgtypes.MsgAddDkgVote{}):             1, // Exactly one DKG vote message is expected.
 		}
 
 		rawTX := req.Txs[0]

--- a/client/app/prouter_internal_test.go
+++ b/client/app/prouter_internal_test.go
@@ -56,7 +56,7 @@ func createRequest(t *testing.T, txConfig client.TxConfig, msg []types.Msg, isFi
 		txs = append(txs, txBz)
 	}
 
-	height := int64(200) // Past v2.0.0 upgrade height for TestChainID (110).
+	height := int64(200)
 	if isFirst {
 		height = 1
 	}

--- a/client/app/upgrades.go
+++ b/client/app/upgrades.go
@@ -54,7 +54,7 @@ func (a *App) setupUpgradeHandlers() {
 	}
 }
 
-// setUpgradeStoreLoaders sets custom store loaders to customize the rootMultiStore initialization for software upgrades.
+// setupUpgradeStoreLoaders sets custom store loaders to customize the rootMultiStore initialization for software upgrades.
 func (a *App) setupUpgradeStoreLoaders() {
 	upgradeHistory, err := netconf.GetUpgradeHistory(a.ChainID())
 	if err != nil {
@@ -72,6 +72,18 @@ func (a *App) setupUpgradeStoreLoaders() {
 			if name == upgrade.UpgradeName {
 				storeUpgradesMap[height] = upgrade.StoreUpgrades
 			}
+		}
+	}
+
+	// For binary-swap upgrades scheduled on-chain via planUpgrade (not in
+	// UpgradeHistories), the old binary writes upgrade-info.json to disk
+	// before halting. Read it to register the store upgrades at the correct
+	// height so the new binary can mount new module stores on startup.
+	diskPlan, diskErr := a.Keepers.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if diskErr == nil && diskPlan.Height > 0 && !a.Keepers.UpgradeKeeper.IsSkipHeight(diskPlan.Height) {
+		storeUpgrades, err := GetStoreUpgrades(diskPlan.Name)
+		if err == nil {
+			storeUpgradesMap[diskPlan.Height] = storeUpgrades
 		}
 	}
 
@@ -205,11 +217,21 @@ func GetUpgradeHeight(ctx sdk.Context, upgradeName string, fallbackHeight int64)
 	case netconf.Horace:
 		return horace.GetUpgradeHeight(ctx)
 
-	case netconf.V200:
-		return v_2_0_0.GetUpgradeHeight(ctx)
-
 	default:
 		// no dynamic resolver → use fallback (static height)
 		return fallbackHeight, true
+	}
+}
+
+// GetStoreUpgrades returns the store upgrades for a given scheduled upgrade on-chain.
+// This is used by the disk-based fallback in setupUpgradeStoreLoaders to
+// determine which stores to add when the upgrade height comes from
+// upgrade-info.json rather than from hardcoded UpgradeHistories.
+func GetStoreUpgrades(upgradeName string) (storetypes.StoreUpgrades, error) {
+	switch upgradeName {
+	case netconf.V200:
+		return v_2_0_0.Upgrade.StoreUpgrades, nil
+	default:
+		return storetypes.StoreUpgrades{}, errors.New("no matched store upgrades")
 	}
 }

--- a/client/app/upgrades/v_2_0_0/constants.go
+++ b/client/app/upgrades/v_2_0_0/constants.go
@@ -8,10 +8,16 @@ import (
 	"github.com/piplabs/story/client/app/keepers"
 	"github.com/piplabs/story/client/app/upgrades"
 	dkgtypes "github.com/piplabs/story/client/x/dkg/types"
-	"github.com/piplabs/story/lib/log"
 	"github.com/piplabs/story/lib/netconf"
 )
 
+// UpgradeName is the on-chain name for the v2.0.0 upgrade that activates the
+// DKG module. This is a binary-swap upgrade: the old binary should halt at
+// the scheduled height, and operators replace it with the v2.0.0 binary.
+//
+// the upgrade is scheduled on-chain by calling UpgradeEntrypoint.planUpgrade("v2.0.0", height).
+// The old binary writes upgrade-info.json to disk before halting, which the new binary reads
+// to configure the store loader (see setupUpgradeStoreLoaders in upgrades.go).
 const UpgradeName = netconf.V200
 
 var Upgrade = upgrades.Upgrade{
@@ -26,15 +32,4 @@ var Fork = upgrades.Fork{
 	UpgradeName:    UpgradeName,
 	UpgradeInfo:    "activate DKG module on the network",
 	BeginForkLogic: func(_ sdk.Context, _ *keepers.Keepers) {},
-}
-
-func GetUpgradeHeight(ctx sdk.Context) (int64, bool) {
-	height, err := netconf.GetUpgradeHeight(ctx.ChainID(), UpgradeName)
-	if err != nil {
-		log.Error(ctx, "Failed to get upgrade height", err, "chain_id", ctx.ChainID(), "upgrade_name", UpgradeName)
-
-		return 0, false
-	}
-
-	return height, true
 }

--- a/client/app/upgrades_internal_test.go
+++ b/client/app/upgrades_internal_test.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"testing"
+
+	dbm "github.com/cosmos/cosmos-db"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/store/metrics"
+	"cosmossdk.io/store/rootmulti"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStore creates an in-memory rootmulti.Store with the given store keys mounted.
+func newTestStore(t *testing.T, keys ...string) *rootmulti.Store {
+	t.Helper()
+	db := dbm.NewMemDB()
+	ms := rootmulti.NewStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+
+	for _, k := range keys {
+		ms.MountStoreWithDB(storetypes.NewKVStoreKey(k), storetypes.StoreTypeIAVL, nil)
+	}
+
+	require.NoError(t, ms.LoadLatestVersion())
+
+	return ms
+}
+
+func TestUpgradeStoreLoader_FreshGenesis(t *testing.T) {
+	ms := newTestStore(t, "bank", "staking", "dkg")
+	// lastVersion == 0 on fresh genesis → DefaultStoreLoader path
+	require.Equal(t, int64(0), ms.LastCommitID().Version)
+
+	loader := UpgradeStoreLoader(StoreUpgradesMap{
+		100: {Added: []string{"dkg"}},
+	})
+
+	require.NoError(t, loader(ms))
+}
+
+func TestUpgradeStoreLoader_FutureUpgradePreAddsStores(t *testing.T) {
+	ms := newTestStore(t, "bank", "staking")
+	// Commit once so lastVersion > 0
+	ms.Commit()
+	require.Equal(t, int64(1), ms.LastCommitID().Version)
+
+	// Upgrade at height 100 (far in the future, nextVersion=2)
+	loader := UpgradeStoreLoader(StoreUpgradesMap{
+		100: {Added: []string{"dkg"}},
+	})
+
+	require.NoError(t, loader(ms))
+
+	// After loading, dkg store should be available
+	dkgKey := storetypes.NewKVStoreKey("dkg")
+	ms.MountStoreWithDB(dkgKey, storetypes.StoreTypeIAVL, nil)
+	// This verifies the store was pre-added (LoadLatestVersionAndUpgrade was called)
+}
+
+func TestUpgradeStoreLoader_ExactUpgradeHeight(t *testing.T) {
+	ms := newTestStore(t, "bank", "staking")
+	ms.Commit()
+	require.Equal(t, int64(1), ms.LastCommitID().Version)
+
+	// nextVersion = 2, so height=2 is the exact upgrade height
+	loader := UpgradeStoreLoader(StoreUpgradesMap{
+		2: {Added: []string{"dkg"}},
+	})
+
+	require.NoError(t, loader(ms))
+}
+
+func TestUpgradeStoreLoader_PastUpgradeSkipped(t *testing.T) {
+	ms := newTestStore(t, "bank", "staking", "dkg")
+	ms.Commit() // version 1
+	ms.Commit() // version 2
+
+	require.Equal(t, int64(2), ms.LastCommitID().Version)
+
+	// Upgrade at height 1 is in the past (nextVersion=3)
+	loader := UpgradeStoreLoader(StoreUpgradesMap{
+		1: {Added: []string{"newmodule"}},
+	})
+
+	// Should use DefaultStoreLoader since no pending upgrades
+	require.NoError(t, loader(ms))
+}
+
+func TestUpgradeStoreLoader_EmptyMap(t *testing.T) {
+	ms := newTestStore(t, "bank", "staking")
+	ms.Commit()
+
+	loader := UpgradeStoreLoader(StoreUpgradesMap{})
+	require.NoError(t, loader(ms))
+}
+
+func TestUpgradeStoreLoader_DeterministicOrdering(t *testing.T) {
+	// Ensure multiple upgrades produce consistent merged results
+	ms := newTestStore(t, "bank")
+	ms.Commit()
+
+	loader := UpgradeStoreLoader(StoreUpgradesMap{
+		100: {Added: []string{"module_a"}},
+		200: {Added: []string{"module_b"}},
+		300: {Added: []string{"module_c"}},
+	})
+
+	require.NoError(t, loader(ms))
+}

--- a/client/x/dkg/keeper/abci.go
+++ b/client/x/dkg/keeper/abci.go
@@ -8,24 +8,11 @@ import (
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
-	"github.com/piplabs/story/lib/netconf"
 )
 
 func (k *Keeper) BeginBlocker(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	currentHeight := sdkCtx.BlockHeight()
-
-	// DKG module activates at the v2.0.0 upgrade height. Before that,
-	// BeginBlocker is a complete no-op to ensure identical behavior to
-	// the pre-upgrade binary during rolling upgrades.
-	isV200, err := netconf.IsV200(sdkCtx.ChainID(), currentHeight)
-	if err != nil {
-		return errors.Wrap(err, "check v2.0.0 upgrade height")
-	}
-
-	if !isV200 {
-		return nil
-	}
 
 	params, err := k.GetParams(ctx)
 	if err != nil {

--- a/client/x/dkg/keeper/dkg_lifecycle_internal_test.go
+++ b/client/x/dkg/keeper/dkg_lifecycle_internal_test.go
@@ -473,24 +473,6 @@ func TestDKGLifecycle_StageTransitionTiming(t *testing.T) {
 		"should transition to Dealing at exact boundary")
 }
 
-// TestDKGLifecycle_BeginBlockerPreV200Noop verifies that BeginBlocker is a
-// complete no-op before V200 activation height.
-func TestDKGLifecycle_BeginBlockerPreV200Noop(t *testing.T) {
-	t.Parallel()
-	env := setupDKGLifecycleEnv(t, 3)
-
-	// TestChainID has V200 at block 110. Set height to 109 (before V200).
-	env.advanceToHeight(109)
-
-	// BeginBlocker should return nil without doing anything
-	require.NoError(t, env.keeper.BeginBlocker(env.sdkCtx))
-
-	// No DKG round should exist
-	latestRound, err := env.keeper.GetLatestDKGRound(env.sdkCtx)
-	require.NoError(t, err)
-	require.Nil(t, latestRound, "no DKG round should be created before V200")
-}
-
 // TestDKGLifecycle_InsufficientRegistrations verifies that when the number of
 // verified registrations is below MinReqRegisteredParticipants, the round is
 // skipped and a new round is initiated.

--- a/client/x/dkg/keeper/vote.go
+++ b/client/x/dkg/keeper/vote.go
@@ -12,7 +12,6 @@ import (
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
-	"github.com/piplabs/story/lib/netconf"
 )
 
 const (
@@ -25,17 +24,7 @@ const (
 	maxItemsPerVote = 80
 )
 
-func (k *Keeper) ExtendVote(ctx sdk.Context, _ *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
-	// Vote extensions are only active after v2.0.0 upgrade.
-	isV200, err := netconf.IsV200(ctx.ChainID(), ctx.BlockHeight())
-	if err != nil {
-		return nil, errors.Wrap(err, "check v2.0.0 upgrade height")
-	}
-
-	if !isV200 {
-		return &abci.ResponseExtendVote{}, nil
-	}
-
+func (k *Keeper) ExtendVote(_ sdk.Context, _ *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
 	dequeuedDeals := k.DequeueDeals(maxItemsPerVote)
 	dequeuedResponses := k.DequeueResponses(maxItemsPerVote)
 	dequeuedJustifications := k.DequeueJustifications(maxItemsPerVote)
@@ -55,19 +44,9 @@ func (k *Keeper) ExtendVote(ctx sdk.Context, _ *abci.RequestExtendVote) (*abci.R
 }
 
 func (k *Keeper) VerifyVoteExtension(ctx sdk.Context, req *abci.RequestVerifyVoteExtension) (*abci.ResponseVerifyVoteExtension, error) {
-	// Vote extensions are only active after v2.0.0 upgrade.
-	isV200, err := netconf.IsV200(ctx.ChainID(), ctx.BlockHeight())
-	if err != nil {
-		return nil, errors.Wrap(err, "check v2.0.0 upgrade height")
-	}
-
-	if !isV200 {
-		return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_ACCEPT}, nil
-	}
-
 	// Reject malformed vote extensions via ABCI status (not Go error),
 	// as returning a Go error is treated as an application bug by CometBFT.
-	_, _, err = k.parseAndVerifyVoteExtension(req.VoteExtension)
+	_, _, err := k.parseAndVerifyVoteExtension(req.VoteExtension)
 	if err != nil {
 		log.Warn(ctx, "Rejecting malformed vote extension", err)
 		return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
@@ -112,18 +91,20 @@ func (*Keeper) parseAndVerifyVoteExtension(voteExt []byte) ([]*types.Vote, bool,
 func (k *Keeper) PrepareVotes(ctx context.Context, commit abci.ExtendedCommitInfo, commitHeight uint64) (sdk.Msg, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	// Vote extensions become available in LocalLastCommit two blocks after the
-	// upgrade: the upgrade handler at height H sets vote_extensions_enable_height
-	// to H+1, CometBFT starts collecting VEs at H+1, and they appear in
-	// LocalLastCommit at H+2. Return nil so the caller omits MsgAddDkgVote
-	// from the proposal, keeping it compatible with pre-upgrade validators.
-	v200Height, err := netconf.GetUpgradeHeight(sdkCtx.ChainID(), netconf.V200)
-	if err != nil {
-		return nil, errors.Wrap(err, "get v2.0.0 upgrade height")
+	// Vote extensions become available in LocalLastCommit one block after the
+	// VoteExtensionsEnableHeight. At the enable height itself, LocalLastCommit
+	// contains votes from the previous height which have no VE data.
+	// Return an empty MsgAddDkgVote until VEs are actually present.
+	cp := sdkCtx.ConsensusParams()
+	veHeight := int64(0)
+	if cp.Abci != nil {
+		veHeight = cp.Abci.VoteExtensionsEnableHeight
 	}
-
-	if sdkCtx.BlockHeight() <= v200Height+1 {
-		return nil, nil
+	if veHeight == 0 || sdkCtx.BlockHeight() <= veHeight {
+		return &types.MsgAddDkgVote{
+			Authority: k.GetAuthority(),
+			Vote:      &types.Vote{},
+		}, nil
 	}
 
 	// The VEs in LastLocalCommit is expected to be valid

--- a/client/x/dkg/keeper/vote_justification_test.go
+++ b/client/x/dkg/keeper/vote_justification_test.go
@@ -23,7 +23,6 @@ func newTestSDKContext(t *testing.T, keyName string) sdk.Context {
 	transKey := storetypes.NewTransientStoreKey(keyName + "_transient")
 	testCtx := testutil.DefaultContextWithDB(t, key, transKey)
 
-	// Set chain ID and block height so that IsV200 returns true.
 	return testCtx.Ctx.WithChainID(netconf.TestChainID).WithBlockHeight(200)
 }
 

--- a/client/x/evmengine/keeper/abci.go
+++ b/client/x/evmengine/keeper/abci.go
@@ -195,11 +195,9 @@ func (k *Keeper) PrepareProposal(ctx sdk.Context, req *abci.RequestPreparePropos
 		return nil, errors.Wrap(err, "prepare votes")
 	}
 
-	// Combine all the votes messages and the payload message into a single transaction.
+	// Combine the payload message and vote message into a single transaction.
 	b := k.txConfig.NewTxBuilder()
 
-	// Before v2.0.0 activation, voteMsg is nil — omit it to keep
-	// proposals compatible with pre-upgrade validators.
 	msgs := []sdk.Msg{payloadMsg}
 	if voteMsg != nil {
 		msgs = append(msgs, voteMsg)

--- a/client/x/evmstaking/keeper/ubi.go
+++ b/client/x/evmstaking/keeper/ubi.go
@@ -10,7 +10,6 @@ import (
 	"github.com/piplabs/story/client/x/evmstaking/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
-	"github.com/piplabs/story/lib/netconf"
 )
 
 func (k Keeper) ProcessUbiWithdrawal(ctx context.Context) error {
@@ -21,22 +20,10 @@ func (k Keeper) ProcessUbiWithdrawal(ctx context.Context) error {
 		return errors.Wrap(err, "get ubi params")
 	}
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	currentHeight := sdkCtx.BlockHeight()
-
-	// DKG-related reward distribution only activates at the v2.0.0 upgrade height.
-	isV200, err := netconf.IsV200(sdkCtx.ChainID(), currentHeight)
+	// Sweep any settlement balance from the DKG module (leftover UBI from FinalizeDKGRound).
+	settlementAmount, err := k.dkgKeeper.ClaimSettlementBalance(ctx, types.ModuleName)
 	if err != nil {
-		return errors.Wrap(err, "check v2.0.0 upgrade height")
-	}
-
-	settlementAmount := math.ZeroInt()
-	if isV200 {
-		// Sweep any settlement balance from the DKG module (leftover UBI from FinalizeDKGRound).
-		settlementAmount, err = k.dkgKeeper.ClaimSettlementBalance(ctx, types.ModuleName)
-		if err != nil {
-			return errors.Wrap(err, "claim DKG settlement balance")
-		}
+		return errors.Wrap(err, "claim DKG settlement balance")
 	}
 
 	ubiBalance, err := k.distributionKeeper.GetUbiBalanceByDenom(ctx, sdk.DefaultBondDenom)
@@ -59,15 +46,13 @@ func (k Keeper) ProcessUbiWithdrawal(ctx context.Context) error {
 
 		withdrawnAmount = ubiCoin.Amount
 
-		if isV200 {
-			// Distribute DKG rewards for the current active DKG committee.
-			distributed, err := k.dkgKeeper.DistributeRewardsToActiveCommittee(ctx, types.ModuleName, withdrawnAmount)
-			if err != nil {
-				return errors.Wrap(err, "distribute DKG committee rewards")
-			}
-
-			withdrawnAmount = withdrawnAmount.Sub(distributed)
+		// Distribute DKG rewards for the current active DKG committee.
+		distributed, err := k.dkgKeeper.DistributeRewardsToActiveCommittee(ctx, types.ModuleName, withdrawnAmount)
+		if err != nil {
+			return errors.Wrap(err, "distribute DKG committee rewards")
 		}
+
+		withdrawnAmount = withdrawnAmount.Sub(distributed)
 	}
 
 	// Total amount to burn and add to withdrawal queue = withdrawn remainder + settlement.

--- a/client/x/evmstaking/keeper/ubi_test.go
+++ b/client/x/evmstaking/keeper/ubi_test.go
@@ -130,7 +130,6 @@ func TestProcessUbiWithdrawal(t *testing.T) {
 				tc.setupMocks(bk, dk, dkgk)
 			}
 
-			// Set block height past v2.0.0 upgrade height to activate DKG features.
 			cachedCtx, _ := ctx.WithBlockHeight(200).CacheContext()
 
 			// initialize withdrawal queue

--- a/lib/netconf/upgrades.go
+++ b/lib/netconf/upgrades.go
@@ -32,21 +32,18 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Terence: 50,
 		V142:    50,
 		Horace:  100,
-		V200:    110,
 	},
 	LocalChainID: {
 		V121:    0,
 		Terence: 50,
 		V142:    50,
 		Horace:  100,
-		V200:    110,
 	},
 	StoryLocalnetID: {
 		V121:    0,
 		Terence: 0,
 		V142:    0,
 		Horace:  100,
-		V200:    110,
 	},
 	AeneidChainID: {
 		Virgil:   345158,
@@ -56,7 +53,6 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Terence:  10886688,
 		V142:     12088950,
 		Horace:   14017000,
-		V200:     100000000, // TBD: set before deployment
 	},
 	StoryChainID: {
 		Virgil:   809988,
@@ -66,7 +62,6 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Terence:  11538000,
 		V142:     11784600,
 		Horace:   13780500,
-		V200:     100000000, // TBD: set before deployment
 	},
 }
 
@@ -127,13 +122,4 @@ func IsV142(chainID string, blockNumber int64) (bool, error) {
 	}
 
 	return blockNumber >= v142Block, nil
-}
-
-func IsV200(chainID string, blockNumber int64) (bool, error) {
-	v200Block, err := GetUpgradeHeight(chainID, V200)
-	if err != nil {
-		return false, err
-	}
-
-	return blockNumber >= v200Block, nil
 }


### PR DESCRIPTION
## Summary

v2.0.0 is a binary-swap upgrade — the v2.0.0 binary only ever processes blocks at or after the upgrade height. All `isV200` early-return guards are therefore dead code and have been removed. The `PrepareVotes` timing guard has been replaced with a direct check against `VoteExtensionsEnableHeight` from consensus params.

This PR also adds support for on-chain upgrade scheduling via `UpgradeEntrypoint.planUpgrade()`, so live networks no longer need hardcoded v200 heights in `UpgradeHistories`.

## Changes

**Remove `isV200` checks**
- `BeginBlocker`, `ExtendVote`, `VerifyVoteExtension`, `ProcessUbiWithdrawal`: remove early return for `!isV200`
- `ProcessProposal`: always expect `MsgAddDkgVote` (binary is always v2.0.0+)
- `ProcessUbiWithdrawal`: make DKG settlement claim and reward distribution unconditional
- Delete `IsV200()` function, `TestDKGLifecycle_BeginBlockerPreV200Noop`

**Replace VE timing guard**
- `PrepareVotes`: replace `isV200` / `v200Height+1` guard with a direct check against `VoteExtensionsEnableHeight` from consensus params. Returns empty `MsgAddDkgVote` until VE is available in `LocalLastCommit`.

**Support on-chain upgrade scheduling**
- `setupUpgradeStoreLoaders`: add disk-based fallback that reads `upgrade-info.json` (written by old binary during `planUpgrade` halt) to register store upgrades at the correct height
- `GetStoreUpgrades`: new function that maps upgrade names to their store upgrades
- Remove v200 from `GetUpgradeHeight` switch and from live chain `UpgradeHistories`
- Add unit tests for `UpgradeStoreLoader`

## Test results

**Test A: v1.5.3 → planUpgrade → v2.0.0 binary swap + RPC node sync**

| Step | Result |
|------|--------|
| v1.5.3 startup | blocks producing |
| `planUpgrade("v2.0.0", H)` | `status: 1 (success)` |
| v1.5.3 halt | `UPGRADE "v2.0.0" NEEDED at height: H` |
| v2.0.0 binary swap | upgrade applied, DKG round 1 initiated, blocks resume |
| RPC node full sync with binary swap | synced to latest, catching_up=false, 0 app hash mismatches |

**Test B: Genesis v2.0.0 chain + RPC node sync**

| Step | Result |
|------|--------|
| v2.0.0 genesis startup | DKG round 1 at height 1, blocks producing |
| RPC node full sync | synced to latest, catching_up=false, 0 app hash mismatches |

issue: none
