### PR TITLE
fix(dkg): expose blocknumber via contract client interface

### DIFF
--- a/client/x/dkg/keeper/contract_client.go
+++ b/client/x/dkg/keeper/contract_client.go
@@ -34,6 +34,7 @@ type EthClient interface {
 	// bind.WaitMined can be called with this interface directly.
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
+	BlockNumber(ctx context.Context) (uint64, error)
 }
 
 // DKGContractBinding abstracts the DKG smart-contract methods used by ContractClient.
@@ -151,6 +152,11 @@ func NewContractClient(ctx context.Context, engineEndpoint string, engineChainID
 	)
 
 	return client, nil
+}
+
+// BlockNumber returns the current block number from the EL client.
+func (c *ContractClient) BlockNumber(ctx context.Context) (uint64, error) {
+	return c.ethClient.BlockNumber(ctx)
 }
 
 // Register calls the register contract method.

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -280,7 +280,7 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 		return
 	}
 
-	currentHeight, err := k.contractClient.ethClient.BlockNumber(ctx)
+	currentHeight, err := k.contractClient.BlockNumber(ctx)
 	if err != nil {
 		log.Error(ctx, "Failed to get current block height for decrypt queue processing", err)
 		return

--- a/client/x/dkg/types/expected_keepers.go
+++ b/client/x/dkg/types/expected_keepers.go
@@ -36,4 +36,5 @@ type DKGContractClient interface {
 	Register(ctx context.Context, round uint32, enclaveType [32]byte, startBlockHeight uint64, startBlockHash []byte, dkgPubKey []byte, commPubKey []byte, enclaveReport []byte) (*ethtypes.Receipt, error)
 	Finalize(ctx context.Context, round uint32, enclaveType [32]byte, participantsRoot []byte, globalPubKey []byte, publicCoeffs [][]byte, pubKeyShare []byte, signature []byte) (*ethtypes.Receipt, error)
 	SubmitEncryptedPartialDecryption(ctx context.Context, round uint32, pid uint32, encryptedPartial []byte, ephemeralPubKey []byte, pubShare []byte, requesterPubKey []byte, ciphertext []byte, uuid uint32, signature []byte) (*ethtypes.Receipt, error)
+	BlockNumber(ctx context.Context) (uint64, error)
 }


### PR DESCRIPTION
## Summary

Add BlockNumber method to DKGContractClient and EthClient interfaces so processDecryptQueue can query block height without accessing private ethClient field. Fixes compilation error introduced in #727.

- Add `BlockNumber(ctx)` to `DKGContractClient` and `EthClient` interfaces
- Implement on `ContractClient`, delegates to `ethClient.BlockNumber`
- Fix caller in `dkg_svc.go` to use interface method

issue: #750