### PR TITLE
fix(cdr): fix stage transition

### DIFF
--- a/client/x/dkg/keeper/abci.go
+++ b/client/x/dkg/keeper/abci.go
@@ -76,11 +76,12 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 	nextStage, shouldTransition := k.shouldTransitionStage(currentHeight, latestRound, params)
 	if shouldTransition {
 		// Update the stage of this round before emitting events
-		latestRound.Stage = nextStage
-		if err := k.setDKGNetwork(ctx, latestRound); err != nil {
-			return err
+		if nextStage != types.DKGStageRegistration {
+			latestRound.Stage = nextStage
+			if err := k.setDKGNetwork(ctx, latestRound); err != nil {
+				return err
+			}
 		}
-
 		// Emit appropriate events for stage transitions
 		switch nextStage {
 		case types.DKGStageRegistration:

--- a/client/x/dkg/keeper/dkg_round.go
+++ b/client/x/dkg/keeper/dkg_round.go
@@ -14,7 +14,6 @@ func (*Keeper) shouldTransitionStage(currentHeight int64, dkgNetwork *types.DKGN
 	registrationEnd := int64(params.RegistrationPeriod)
 	dealingEnd := registrationEnd + int64(params.DealingPeriod)
 	finalizationEnd := dealingEnd + int64(params.FinalizationPeriod)
-	activeEnd := finalizationEnd + int64(params.ActivePeriod)
 
 	// in switch, we check if the elapsed time is greater than the end of the current stage
 	switch currentStage {
@@ -29,11 +28,6 @@ func (*Keeper) shouldTransitionStage(currentHeight int64, dkgNetwork *types.DKGN
 	case types.DKGStageFinalization:
 		if elapsed >= finalizationEnd {
 			return types.DKGStageActive, true
-		}
-	case types.DKGStageActive:
-		if elapsed >= activeEnd {
-			// Round has ended, should initiate new round (resharing)
-			return types.DKGStageRegistration, true
 		}
 	case types.DKGStageFailed:
 		return types.DKGStageFailed, false

--- a/client/x/dkg/keeper/dkg_round.go
+++ b/client/x/dkg/keeper/dkg_round.go
@@ -14,6 +14,7 @@ func (*Keeper) shouldTransitionStage(currentHeight int64, dkgNetwork *types.DKGN
 	registrationEnd := int64(params.RegistrationPeriod)
 	dealingEnd := registrationEnd + int64(params.DealingPeriod)
 	finalizationEnd := dealingEnd + int64(params.FinalizationPeriod)
+	activeEnd := finalizationEnd + int64(params.ActivePeriod)
 
 	// in switch, we check if the elapsed time is greater than the end of the current stage
 	switch currentStage {
@@ -28,6 +29,11 @@ func (*Keeper) shouldTransitionStage(currentHeight int64, dkgNetwork *types.DKGN
 	case types.DKGStageFinalization:
 		if elapsed >= finalizationEnd {
 			return types.DKGStageActive, true
+		}
+	case types.DKGStageActive:
+		if elapsed >= activeEnd {
+			// Round has ended, should initiate new round (resharing)
+			return types.DKGStageRegistration, true
 		}
 	case types.DKGStageFailed:
 		return types.DKGStageFailed, false


### PR DESCRIPTION
Changes:
Never update the stage of a round from `active` to `registration`. Because stage transition is for new rounds. The last stage for old rounds should be `end` which is set during finalizeDKG. Before this change, stage of old round is changed to `registration` before new round is finalized, which causes threshold decrypt requests are not accepted.

issue: none