### PR TITLE
refactor(dkg): rename v200 upgrade to v160

### DIFF
--- a/client/app/upgrades.go
+++ b/client/app/upgrades.go
@@ -16,7 +16,7 @@ import (
 	"github.com/piplabs/story/client/app/upgrades/singularity/virgil"
 	"github.com/piplabs/story/client/app/upgrades/terence"
 	"github.com/piplabs/story/client/app/upgrades/v_1_2_0"
-	"github.com/piplabs/story/client/app/upgrades/v_2_0_0"
+	"github.com/piplabs/story/client/app/upgrades/v_1_6_0"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/netconf"
 )
@@ -30,7 +30,7 @@ var (
 		polybius.Upgrade,
 		terence.Upgrade,
 		horace.Upgrade,
-		v_2_0_0.Upgrade,
+		v_1_6_0.Upgrade,
 	}
 	// Forks are for hard forks that breaks backward compatibility.
 	Forks = []upgrades.Fork{
@@ -39,7 +39,7 @@ var (
 		polybius.Fork,
 		terence.Fork,
 		horace.Fork,
-		v_2_0_0.Fork,
+		v_1_6_0.Fork,
 	}
 )
 
@@ -229,8 +229,8 @@ func GetUpgradeHeight(ctx sdk.Context, upgradeName string, fallbackHeight int64)
 // upgrade-info.json rather than from hardcoded UpgradeHistories.
 func GetStoreUpgrades(upgradeName string) (storetypes.StoreUpgrades, error) {
 	switch upgradeName {
-	case netconf.V200:
-		return v_2_0_0.Upgrade.StoreUpgrades, nil
+	case netconf.V160:
+		return v_1_6_0.Upgrade.StoreUpgrades, nil
 	default:
 		return storetypes.StoreUpgrades{}, errors.New("no matched store upgrades")
 	}

--- a/client/app/upgrades/v_1_6_0/constants.go
+++ b/client/app/upgrades/v_1_6_0/constants.go
@@ -1,4 +1,4 @@
-package v_2_0_0
+package v_1_6_0
 
 import (
 	storetypes "cosmossdk.io/store/types"
@@ -11,14 +11,14 @@ import (
 	"github.com/piplabs/story/lib/netconf"
 )
 
-// UpgradeName is the on-chain name for the v2.0.0 upgrade that activates the
+// UpgradeName is the on-chain name for the v1.6.0 upgrade that activates the
 // DKG module. This is a binary-swap upgrade: the old binary should halt at
-// the scheduled height, and operators replace it with the v2.0.0 binary.
+// the scheduled height, and operators replace it with the v1.6.0 binary.
 //
-// the upgrade is scheduled on-chain by calling UpgradeEntrypoint.planUpgrade("v2.0.0", height).
+// the upgrade is scheduled on-chain by calling UpgradeEntrypoint.planUpgrade("v1.6.0", height).
 // The old binary writes upgrade-info.json to disk before halting, which the new binary reads
 // to configure the store loader (see setupUpgradeStoreLoaders in upgrades.go).
-const UpgradeName = netconf.V200
+const UpgradeName = netconf.V160
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,

--- a/client/app/upgrades/v_1_6_0/upgrades.go
+++ b/client/app/upgrades/v_1_6_0/upgrades.go
@@ -1,4 +1,4 @@
-package v_2_0_0
+package v_1_6_0
 
 import (
 	"context"
@@ -22,7 +22,7 @@ func CreateUpgradeHandler(
 	keepers *keepers.Keepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-		log.Info(ctx, "Start v2.0.0 upgrade — activating DKG module")
+		log.Info(ctx, "Start v1.6.0 upgrade — activating DKG module")
 
 		// RunMigrations handles InitGenesis for truly new modules (not in vm).
 		// On a fresh genesis chain, DKG is already in the vm so this is a no-op
@@ -48,7 +48,7 @@ func CreateUpgradeHandler(
 			return newVM, err
 		}
 
-		log.Info(ctx, "V2.0.0 upgrade complete — DKG module activated")
+		log.Info(ctx, "V1.6.0 upgrade complete — DKG module activated")
 
 		return newVM, nil
 	}

--- a/client/app/upgrades/v_1_6_0/upgrades_test.go
+++ b/client/app/upgrades/v_1_6_0/upgrades_test.go
@@ -1,4 +1,4 @@
-package v_2_0_0
+package v_1_6_0
 
 import (
 	"context"

--- a/client/x/dkg/README.md
+++ b/client/x/dkg/README.md
@@ -251,7 +251,7 @@ DKG.whitelistEnclaveType(
 The DKG contract owner schedules the upgrade:
 
 ```solidity
-DKG.scheduleUpgrade(activationHeight, "v2.0.0");
+DKG.scheduleUpgrade(activationHeight, "v1.6.0");
 ```
 
 - `activationHeight` must be in the future.
@@ -262,7 +262,7 @@ DKG.scheduleUpgrade(activationHeight, "v2.0.0");
 At `activationHeight`, the consensus layer automatically initiates an upgrade resharing round:
 
 ```
-INFO Kernel upgrade activated, initiating upgrade resharing round  upgrade_version=v2.0.0
+INFO Kernel upgrade activated, initiating upgrade resharing round  upgrade_version=v1.6.0
 ```
 
 #### Step 6: Clean Up
@@ -279,7 +279,7 @@ Cancel before the activation height, then re-schedule:
 
 ```solidity
 DKG.cancelUpgrade();
-DKG.scheduleUpgrade(newActivationHeight, "v2.0.0");
+DKG.scheduleUpgrade(newActivationHeight, "v1.6.0");
 ```
 
 ### Troubleshooting

--- a/client/x/dkg/keeper/dkg_handler_internal_test.go
+++ b/client/x/dkg/keeper/dkg_handler_internal_test.go
@@ -1081,7 +1081,7 @@ func TestKeeper_UpgradeScheduled(t *testing.T) {
 		{
 			name:             "fail: pending upgrade already exists",
 			activationHeight: 2000,
-			upgradeVersion:   "v2.0.0",
+			upgradeVersion:   "v1.6.0",
 			setupExisting:    true,
 			expectedErr:      "pending upgrade already exists",
 		},

--- a/client/x/dkg/keeper/dkg_lifecycle_test.go
+++ b/client/x/dkg/keeper/dkg_lifecycle_test.go
@@ -45,14 +45,14 @@ type dkgLifecycleEnv struct {
 
 // setupDKGLifecycleEnv creates a test environment with DKG keeper, short stage
 // periods, and mock validators configured. The SDK context uses the DKGTestChainID
-// with block height at the V200 activation point so BeginBlocker is active.
+// with block height at the V160 activation point so BeginBlocker is active.
 func setupDKGLifecycleEnv(t *testing.T, numValidators int) *dkgLifecycleEnv {
 	t.Helper()
 
 	k, _, dk, ctx := setupDKGKeeperWithMocks(t)
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	// Use TestChainID where V200 activates at block 110.
+	// Use TestChainID where V160 activates at block 110.
 	// Set a non-nil HeaderHash so DKG network's StartBlockHash is populated.
 	testHeaderHash := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
 	sdkCtx = sdkCtx.WithChainID(netconf.TestChainID).WithBlockHeight(110).WithHeaderHash(testHeaderHash.Bytes())

--- a/docs/design/DKG.md
+++ b/docs/design/DKG.md
@@ -78,7 +78,6 @@ The DKG (Distributed Key Generation) and CDR (Confidential Data Rails) system en
 |                   DKG Module (x/dkg)                      |
 |                                                           |
 |  BeginBlocker:                                            |
-|  - IsV200 gate                                            |
 |  - Stage transitions (Reg -> Deal -> Final -> Active)     |
 |  - Kernel upgrade activation                              |
 |  - Decrypt request pruning                                |
@@ -304,28 +303,16 @@ Each validator maintains a local `DKGSession` with its own phase tracking. This 
                        PhaseFailed  -----> (ResumeDKGService recovers)
 ```
 
-### 2.3 V2.0.0 Activation & BeginBlocker
+### 2.3 V1.6.0 Activation & BeginBlocker
 
-The DKG module activates at the v2.0.0 upgrade height. Before that height, `BeginBlocker` is a complete no-op.
-
-**Gate check** (`abci.go`):
-```go
-isV200, err := netconf.IsV200(sdkCtx.ChainID(), currentHeight)
-if !isV200 {
-    return nil  // no-op before v2.0.0
-}
-```
+The DKG module activates at the v1.6.0 upgrade height. The upgrade handler registers the DKG store, and `BeginBlocker` starts managing DKG rounds from that point.
 
 **BeginBlocker flow**:
 
 ```
 BeginBlocker(ctx)
   |
-  +-- IsV200? No --> return nil
-  |
-  +-- Yes
-       |
-       +-- GetLatestDKGRound()
+  +-- GetLatestDKGRound()
        |     |
        |     +-- nil? --> InitiateDKGRound(isUpgrade=false)  [first round ever]
        |
@@ -526,7 +513,6 @@ DKG data (deals, responses, justifications) propagates between validators throug
                     Block N-1 (Proposer P)
                            |
                     ExtendVote() [each validator]
-                    - IsV200 gate (no-op before v2.0.0)
                     - DequeueDeals(maxItemsPerVote=80)
                     - DequeueResponses(80)
                     - DequeueJustifications(80)
@@ -534,7 +520,6 @@ DKG data (deals, responses, justifications) propagates between validators throug
                     - Return as VoteExtension bytes
                            |
                     VerifyVoteExtension() [each validator]
-                    - IsV200 gate (ACCEPT before v2.0.0)
                     - Size check (<= 256KB)
                     - Proto unmarshal
                     - Item count checks (<= 80 each)
@@ -543,7 +528,7 @@ DKG data (deals, responses, justifications) propagates between validators throug
                     Block N (Proposer Q)
                     PrepareProposal:
                       PrepareVotes(LocalLastCommit)
-                      - Skip first 2 blocks after v2.0.0
+                      - Skip first 2 blocks after v1.6.0
                       - ValidateVoteExtensions
                       - Parse, verify, discard invalid
                       - aggregateVotes (merge + deduplicate)
@@ -680,8 +665,6 @@ Every UBI withdrawal cycle, evmstaking distributes a portion of the withdrawn UB
 evmstaking.EndBlock()
   |
   +-- ProcessUbiWithdrawal()
-        |
-        +-- IsV200? No --> skip DKG reward distribution
         |
         +-- ClaimSettlementBalance() --> settlementAmount
         |     (claim leftover from previous round transition)
@@ -866,7 +849,7 @@ dkgKeeper.UpgradeCancelled(upgradeVersion)
 
 Vote extensions are the mechanism by which DKG data propagates through CometBFT consensus.
 
-**Timing after v2.0.0 upgrade**:
+**Timing after v1.6.0 upgrade**:
 - Height H: Upgrade handler sets `vote_extensions_enable_height = H+1`
 - Height H+1: CometBFT starts collecting VEs from validators
 - Height H+2: VEs appear in `LocalLastCommit`, `PrepareVotes` starts producing `MsgAddDkgVote`
@@ -874,11 +857,6 @@ Vote extensions are the mechanism by which DKG data propagates through CometBFT 
 **Size limits**:
 - `maxVoteExtensionSize`: 256 KB per vote extension
 - `maxItemsPerVote`: 80 deals, 80 responses, or 80 justifications per VE
-
-**IsV200 gating**:
-- `ExtendVote`: returns empty VE before v2.0.0 (no-op)
-- `VerifyVoteExtension`: returns `ACCEPT` before v2.0.0 (allow all)
-- `PrepareVotes`: skips first 2 blocks after v2.0.0 (`height <= v200Height+1`)
 
 **Malformation handling**:
 - `VerifyVoteExtension` returns `REJECT` (not Go error) for malformed VEs
@@ -1117,7 +1095,7 @@ The system uses two indexing conventions that must be carefully managed:
 ## Appendix E: Complete Lifecycle Sequence Diagram
 
 ```
-Height H: v2.0.0 upgrade
+Height H: v1.6.0 upgrade
 Height H+1: VE collection starts
 Height H+2: First MsgAddDkgVote
 

--- a/lib/netconf/upgrades.go
+++ b/lib/netconf/upgrades.go
@@ -15,7 +15,7 @@ const (
 	V142    = "v1.4.2"
 
 	Horace = "horace"
-	V200   = "v2.0.0"
+	V160   = "v1.6.0"
 )
 
 var (


### PR DESCRIPTION
## Summary

Rename v2.0.0 upgrade to v1.6.0 across all code, tests, and documentation.

- Rename `client/app/upgrades/v_2_0_0/` → `v_1_6_0/` (package, constants, handler)
- `V200` → `V160` in `lib/netconf/upgrades.go` and all references
- Remove stale `IsV200` gate references from design docs (gate was already removed from code)
- Update DKG README upgrade examples and design doc

issue: none
