### PR TITLE
fix(cdr): avoid adding submission count when partials are not accepted

### DIFF
--- a/client/x/dkg/keeper/dkg_handler.go
+++ b/client/x/dkg/keeper/dkg_handler.go
@@ -487,7 +487,7 @@ func (k *Keeper) ThresholdDecryptRequested(ctx context.Context, round uint32, re
 }
 
 // PartialDecryptionSubmitted handles TDH2 partial decrypt submissions emitted by the contract.
-// It stores submission payloads for later processing.
+// It stores submission payloads for later processing and returns true only when validation succeeds.
 func (k *Keeper) PartialDecryptionSubmitted(
 	ctx context.Context,
 	validator common.Address,
@@ -500,22 +500,22 @@ func (k *Keeper) PartialDecryptionSubmitted(
 	ciphertext []byte,
 	label []byte,
 	signature []byte,
-) error {
+) (bool, error) {
 	// Enforce timeout: reject partial decryptions submitted too late.
 	req, found, err := k.getDecryptRequest(ctx, requesterPubKey, label, round, ciphertext)
 	if err != nil {
-		return errors.Wrap(err, "failed to look up decrypt request registry")
+		return false, errors.Wrap(err, "failed to look up decrypt request registry")
 	}
 	if !found {
 		log.Info(ctx, "Partial decryption submitted for unknown or cleaned-up request",
 			"validator", validator.Hex(),
 			"round", round,
 		)
-		return nil
+		return false, nil
 	}
 
 	if round != req.Round {
-		return errors.New("round mismatch between partial decryption submission and decrypt request",
+		return false, errors.New("round mismatch between partial decryption submission and decrypt request",
 			"validator", validator.Hex(),
 			"submission_round", round,
 			"request_round", req.Round,
@@ -523,7 +523,7 @@ func (k *Keeper) PartialDecryptionSubmitted(
 	}
 
 	if !bytes.Equal(ciphertext, req.Ciphertext) {
-		return errors.New("ciphertext mismatch between partial decryption submission and decrypt request",
+		return false, errors.New("ciphertext mismatch between partial decryption submission and decrypt request",
 			"validator", validator.Hex(),
 			"label", hex.EncodeToString(label),
 			"round", round,
@@ -541,25 +541,25 @@ func (k *Keeper) PartialDecryptionSubmitted(
 			"validator", validator.Hex(),
 		)
 		if err := k.deleteDecryptRequest(ctx, requesterPubKey, label, round, ciphertext); err != nil {
-			return errors.Wrap(err, "failed to delete expired decrypt request registry entry")
+			return false, errors.Wrap(err, "failed to delete expired decrypt request registry entry")
 		}
-		return nil
+		return false, nil
 	}
 
 	reg, err := k.getDKGRegistration(ctx, req.Round, validator)
 	if err != nil {
-		return errors.Wrap(err, "failed to get DKG registration for signature verification")
+		return false, errors.Wrap(err, "failed to get DKG registration for signature verification")
 	}
 
 	if !bytes.Equal(pubShare, reg.PubKeyShare) {
-		return errors.New("pubShare mismatch: submitted pubShare does not match stored pubKeyShare",
+		return false, errors.New("pubShare mismatch: submitted pubShare does not match stored pubKeyShare",
 			"validator", validator.Hex(),
 			"round", req.Round,
 		)
 	}
 
 	if err := verifyPartialDecryptionSignature(reg.CommPubKey, round, ciphertext, encryptedPartial, ephemeralPubKey, pubShare, signature); err != nil {
-		return errors.Wrap(err, "partial decryption signature verification failed")
+		return false, errors.Wrap(err, "partial decryption signature verification failed")
 	}
 
 	if err := k.setPartialDecryptionSubmission(
@@ -580,9 +580,9 @@ func (k *Keeper) PartialDecryptionSubmitted(
 				"round", round,
 				"pid", pid,
 			)
-			return nil
+			return false, nil
 		}
-		return errors.Wrap(err, "failed to store partial decryption submission")
+		return false, errors.Wrap(err, "failed to store partial decryption submission")
 	}
 
 	log.Info(ctx, "DKG PartialDecryptionSubmitted event received",
@@ -596,5 +596,5 @@ func (k *Keeper) PartialDecryptionSubmitted(
 		"label_len", len(label),
 	)
 
-	return nil
+	return true, nil
 }

--- a/client/x/dkg/keeper/dkg_handler_internal_test.go
+++ b/client/x/dkg/keeper/dkg_handler_internal_test.go
@@ -918,6 +918,147 @@ func signPartialDecryptionData(t *testing.T, key *ecdsa.PrivateKey, round uint32
 	return sig
 }
 
+func TestKeeper_PartialDecryptionSubmitted_IgnoredCases(t *testing.T) {
+	t.Run("unknown request returns not accepted", func(t *testing.T) {
+		k, ctx := setupDKGKeeper(t)
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		accepted, err := k.PartialDecryptionSubmitted(
+			sdkCtx,
+			common.HexToAddress("0x1234567890123456789012345678901234567890"),
+			uint32(1),
+			uint32(1),
+			[]byte("encrypted-partial"),
+			[]byte("ephemeral-pub-key"),
+			[]byte("pub-share"),
+			[]byte("requester-pub-key"),
+			[]byte("ciphertext"),
+			[]byte("label"),
+			[]byte("signature"),
+		)
+		require.NoError(t, err)
+		require.False(t, accepted)
+	})
+
+	t.Run("expired request returns not accepted and deletes registry entry", func(t *testing.T) {
+		k, ctx := setupDKGKeeper(t)
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		validator := common.HexToAddress("0x1234567890123456789012345678901234567890")
+		round := uint32(2)
+		pid := uint32(1)
+		requesterPubKey := []byte("requester-pub-key")
+		ciphertext := []byte("ciphertext")
+		label := []byte("label")
+
+		currentHeight := uint64(1000)
+		requestHeight := currentHeight - types.PartialDecryptionTimeoutBlocks - 1
+		sdkCtx = sdkCtx.WithBlockHeight(int64(currentHeight))
+
+		req := types.DecryptRequest{
+			Round:           round,
+			Ciphertext:      ciphertext,
+			Label:           label,
+			RequesterPubKey: requesterPubKey,
+			Height:          requestHeight,
+		}
+		require.NoError(t, k.setDecryptRequest(sdkCtx, requesterPubKey, label, req))
+
+		accepted, err := k.PartialDecryptionSubmitted(
+			sdkCtx,
+			validator,
+			round,
+			pid,
+			[]byte("encrypted-partial"),
+			[]byte("ephemeral-pub-key"),
+			[]byte("pub-share"),
+			requesterPubKey,
+			ciphertext,
+			label,
+			[]byte("signature"),
+		)
+		require.NoError(t, err)
+		require.False(t, accepted)
+
+		_, found, err := k.getDecryptRequest(sdkCtx, requesterPubKey, label, round, ciphertext)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("duplicate submission returns not accepted", func(t *testing.T) {
+		k, ctx := setupDKGKeeper(t)
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+		validator := common.HexToAddress("0x1234567890123456789012345678901234567890")
+		round := uint32(3)
+		pid := uint32(1)
+		requesterPubKey := []byte("requester-pub-key")
+		ciphertext := []byte("ciphertext")
+		label := []byte("label")
+		encryptedPartial := []byte("encrypted-partial")
+		ephemeralPubKey := []byte("ephemeral-pub-key")
+		pubShare := []byte("pub-share")
+
+		sigKey, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		commPubKey := crypto.FromECDSAPub(&sigKey.PublicKey)[1:]
+
+		req := types.DecryptRequest{
+			Round:           round,
+			Ciphertext:      ciphertext,
+			Label:           label,
+			RequesterPubKey: requesterPubKey,
+			Height:          uint64(sdkCtx.BlockHeight()),
+		}
+		require.NoError(t, k.setDecryptRequest(sdkCtx, requesterPubKey, label, req))
+
+		reg := &types.DKGRegistration{
+			Round:         round,
+			ValidatorAddr: validator.Hex(),
+			Index:         1,
+			DkgPubKey:     []byte("dkg-pub-key"),
+			CommPubKey:    commPubKey,
+			PubKeyShare:   pubShare,
+			Status:        types.DKGRegStatusVerified,
+		}
+		require.NoError(t, k.setDKGRegistration(sdkCtx, validator, reg))
+
+		signature := signPartialDecryptionData(t, sigKey, round, ciphertext, encryptedPartial, ephemeralPubKey, pubShare)
+
+		accepted, err := k.PartialDecryptionSubmitted(
+			sdkCtx,
+			validator,
+			round,
+			pid,
+			encryptedPartial,
+			ephemeralPubKey,
+			pubShare,
+			requesterPubKey,
+			ciphertext,
+			label,
+			signature,
+		)
+		require.NoError(t, err)
+		require.True(t, accepted)
+
+		accepted, err = k.PartialDecryptionSubmitted(
+			sdkCtx,
+			validator,
+			round,
+			pid,
+			encryptedPartial,
+			ephemeralPubKey,
+			pubShare,
+			requesterPubKey,
+			ciphertext,
+			label,
+			signature,
+		)
+		require.NoError(t, err)
+		require.False(t, accepted)
+	})
+}
+
 func TestKeeper_UpgradeScheduled(t *testing.T) {
 	tcs := []struct {
 		name             string

--- a/client/x/evmengine/keeper/cdr.go
+++ b/client/x/evmengine/keeper/cdr.go
@@ -157,7 +157,7 @@ func (k *Keeper) ProcessDKGPartialDecryptionSubmitted(ctx context.Context, ethlo
 		})
 	}()
 
-	partialErr := k.dkgKeeper.PartialDecryptionSubmitted(
+	accepted, partialErr := k.dkgKeeper.PartialDecryptionSubmitted(
 		cachedCtx,
 		ev.Validator,
 		ev.Round,
@@ -171,7 +171,7 @@ func (k *Keeper) ProcessDKGPartialDecryptionSubmitted(ctx context.Context, ethlo
 		ev.Signature,
 	)
 
-	if partialErr == nil {
+	if accepted && partialErr == nil {
 		if err := k.dkgKeeper.IncrementCDRPartialSubmitCount(cachedCtx, ev.Validator); err != nil {
 			partialErr = errors.Wrap(err, "increment CDR submit count")
 		} else if ev.Fee != nil && ev.Fee.Sign() > 0 {

--- a/client/x/evmengine/testutil/expected_keepers_mocks.go
+++ b/client/x/evmengine/testutil/expected_keepers_mocks.go
@@ -391,11 +391,12 @@ func (mr *MockDKGKeeperMockRecorder) IncrementCDRPartialSubmitCount(ctx, validat
 }
 
 // PartialDecryptionSubmitted mocks base method.
-func (m *MockDKGKeeper) PartialDecryptionSubmitted(ctx context.Context, validator common.Address, round, pid uint32, encryptedPartial, ephemeralPubKey, pubShare, requesterPubKey, ciphertext, label, signature []byte) error {
+func (m *MockDKGKeeper) PartialDecryptionSubmitted(ctx context.Context, validator common.Address, round, pid uint32, encryptedPartial, ephemeralPubKey, pubShare, requesterPubKey, ciphertext, label, signature []byte) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PartialDecryptionSubmitted", ctx, validator, round, pid, encryptedPartial, ephemeralPubKey, pubShare, requesterPubKey, ciphertext, label, signature)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PartialDecryptionSubmitted indicates an expected call of PartialDecryptionSubmitted.

--- a/client/x/evmengine/types/expected_keepers.go
+++ b/client/x/evmengine/types/expected_keepers.go
@@ -49,7 +49,7 @@ type DKGKeeper interface {
 	UpgradeScheduled(ctx context.Context, activationHeight int64, upgradeVersion string) error
 	UpgradeCancelled(ctx context.Context, upgradeVersion string) error
 	ThresholdDecryptRequested(ctx context.Context, round uint32, requesterPubKey []byte, ciphertext []byte, label []byte, blockHeight uint64) error
-	PartialDecryptionSubmitted(ctx context.Context, validator common.Address, round uint32, pid uint32, encryptedPartial []byte, ephemeralPubKey []byte, pubShare []byte, requesterPubKey []byte, ciphertext []byte, label []byte, signature []byte) error
+	PartialDecryptionSubmitted(ctx context.Context, validator common.Address, round uint32, pid uint32, encryptedPartial []byte, ephemeralPubKey []byte, pubShare []byte, requesterPubKey []byte, ciphertext []byte, label []byte, signature []byte) (bool, error)
 
 	// CDR fee pool operations
 	AddCDRFeeToPool(ctx context.Context, amount *big.Int) error


### PR DESCRIPTION
Check if a partial is accepted before updating submission count.

issue: #734 