### PR TITLE
refactor(cdr): remove misleading log and add more unit tests

### DIFF
--- a/client/x/dkg/keeper/dkg_partial_decryption_test.go
+++ b/client/x/dkg/keeper/dkg_partial_decryption_test.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"testing"
 
+	"cosmossdk.io/collections"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -220,6 +222,78 @@ func TestDecodePartialDecryptionSubmission_RoundTrip(t *testing.T) {
 	require.Equal(t, uint32(5), submission.Round)
 	require.Equal(t, uint32(2), submission.Pid)
 	require.Equal(t, []byte("enc-partial"), submission.EncryptedPartial)
+}
+
+// TestGetPartialDecryptionsByPrefix verifies that iterating with a prefix
+// derived from (requesterPubKey, label) returns all submissions regardless of
+// round, ciphertext, or validator, and nothing for a different requester.
+func TestGetPartialDecryptionsByPrefix(t *testing.T) {
+	t.Parallel()
+
+	k, _, _, ctx := setupDKGKeeperWithMocks(t)
+
+	requesterPubKey := []byte("requester-pub-key")
+	otherRequesterPubKey := []byte("other-requester")
+	label := testLabel()
+	ciphertext1 := []byte("ciphertext-1")
+	ciphertext2 := []byte("ciphertext-2")
+
+	// Store 3 submissions under the same (requesterPubKey, label):
+	//   - validator1, round 1, ciphertext1
+	//   - validator2, round 1, ciphertext1
+	//   - validator1, round 2, ciphertext2
+	submissions := []struct {
+		validator  common.Address
+		round      uint32
+		pid        uint32
+		ciphertext []byte
+	}{
+		{testValidator1, 1, 1, ciphertext1},
+		{testValidator2, 1, 2, ciphertext1},
+		{testValidator1, 2, 1, ciphertext2},
+	}
+	for _, s := range submissions {
+		require.NoError(t, k.setPartialDecryptionSubmission(
+			ctx,
+			s.validator, s.round, s.pid,
+			[]byte("enc-partial"),
+			[]byte("eph-key"),
+			[]byte("pub-share"),
+			requesterPubKey, label, s.ciphertext,
+		))
+	}
+
+	// Store one submission for a different requester — must NOT appear in results.
+	require.NoError(t, k.setPartialDecryptionSubmission(
+		ctx,
+		testValidator1, 1, 1,
+		[]byte("enc-partial"),
+		[]byte("eph-key"),
+		[]byte("pub-share"),
+		otherRequesterPubKey, label, ciphertext1,
+	))
+
+	// Iterate by prefix for (requesterPubKey, label).
+	prefix := dkgPartialDecryptPrefix(requesterPubKey, label)
+	rangePrefix := (&collections.Range[string]{}).Prefix(prefix)
+	iter, err := k.DKGPartialDecrypt.Iterate(ctx, rangePrefix)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var got []string
+	for ; iter.Valid(); iter.Next() {
+		bz, err := iter.Value()
+		require.NoError(t, err)
+		sub, err := decodePartialDecryptionSubmission(bz)
+		require.NoError(t, err)
+		got = append(got, sub.Validator+":"+string(sub.Ciphertext))
+	}
+
+	// Expect exactly the 3 entries stored under requesterPubKey.
+	require.Len(t, got, 3)
+	require.Contains(t, got, testValidator1.Hex()+":"+string(ciphertext1))
+	require.Contains(t, got, testValidator2.Hex()+":"+string(ciphertext1))
+	require.Contains(t, got, testValidator1.Hex()+":"+string(ciphertext2))
 }
 
 // TestDecodePartialDecryptionSubmission_InvalidJSON verifies that decoding

--- a/client/x/dkg/keeper/query_test.go
+++ b/client/x/dkg/keeper/query_test.go
@@ -462,6 +462,103 @@ func TestQuery_GetCDRPartials_FoundSingleSubmission(t *testing.T) {
 	require.False(t, resp.Submissions[0].ThresholdMet, "threshold not met with only 1 of 2 required")
 }
 
