### PR TITLE
feat: license holder read condition contract

### DIFF
--- a/contracts/src/protocol/CDR.sol
+++ b/contracts/src/protocol/CDR.sol
@@ -11,7 +11,6 @@ import { ICDRWriteCondition } from "../interfaces/ICDRWriteCondition.sol";
 import { ICDRReadCondition } from "../interfaces/ICDRReadCondition.sol";
 
 contract CDR is ICDR, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, PausableUpgradeable, UUPSUpgradeable {
-
     /// @dev Storage structure for the CDR
     /// @param uuid The UUID of the vault
     /// @param baseFee The base fee

--- a/contracts/src/protocol/cdr/LicenseReadCondition.sol
+++ b/contracts/src/protocol/cdr/LicenseReadCondition.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+
+import { ICDRReadCondition } from "../../interfaces/ICDRReadCondition.sol";
+
+/// @notice Minimal interface for Story Protocol's LicenseToken (ERC721-based).
+interface ILicenseToken {
+    struct LicenseTokenMetadata {
+        address licensorIpId;
+        address licenseTemplate;
+        uint256 licenseTermsId;
+        bool transferable;
+        uint32 commercialRevShare;
+    }
+
+    function ownerOf(uint256 tokenId) external view returns (address);
+    function getLicenseTokenMetadata(uint256 tokenId) external view returns (LicenseTokenMetadata memory);
+    function isLicenseTokenRevoked(uint256 tokenId) external view returns (bool);
+}
+
+/// @title LicenseReadCondition
+/// @notice CDR read condition that gates access to a vault based on ownership of a Story Protocol
+///         license token for the vault's IP asset.
+///
+/// Usage:
+///   - When allocating a vault via CDR.allocate(), set readConditionAddr to this contract's address
+///     and readConditionData to abi.encode(licenseTokenAddress, ipId).
+///   - When reading via CDR.read(), pass accessAuxData as abi.encode(licenseTokenIds) where
+///     licenseTokenIds is a uint256[] of token IDs the caller owns.
+contract LicenseReadCondition is ICDRReadCondition {
+    /// @notice Checks whether the caller holds a valid (non-revoked) license token
+    ///         issued for the vault's IP asset.
+    /// @param accessAuxData ABI-encoded uint256[] of license token IDs the caller presents as proof
+    /// @param readConditionData ABI-encoded (address licenseToken, address ipId)
+    /// @param caller The address attempting to read the vault
+    /// @return True if the caller owns at least one valid license token for the IP asset
+    function checkReadCondition(
+        uint32,
+        bytes calldata accessAuxData,
+        bytes calldata readConditionData,
+        address caller
+    ) external view override returns (bool) {
+        (address licenseToken, address ipId) = abi.decode(readConditionData, (address, address));
+        uint256[] memory tokenIds = abi.decode(accessAuxData, (uint256[]));
+
+        ILicenseToken lt = ILicenseToken(licenseToken);
+
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            // Caller must own the token
+            if (lt.ownerOf(tokenIds[i]) != caller) continue;
+
+            // Token must not be revoked
+            if (lt.isLicenseTokenRevoked(tokenIds[i])) continue;
+
+            // Token must be issued for the target IP asset
+            ILicenseToken.LicenseTokenMetadata memory meta = lt.getLicenseTokenMetadata(tokenIds[i]);
+            if (meta.licensorIpId == ipId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/contracts/test/cdr/LicenseReadCondition.t.sol
+++ b/contracts/test/cdr/LicenseReadCondition.t.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+/* solhint-disable no-console */
+/* solhint-disable max-line-length */
+
+import { Test as ForgeTest } from "forge-std/Test.sol";
+
+import { LicenseReadCondition } from "../../src/protocol/cdr/LicenseReadCondition.sol";
+import { MockLicenseToken } from "./MockLicenseToken.sol";
+
+contract LicenseReadConditionTest is ForgeTest {
+    LicenseReadCondition internal condition;
+    MockLicenseToken internal licenseToken;
+
+    address internal ipId = address(0x1111);
+    address internal otherIpId = address(0xBEEF);
+    address internal licenseTemplate = address(0x7E9B7A7E);
+    address internal alice = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    function setUp() public {
+        condition = new LicenseReadCondition();
+        licenseToken = new MockLicenseToken();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    function _readConditionData() internal view returns (bytes memory) {
+        return abi.encode(address(licenseToken), ipId);
+    }
+
+    function _accessAuxData(uint256[] memory tokenIds) internal pure returns (bytes memory) {
+        return abi.encode(tokenIds);
+    }
+
+    function _singleTokenArray(uint256 tokenId) internal pure returns (uint256[] memory) {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = tokenId;
+        return ids;
+    }
+
+    function _check(address caller, uint256[] memory tokenIds) internal view returns (bool) {
+        return
+            condition.checkReadCondition(
+                0, // uuid (unused)
+                _accessAuxData(tokenIds),
+                _readConditionData(),
+                caller
+            );
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests: valid license holder can read
+    // -----------------------------------------------------------------------
+
+    function testCheckReadCondition_ValidLicense() public {
+        uint256 tokenId = licenseToken.mint(alice, ipId, licenseTemplate, 1, true, 0);
+        assertTrue(_check(alice, _singleTokenArray(tokenId)));
+    }
+
+    function testCheckReadCondition_MultipleTokens_OneValid() public {
+        // Token for a different IP
+        uint256 wrongIp = licenseToken.mint(alice, otherIpId, licenseTemplate, 1, true, 0);
+        // Token for the correct IP
+        uint256 correctIp = licenseToken.mint(alice, ipId, licenseTemplate, 2, true, 0);
+
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = wrongIp;
+        ids[1] = correctIp;
+        assertTrue(_check(alice, ids));
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests: no license → denied
+    // -----------------------------------------------------------------------
+
+    function testCheckReadCondition_NoTokens() public view {
+        uint256[] memory empty = new uint256[](0);
+        assertFalse(_check(alice, empty));
+    }
+
+    function testCheckReadCondition_NotOwner() public {
+        uint256 tokenId = licenseToken.mint(bob, ipId, licenseTemplate, 1, true, 0);
+        // alice tries to use bob's token
+        assertFalse(_check(alice, _singleTokenArray(tokenId)));
+    }
+
+    function testCheckReadCondition_WrongIpId() public {
+        uint256 tokenId = licenseToken.mint(alice, otherIpId, licenseTemplate, 1, true, 0);
+        assertFalse(_check(alice, _singleTokenArray(tokenId)));
+    }
+
+    function testCheckReadCondition_RevokedToken() public {
+        uint256 tokenId = licenseToken.mint(alice, ipId, licenseTemplate, 1, true, 0);
+        licenseToken.revoke(tokenId);
+        assertFalse(_check(alice, _singleTokenArray(tokenId)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests: edge cases
+    // -----------------------------------------------------------------------
+
+    function testCheckReadCondition_RevokedAndValid() public {
+        uint256 revoked = licenseToken.mint(alice, ipId, licenseTemplate, 1, true, 0);
+        licenseToken.revoke(revoked);
+
+        uint256 valid = licenseToken.mint(alice, ipId, licenseTemplate, 2, true, 0);
+
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = revoked;
+        ids[1] = valid;
+        assertTrue(_check(alice, ids));
+    }
+
+    function testCheckReadCondition_TransferredAway() public {
+        uint256 tokenId = licenseToken.mint(alice, ipId, licenseTemplate, 1, true, 0);
+        // alice transfers to bob
+        licenseToken.transferFrom(alice, bob, tokenId);
+
+        // alice no longer has access
+        assertFalse(_check(alice, _singleTokenArray(tokenId)));
+        // bob now has access
+        assertTrue(_check(bob, _singleTokenArray(tokenId)));
+    }
+
+    function testCheckReadCondition_AllTokensInvalid() public {
+        uint256 wrongOwner = licenseToken.mint(bob, ipId, licenseTemplate, 1, true, 0);
+        uint256 wrongIp = licenseToken.mint(alice, otherIpId, licenseTemplate, 2, true, 0);
+        uint256 revoked = licenseToken.mint(alice, ipId, licenseTemplate, 3, true, 0);
+        licenseToken.revoke(revoked);
+
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = wrongOwner;
+        ids[1] = wrongIp;
+        ids[2] = revoked;
+        assertFalse(_check(alice, ids));
+    }
+
+    function testCheckReadCondition_NonTransferable_StillValid() public {
+        // transferable=false doesn't affect read access, only transferability
+        uint256 tokenId = licenseToken.mint(alice, ipId, licenseTemplate, 1, false, 0);
+        assertTrue(_check(alice, _singleTokenArray(tokenId)));
+    }
+
+    function testCheckReadCondition_WithCommercialRevShare() public {
+        uint256 tokenId = licenseToken.mint(alice, ipId, licenseTemplate, 1, true, 500);
+        assertTrue(_check(alice, _singleTokenArray(tokenId)));
+    }
+}

--- a/contracts/test/cdr/MockLicenseToken.sol
+++ b/contracts/test/cdr/MockLicenseToken.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+
+import { ILicenseToken } from "../../src/protocol/cdr/LicenseReadCondition.sol";
+
+/// @title MockLicenseToken
+/// @notice Mock of Story Protocol's LicenseToken for testing LicenseReadCondition.
+contract MockLicenseToken {
+    struct TokenData {
+        address owner;
+        address licensorIpId;
+        address licenseTemplate;
+        uint256 licenseTermsId;
+        bool transferable;
+        uint32 commercialRevShare;
+        bool revoked;
+        bool exists;
+    }
+
+    mapping(uint256 => TokenData) private _tokens;
+    uint256 private _nextTokenId;
+
+    /// @notice Mints a license token for testing
+    function mint(
+        address to,
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        bool transferable,
+        uint32 commercialRevShare
+    ) external returns (uint256 tokenId) {
+        tokenId = _nextTokenId++;
+        _tokens[tokenId] = TokenData({
+            owner: to,
+            licensorIpId: licensorIpId,
+            licenseTemplate: licenseTemplate,
+            licenseTermsId: licenseTermsId,
+            transferable: transferable,
+            commercialRevShare: commercialRevShare,
+            revoked: false,
+            exists: true
+        });
+    }
+
+    /// @notice Revokes a license token for testing
+    function revoke(uint256 tokenId) external {
+        require(_tokens[tokenId].exists, "Token does not exist");
+        _tokens[tokenId].revoked = true;
+    }
+
+    /// @notice Transfers a token for testing
+    function transferFrom(address, address to, uint256 tokenId) external {
+        require(_tokens[tokenId].exists, "Token does not exist");
+        _tokens[tokenId].owner = to;
+    }
+
+    // --- ILicenseToken interface ---
+
+    function ownerOf(uint256 tokenId) external view returns (address) {
+        require(_tokens[tokenId].exists, "Token does not exist");
+        return _tokens[tokenId].owner;
+    }
+
+    function getLicenseTokenMetadata(
+        uint256 tokenId
+    ) external view returns (ILicenseToken.LicenseTokenMetadata memory) {
+        require(_tokens[tokenId].exists, "Token does not exist");
+        TokenData storage t = _tokens[tokenId];
+        return
+            ILicenseToken.LicenseTokenMetadata({
+                licensorIpId: t.licensorIpId,
+                licenseTemplate: t.licenseTemplate,
+                licenseTermsId: t.licenseTermsId,
+                transferable: t.transferable,
+                commercialRevShare: t.commercialRevShare
+            });
+    }
+
+    function isLicenseTokenRevoked(uint256 tokenId) external view returns (bool) {
+        require(_tokens[tokenId].exists, "Token does not exist");
+        return _tokens[tokenId].revoked;
+    }
+}


### PR DESCRIPTION
### Summary
Add `LicenseReadCondition` contract that gates CDR vault (registered as IP asset) read access based on ownership of a valid, non-revoked Story Protocol license token for the vault's IP asset. Include Foundry tests with a mock LicenseToken contract.

### Details
The LicenseReadCondition implements ICDRReadCondition and verifies that the caller owns at least one license token whose licensorIpId matches the vault's IP asset. Revoked tokens are rejected.

issue: <!-- fixes/closes/resolves #<issue number> -->
