### PR TITLE
fix(dkg): resolve issues discovered in claude audit

### DIFF
--- a/client/proto/story/dkg/v1/types/event.proto
+++ b/client/proto/story/dkg/v1/types/event.proto
@@ -16,7 +16,7 @@ enum EventType {
 
 message EventBeginInitialization {
   uint32 round = 1;
-  uint32 start_block_height = 2;
+  int64 start_block_height = 2;
   repeated string active_validators = 3;
 }
 

--- a/client/x/dkg/keeper/dkg_cdr_fees.go
+++ b/client/x/dkg/keeper/dkg_cdr_fees.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"math/big"
+	"sort"
 	"strings"
 
 	"cosmossdk.io/collections"
@@ -179,7 +180,15 @@ func (k *Keeper) distributeCDRRewardPool(ctx context.Context) error {
 	totalCountInt := math.NewInt(int64(totalCount))
 	distributed := math.ZeroInt()
 
-	for addr, count := range counts {
+	// Sort keys for deterministic iteration order across all validators.
+	sortedAddrs := make([]string, 0, len(counts))
+	for addr := range counts {
+		sortedAddrs = append(sortedAddrs, addr)
+	}
+	sort.Strings(sortedAddrs)
+
+	for _, addr := range sortedAddrs {
+		count := counts[addr]
 		share := poolBalance.Mul(math.NewInt(int64(count))).Quo(totalCountInt)
 		if share.IsZero() {
 			continue

--- a/client/x/dkg/keeper/dkg_decrypt_registry.go
+++ b/client/x/dkg/keeper/dkg_decrypt_registry.go
@@ -12,14 +12,20 @@ import (
 	"github.com/piplabs/story/lib/errors"
 )
 
-// decryptRequestRegistryKey builds the key for the DecryptRequestRegistry map:
+// decryptRequestRegistryKey builds the key for the DecryptRequestRegistry map.
+// The label is hex-encoded to prevent raw bytes from containing the '_' separator
+// and causing key collisions between different (label, round) combinations.
 func decryptRequestRegistryKey(requesterPubKey []byte, label []byte, round uint32, ciphertext []byte) string {
+	if len(label) == 0 {
+		return ""
+	}
+
 	requesterHash := sha256.Sum256(requesterPubKey)
 	ciphertextHash := sha256.Sum256(ciphertext)
 	return fmt.Sprintf(
 		"%s_%s_%d_%s",
 		hex.EncodeToString(requesterHash[:]),
-		label,
+		hex.EncodeToString(label),
 		round,
 		hex.EncodeToString(ciphertextHash[:]),
 	)
@@ -29,6 +35,9 @@ func decryptRequestRegistryKey(requesterPubKey []byte, label []byte, round uint3
 // Called by all consensus nodes in ThresholdDecryptRequested.
 func (k *Keeper) setDecryptRequest(ctx context.Context, requesterPubKey []byte, label []byte, req types.DecryptRequest) error {
 	key := decryptRequestRegistryKey(requesterPubKey, label, req.Round, req.Ciphertext)
+	if key == "" {
+		return errors.New("cannot set decrypt request with empty label")
+	}
 	if err := k.DecryptRequestRegistry.Set(ctx, key, req); err != nil {
 		return errors.Wrap(err, "set decrypt request registry")
 	}

--- a/client/x/dkg/keeper/dkg_events.go
+++ b/client/x/dkg/keeper/dkg_events.go
@@ -22,7 +22,7 @@ func (*Keeper) emitBeginDKGInitialization(ctx context.Context, dkgNetwork *types
 	err := sdkCtx.EventManager().EmitTypedEvent(&types.EventBeginInitialization{
 		Round:            dkgNetwork.Round,
 		ActiveValidators: dkgNetwork.ActiveValSet,
-		StartBlockHeight: uint32(dkgNetwork.StartBlockHeight),
+		StartBlockHeight: dkgNetwork.StartBlockHeight,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to emit dkg_begin_initialization event")

--- a/client/x/dkg/keeper/dkg_finalization.go
+++ b/client/x/dkg/keeper/dkg_finalization.go
@@ -27,6 +27,16 @@ func (k *Keeper) BeginFinalization(ctx context.Context, latestRound *types.DKGNe
 }
 
 func (k *Keeper) FinalizeDKGRound(ctx context.Context, latestRound *types.DKGNetwork) error {
+	// Guard: global public key must be set before finalizing. If it's empty,
+	// the round did not complete key generation and should not be activated.
+	if len(latestRound.GlobalPublicKey) == 0 {
+		log.Info(ctx, "Global public key not set, skipping to next round",
+			"round", latestRound.Round,
+		)
+
+		return k.SkipToNextRound(ctx, latestRound)
+	}
+
 	finalizedCount, err := k.countDKGRegistrationsByStatus(ctx, latestRound.Round, types.DKGRegStatusFinalized)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch DKG registrations in Finalized status")

--- a/client/x/dkg/keeper/dkg_finalization_internal_test.go
+++ b/client/x/dkg/keeper/dkg_finalization_internal_test.go
@@ -56,7 +56,17 @@ func TestFinalizeDKGRound_ThresholdChecks(t *testing.T) {
 		threshold       uint32
 		total           uint32
 		expectSkip      bool
+		emptyGlobalKey  bool
 	}{
+		{
+			name:            "skip: global public key not set",
+			finalizedCount:  4,
+			minReqFinalized: 3,
+			threshold:       4,
+			total:           5,
+			expectSkip:      true,
+			emptyGlobalKey:  true,
+		},
 		{
 			name:            "skip: finalized count below min_req_finalized_participants",
 			finalizedCount:  2,
@@ -109,13 +119,18 @@ func TestFinalizeDKGRound_ThresholdChecks(t *testing.T) {
 			params.MinReqFinalizedParticipants = tc.minReqFinalized
 			require.NoError(t, k.SetParams(ctx, params))
 
-			// Set up DKG network
+			// Set up DKG network (GlobalPublicKey must be non-empty for finalization to proceed)
+			var globalPubKey []byte
+			if !tc.emptyGlobalKey {
+				globalPubKey = []byte("global-pub-key")
+			}
 			latestRound := &types.DKGNetwork{
-				Round:        testRound,
-				ActiveValSet: activeValSet,
-				Total:        tc.total,
-				Threshold:    tc.threshold,
-				Stage:        types.DKGStageFinalization,
+				Round:           testRound,
+				ActiveValSet:    activeValSet,
+				Total:           tc.total,
+				Threshold:       tc.threshold,
+				Stage:           types.DKGStageFinalization,
+				GlobalPublicKey: globalPubKey,
 			}
 			require.NoError(t, k.setDKGNetwork(sdkCtx, latestRound))
 
@@ -162,11 +177,12 @@ func TestFinalizeDKGRound_DistributesCDRFeePool(t *testing.T) {
 	require.NoError(t, k.setLatestActiveRound(ctx, prevActive))
 
 	latestRound := &types.DKGNetwork{
-		Round:        2,
-		ActiveValSet: []string{},
-		Total:        2,
-		Threshold:    1,
-		Stage:        types.DKGStageFinalization,
+		Round:           2,
+		ActiveValSet:    []string{},
+		Total:           2,
+		Threshold:       1,
+		Stage:           types.DKGStageFinalization,
+		GlobalPublicKey: []byte("global-pub-key"),
 	}
 	require.NoError(t, k.setDKGNetwork(sdkCtx, latestRound))
 

--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -39,6 +39,10 @@ func (k *Keeper) GetActiveValidators(ctx context.Context) ([]string, error) {
 // as an upgrade resharing round (IsResharing=true, IsUpgrade=true) and the current
 // active round is NOT inactive.
 func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
+	// Flush stale deals/responses/justifications from previous rounds to prevent
+	// them from contaminating the new round's vote extensions.
+	k.FlushAllQueues()
+
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	activeValidators, err := k.GetActiveValidators(ctx)

--- a/client/x/dkg/keeper/dkg_registration.go
+++ b/client/x/dkg/keeper/dkg_registration.go
@@ -71,15 +71,15 @@ func (k *Keeper) getNextDKGRegistrationIndex(ctx context.Context, round uint32) 
 }
 
 // getDKGRegistrationsByRound retrieves all DKG registrations for a specific round.
+// Uses a prefix range to iterate only keys matching the round, avoiding a full-table scan.
 func (k *Keeper) getDKGRegistrationsByRound(ctx context.Context, round uint32) ([]types.DKGRegistration, error) {
 	var registrations []types.DKGRegistration
 
 	prefix := fmt.Sprintf("%d_", round)
+	rng := (&collections.Range[string]{}).Prefix(prefix)
 
-	err := k.DKGRegistrations.Walk(ctx, nil, func(key string, reg types.DKGRegistration) (bool, error) {
-		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
-			registrations = append(registrations, reg)
-		}
+	err := k.DKGRegistrations.Walk(ctx, rng, func(_ string, reg types.DKGRegistration) (bool, error) {
+		registrations = append(registrations, reg)
 
 		return false, nil // Continue iteration
 	})

--- a/client/x/dkg/keeper/helpers.go
+++ b/client/x/dkg/keeper/helpers.go
@@ -9,12 +9,12 @@ import (
 )
 
 const (
-	retryAttemts = 3
+	retryAttempts = 3
 	retryDelay   = 2 * time.Second
 )
 
 func retry(ctx context.Context, fn func(ctx context.Context) error) error {
-	for i := range retryAttemts {
+	for i := range retryAttempts {
 		if err := fn(ctx); err != nil {
 			log.Warn(context.Background(), "retry failed", err, "attempt", i+1)
 			time.Sleep(retryDelay)

--- a/client/x/dkg/keeper/helpers.go
+++ b/client/x/dkg/keeper/helpers.go
@@ -17,7 +17,13 @@ func retry(ctx context.Context, fn func(ctx context.Context) error) error {
 	for i := range retryAttempts {
 		if err := fn(ctx); err != nil {
 			log.Warn(context.Background(), "retry failed", err, "attempt", i+1)
-			time.Sleep(retryDelay)
+
+			// Use context-aware sleep so that cancellation can interrupt the delay.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(retryDelay):
+			}
 
 			continue
 		}

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -69,7 +69,6 @@ type Keeper struct {
 	enclaveType      [32]byte // TEE enclave type identifier
 
 	Schema             collections.Schema
-	ParamsStore        collections.Item[types.Params]
 	DKGNetworks        collections.Map[string, types.DKGNetwork]        // key: round
 	LatestDKGNetwork   collections.Item[string]                         // stores round key of latest DKG network
 	LatestActiveRound  collections.Item[string]                         // stores latest active round of DKG network
@@ -117,7 +116,6 @@ func NewKeeper(
 		kernelRouter:           kernelRouter,
 		contractClient:         contractClient,
 		authority:              authority,
-		ParamsStore:            collections.NewItem(sb, types.ParamsKey, "params", codec.CollValue[types.Params](cdc)),
 		DKGNetworks:            collections.NewMap(sb, types.DKGNetworkKey, "dkg_networks", collections.StringKey, codec.CollValue[types.DKGNetwork](cdc)),
 		LatestDKGNetwork:       collections.NewItem(sb, types.LatestDKGNetworkKey, "latest_dkg_network", collections.StringValue),
 		LatestActiveRound:      collections.NewItem(sb, types.LatestActiveRoundKey, "latest_active_round", collections.StringValue),

--- a/client/x/dkg/keeper/kernel_router.go
+++ b/client/x/dkg/keeper/kernel_router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"time"
 
@@ -153,14 +154,23 @@ func (r *KernelRouter) GetClient(codeCommitment []byte) (types.KernelServiceClie
 	return client, nil
 }
 
-// GetAllCodeCommitments returns all connected code commitments.
+// GetAllCodeCommitments returns all connected code commitments in deterministic
+// (sorted) order. Sorting the hex string keys before decoding ensures consistent
+// kernel client selection across all validators.
 func (r *KernelRouter) GetAllCodeCommitments() [][]byte {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	var ccs [][]byte
-
+	keys := make([]string, 0, len(r.clients))
 	for codeCommitmentHex := range r.clients {
+		keys = append(keys, codeCommitmentHex)
+	}
+
+	sort.Strings(keys)
+
+	ccs := make([][]byte, 0, len(keys))
+
+	for _, codeCommitmentHex := range keys {
 		cc, err := hex.DecodeString(codeCommitmentHex)
 		if err != nil {
 			continue

--- a/client/x/dkg/keeper/kernel_router.go
+++ b/client/x/dkg/keeper/kernel_router.go
@@ -13,6 +13,12 @@ import (
 	"github.com/piplabs/story/lib/log"
 )
 
+// reconnectBackoff tracks per-endpoint exponential backoff state for kernel reconnection.
+type reconnectBackoff struct {
+	lastAttempt     time.Time
+	backoffDuration time.Duration
+}
+
 // KernelRouter manages multiple story-kernel clients, routing requests by code commitment.
 type KernelRouter struct {
 	mu        sync.RWMutex
@@ -21,9 +27,16 @@ type KernelRouter struct {
 	clients   map[string]types.KernelServiceClient // codeCommitmentHex -> KernelServiceClient
 	closers   map[string]io.Closer                 // codeCommitmentHex -> underlying gRPC connection
 	ccByEP    map[string]string                    // endpoint -> codeCommitmentHex (reverse lookup)
+	backoffs  map[string]*reconnectBackoff          // endpoint -> backoff state for reconnection rate limiting
 }
 
 const maxKernelEndpoints = 2
+
+// Reconnection backoff constants.
+const (
+	initialBackoff = 30 * time.Second
+	maxBackoff     = 5 * time.Minute
+)
 
 // NewKernelRouter creates a new router with the given endpoint list and optional TLS configuration.
 // At most 2 endpoints are supported (old + new binary for upgrade resharing).
@@ -39,6 +52,7 @@ func NewKernelRouter(endpoints []string, tlsCfg *TLSConfig) *KernelRouter {
 		clients:   make(map[string]types.KernelServiceClient),
 		closers:   make(map[string]io.Closer),
 		ccByEP:    make(map[string]string),
+		backoffs:  make(map[string]*reconnectBackoff),
 	}
 }
 
@@ -201,13 +215,69 @@ func (r *KernelRouter) TryReconnect() {
 	ctx, cancel := context.WithTimeout(context.Background(), reconnectTimeout)
 	defer cancel()
 
+	now := time.Now()
+
 	for _, ep := range disconnected {
+		if r.isInCooldown(ep, now) {
+			log.Debug(ctx, "Skipping kernel reconnection (in cooldown)", "endpoint", ep)
+
+			continue
+		}
+
 		log.Info(ctx, "Attempting kernel reconnection", "endpoint", ep)
 
 		if err := r.ConnectAndDiscover(ctx, ep); err != nil {
 			log.Warn(ctx, "Kernel reconnection failed", err, "endpoint", ep)
+			r.recordFailedAttempt(ep, now)
+		} else {
+			r.resetBackoff(ep)
 		}
 	}
+}
+
+// isInCooldown returns true if the endpoint was attempted recently and the
+// backoff cooldown has not yet elapsed.
+func (r *KernelRouter) isInCooldown(endpoint string, now time.Time) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	bo, ok := r.backoffs[endpoint]
+	if !ok {
+		return false
+	}
+
+	return now.Before(bo.lastAttempt.Add(bo.backoffDuration))
+}
+
+// recordFailedAttempt updates the backoff state for a failed reconnection attempt,
+// doubling the duration up to maxBackoff.
+func (r *KernelRouter) recordFailedAttempt(endpoint string, now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	bo, ok := r.backoffs[endpoint]
+	if !ok {
+		r.backoffs[endpoint] = &reconnectBackoff{
+			lastAttempt:     now,
+			backoffDuration: initialBackoff,
+		}
+
+		return
+	}
+
+	bo.lastAttempt = now
+	bo.backoffDuration *= 2
+	if bo.backoffDuration > maxBackoff {
+		bo.backoffDuration = maxBackoff
+	}
+}
+
+// resetBackoff clears the backoff state for an endpoint after a successful connection.
+func (r *KernelRouter) resetBackoff(endpoint string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.backoffs, endpoint)
 }
 
 // disconnectedEndpoints returns configured endpoints that do not have a

--- a/client/x/dkg/keeper/state_manager.go
+++ b/client/x/dkg/keeper/state_manager.go
@@ -246,7 +246,8 @@ func (*StateManager) loadSessionFromFile(filename string) (*types.DKGSession, er
 	return &session, nil
 }
 
-// saveSession saves a session to disk.
+// saveSession saves a session to disk atomically by writing to a temporary file
+// and renaming it, preventing corruption from partial writes during crashes.
 func (sm *StateManager) saveSession(session *types.DKGSession) error {
 	data, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
@@ -254,8 +255,17 @@ func (sm *StateManager) saveSession(session *types.DKGSession) error {
 	}
 
 	filename := sm.getSessionFilename(session.GetSessionKey())
-	if err := os.WriteFile(filename, data, 0600); err != nil {
-		return errors.Wrap(err, "failed to write session file")
+	tmpFilename := filename + ".tmp"
+
+	if err := os.WriteFile(tmpFilename, data, 0600); err != nil {
+		return errors.Wrap(err, "failed to write temporary session file")
+	}
+
+	if err := os.Rename(tmpFilename, filename); err != nil {
+		// Clean up the temp file on rename failure
+		_ = os.Remove(tmpFilename)
+
+		return errors.Wrap(err, "failed to atomically rename session file")
 	}
 
 	return nil

--- a/client/x/dkg/keeper/state_manager.go
+++ b/client/x/dkg/keeper/state_manager.go
@@ -254,7 +254,7 @@ func (sm *StateManager) saveSession(session *types.DKGSession) error {
 	}
 
 	filename := sm.getSessionFilename(session.GetSessionKey())
-	if err := os.WriteFile(filename, data, 0644); err != nil {
+	if err := os.WriteFile(filename, data, 0600); err != nil {
 		return errors.Wrap(err, "failed to write session file")
 	}
 

--- a/client/x/dkg/types/event.pb.go
+++ b/client/x/dkg/types/event.pb.go
@@ -67,7 +67,7 @@ func (EventType) EnumDescriptor() ([]byte, []int) {
 
 type EventBeginInitialization struct {
 	Round            uint32   `protobuf:"varint,1,opt,name=round,proto3" json:"round,omitempty"`
-	StartBlockHeight uint32   `protobuf:"varint,2,opt,name=start_block_height,json=startBlockHeight,proto3" json:"start_block_height,omitempty"`
+	StartBlockHeight int64    `protobuf:"varint,2,opt,name=start_block_height,json=startBlockHeight,proto3" json:"start_block_height,omitempty"`
 	ActiveValidators []string `protobuf:"bytes,3,rep,name=active_validators,json=activeValidators,proto3" json:"active_validators,omitempty"`
 }
 
@@ -111,7 +111,7 @@ func (m *EventBeginInitialization) GetRound() uint32 {
 	return 0
 }
 
-func (m *EventBeginInitialization) GetStartBlockHeight() uint32 {
+func (m *EventBeginInitialization) GetStartBlockHeight() int64 {
 	if m != nil {
 		return m.StartBlockHeight
 	}
@@ -1034,7 +1034,7 @@ func (m *EventBeginInitialization) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.StartBlockHeight |= uint32(b&0x7F) << shift
+				m.StartBlockHeight |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/contracts/src/protocol/CDR.sol
+++ b/contracts/src/protocol/CDR.sol
@@ -11,7 +11,6 @@ import { ICDRWriteCondition } from "../interfaces/ICDRWriteCondition.sol";
 import { ICDRReadCondition } from "../interfaces/ICDRReadCondition.sol";
 
 contract CDR is ICDR, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, PausableUpgradeable, UUPSUpgradeable {
-
     /// @dev Storage structure for the CDR
     /// @param uuid The UUID of the vault
     /// @param baseFee The base fee
@@ -106,7 +105,7 @@ contract CDR is ICDR, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Pausa
         bytes calldata writeConditionData,
         bytes calldata readConditionData
     ) external payable whenNotPaused returns (uint32 newVaultUuid) {
-        require(writeConditionAddr != address(0) || readConditionAddr != address(0), "Invalid condition address");
+        require(writeConditionAddr != address(0) && readConditionAddr != address(0), "Invalid condition address");
 
         CDRStorage storage $ = _getCDRStorage();
         // collect allocation fee and burn it


### PR DESCRIPTION
  ## Summary

  Address findings from the DKG/CDR production audit. Fixes consensus-critical bugs, removes dead code, and hardens error handling across the DKG module and CDR contract.

  **Critical:**
  - Sort CDR fee distribution map keys before iteration to prevent non-deterministic app hash (chain halt)
  - Hex-encode label in decrypt request registry key to prevent key collisions
  - Require both write and read condition addresses to be non-zero in CDR vault allocation

  **High:**
  - Remove unused `ParamsStore` (collections.Item) that duplicated raw KV store params access
  - Flush vote extension queues in `InitiateDKGRound` to prevent stale cross-round data
  - Guard `FinalizeDKGRound` against empty GlobalPublicKey — skip to next round instead of committing unusable state

  **Medium/Low:**
  - Add exponential backoff for kernel reconnection attempts
  - Sort `GetAllCodeCommitments` for deterministic kernel client selection
  - Use prefix range for round-scoped registration queries
  - Fix `retryAttempts` typo, use int64 for event block height, restrict session file to 0600, atomic session file writes, context-aware retry sleep

issue: none