+// TestQuery_GetCDRPartials_MultipleGroupsSortedByRound verifies that submissions
+// from different rounds are placed in separate groups and the groups are sorted
+// by round in ascending order.
+func TestQuery_GetCDRPartials_MultipleGroupsSortedByRound(t *testing.T) {
+	t.Parallel()
+
+	k, _, _, ctx := setupDKGKeeperWithMocks(t)
+
+	// Two rounds, both with threshold 1 so ThresholdMet is always true.
+	for _, round := range []uint32{2, 1} { // insert out of order to confirm sort
+		require.NoError(t, k.setDKGNetwork(ctx, &types.DKGNetwork{
+			Round:     round,
+			Total:     3,
+			Threshold: 1,
+			Stage:     types.DKGStageActive,
+		}))
+	}
+
+	requesterPubKey := []byte("multi-round-requester")
+	var label [32]byte
+	label[31] = 0x05 // uuid=5
+	ciphertext := []byte("shared-ciphertext")
+	val1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	val2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	require.NoError(t, k.setPartialDecryptionSubmission(ctx, val1, 1, 1, []byte("ep1"), []byte("eph1"), []byte("ps1"), requesterPubKey, label[:], ciphertext))
+	require.NoError(t, k.setPartialDecryptionSubmission(ctx, val2, 2, 2, []byte("ep2"), []byte("eph2"), []byte("ps2"), requesterPubKey, label[:], ciphertext))
+
+	resp, err := k.GetCDRPartials(ctx, &types.QueryGetCDRPartialsRequest{
+		RequesterPubKeyHex: common.Bytes2Hex(requesterPubKey),
+		Uuid:               5,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Submissions, 2, "one group per round")
+
+	// Verify sorted ascending by round.
+	require.Equal(t, uint32(1), resp.Submissions[0].Round)
+	require.Equal(t, uint32(2), resp.Submissions[1].Round)
+
+	// Each group has exactly one submission and threshold is met.
+	require.Len(t, resp.Submissions[0].Submissions, 1)
+	require.True(t, resp.Submissions[0].ThresholdMet)
+	require.Len(t, resp.Submissions[1].Submissions, 1)
+	require.True(t, resp.Submissions[1].ThresholdMet)
+}
+
+// TestQuery_GetCDRPartials_SameRoundDifferentCiphertexts verifies that two
+// submissions in the same round but for different ciphertexts are placed in
+// separate groups, sorted by ciphertext hex within the same round.
+func TestQuery_GetCDRPartials_SameRoundDifferentCiphertexts(t *testing.T) {
+	t.Parallel()
+
+	k, _, _, ctx := setupDKGKeeperWithMocks(t)
+
+	round := uint32(3)
+	require.NoError(t, k.setDKGNetwork(ctx, &types.DKGNetwork{
+		Round:     round,
+		Total:     3,
+		Threshold: 2,
+		Stage:     types.DKGStageActive,
+	}))
+
+	requesterPubKey := []byte("split-ciphertext-requester")
+	var label [32]byte
+	label[31] = 0x0B // uuid=11
+
+	// ciphertextA sorts before ciphertextB in hex.
+	ciphertextA := []byte("aaaa-ciphertext")
+	ciphertextB := []byte("bbbb-ciphertext")
+	val1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	val2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	require.NoError(t, k.setPartialDecryptionSubmission(ctx, val1, round, 1, []byte("ep1"), []byte("eph1"), []byte("ps1"), requesterPubKey, label[:], ciphertextA))
+	require.NoError(t, k.setPartialDecryptionSubmission(ctx, val2, round, 2, []byte("ep2"), []byte("eph2"), []byte("ps2"), requesterPubKey, label[:], ciphertextB))
+
+	resp, err := k.GetCDRPartials(ctx, &types.QueryGetCDRPartialsRequest{
+		RequesterPubKeyHex: common.Bytes2Hex(requesterPubKey),
+		Uuid:               11,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Submissions, 2, "different ciphertexts → different groups")
+
+	// Both groups are in round 3; verify they carry the right ciphertext.
+	require.Equal(t, round, resp.Submissions[0].Round)
+	require.Equal(t, round, resp.Submissions[1].Round)
+	ciphertexts := []string{
+		string(resp.Submissions[0].Ciphertext),
+		string(resp.Submissions[1].Ciphertext),
+	}
+	require.Contains(t, ciphertexts, string(ciphertextA))
+	require.Contains(t, ciphertexts, string(ciphertextB))
+
+	// Threshold (2) not met for either group since each has only 1 submission.
+	require.False(t, resp.Submissions[0].ThresholdMet)
+	require.False(t, resp.Submissions[1].ThresholdMet)
+}
+
 // TestQuery_GetCDRPartials_ThresholdMet verifies GetCDRPartials reports ThresholdMet=true
 // when the number of submissions reaches the round threshold.
 func TestQuery_GetCDRPartials_ThresholdMet(t *testing.T) {
@@ -498,4 +595,106 @@ func TestQuery_GetCDRPartials_ThresholdMet(t *testing.T) {
 	require.Equal(t, round, resp.Submissions[0].Round)
 	require.Len(t, resp.Submissions[0].Submissions, 2)
 	require.True(t, resp.Submissions[0].ThresholdMet, "threshold should be met with 2 of 2")
+}
+
+// TestQuery_GetCDRPartials_IsolationAmongNoise stores many partial decryption
+// submissions that differ in requester, uuid (label), round, and ciphertext,
+// then queries for one specific (requester, uuid) and asserts that:
+//   - only the expected groups are returned (correct isolation)
+//   - each group contains exactly the right validators
+//   - ThresholdMet is computed correctly per group
+func TestQuery_GetCDRPartials_IsolationAmongNoise(t *testing.T) {
+	t.Parallel()
+
+	k, _, _, ctx := setupDKGKeeperWithMocks(t)
+
+	// --- actors ---
+	reqA := []byte("requester-A")
+	reqB := []byte("requester-B")
+	uuidTarget := uint32(1)
+	uuidOther := uint32(2)
+
+	val1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	val2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	val3 := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	// label helpers
+	makeLabel := func(uuid uint32) []byte {
+		var l [32]byte
+		l[28] = byte(uuid >> 24)
+		l[29] = byte(uuid >> 16)
+		l[30] = byte(uuid >> 8)
+		l[31] = byte(uuid)
+		return l[:]
+	}
+	labelTarget := makeLabel(uuidTarget)
+	labelOther := makeLabel(uuidOther)
+
+	// ciphertexts used by the target query
+	ctX := []byte("ciphertext-X") // round 1
+	ctY := []byte("ciphertext-Y") // round 2
+
+	// Networks: threshold=2 for all rounds used below.
+	for _, round := range []uint32{1, 2} {
+		require.NoError(t, k.setDKGNetwork(ctx, &types.DKGNetwork{
+			Round: round, Total: 3, Threshold: 2, Stage: types.DKGStageActive,
+		}))
+	}
+
+	store := func(validator common.Address, round, pid uint32, reqKey, label, ct []byte) {
+		t.Helper()
+		require.NoError(t, k.setPartialDecryptionSubmission(
+			ctx, validator, round, pid,
+			[]byte("enc"), []byte("eph"), []byte("ps"),
+			reqKey, label, ct,
+		))
+	}
+
+	// === target: reqA + uuidTarget ===
+	// round 1, ciphertextX — 2 validators → ThresholdMet
+	store(val1, 1, 1, reqA, labelTarget, ctX)
+	store(val2, 1, 2, reqA, labelTarget, ctX)
+	// round 2, ciphertextY — 1 validator → threshold NOT met
+	store(val3, 2, 1, reqA, labelTarget, ctY)
+
+	// === noise: same requester, different uuid ===
+	store(val1, 1, 1, reqA, labelOther, ctX)
+
+	// === noise: different requester, same uuid ===
+	store(val1, 1, 1, reqB, labelTarget, ctX)
+	store(val2, 1, 2, reqB, labelTarget, ctX)
+
+	// === noise: different requester, different uuid ===
+	store(val3, 2, 1, reqB, labelOther, ctY)
+
+	// --- query for reqA + uuidTarget ---
+	resp, err := k.GetCDRPartials(ctx, &types.QueryGetCDRPartialsRequest{
+		RequesterPubKeyHex: common.Bytes2Hex(reqA),
+		Uuid:               uuidTarget,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Expect exactly 2 groups (round1/ctX and round2/ctY).
+	require.Len(t, resp.Submissions, 2, "expected one group per (round, ciphertext)")
+
+	// Groups are sorted by round ascending.
+	g1 := resp.Submissions[0]
+	g2 := resp.Submissions[1]
+	require.Equal(t, uint32(1), g1.Round)
+	require.Equal(t, uint32(2), g2.Round)
+
+	// Group 1: round=1, ctX, 2 validators, threshold met.
+	require.Equal(t, ctX, g1.Ciphertext)
+	require.Len(t, g1.Submissions, 2)
+	require.True(t, g1.ThresholdMet)
+	validators1 := []string{g1.Submissions[0].Validator, g1.Submissions[1].Validator}
+	require.Contains(t, validators1, val1.Hex())
+	require.Contains(t, validators1, val2.Hex())
+
+	// Group 2: round=2, ctY, 1 validator, threshold NOT met.
+	require.Equal(t, ctY, g2.Ciphertext)
+	require.Len(t, g2.Submissions, 1)
+	require.False(t, g2.ThresholdMet)
+	require.Equal(t, val3.Hex(), g2.Submissions[0].Validator)
 }

--- a/client/x/evmstaking/keeper/keeper.go
+++ b/client/x/evmstaking/keeper/keeper.go
@@ -238,7 +238,6 @@ func (k Keeper) ProcessStakingEvents(ctx context.Context, height uint64, logs []
 			}
 
 		default:
-			clog.Error(ctx, "Unexpected event type from IP token staking contract", nil)
 			continue
 		}
 	}


### PR DESCRIPTION
Changes:
- remove misleading error logs when processing staking events
- add extra unit tests for rpc `GetPartials`

issue: #760