### PR TITLE
ci(ci): replace deprecated ghcr workflow with push-ghcr.yml

### DIFF
--- a/.github/workflows/push-ghcr.yml
+++ b/.github/workflows/push-ghcr.yml
@@ -1,4 +1,4 @@
-name: -> PUSH to GitHub Container Registry
+name: Push to GitHub Container Registry
 
 on:
   workflow_dispatch:
@@ -12,21 +12,22 @@ on:
       - '*'
 
 jobs:
-  # Build and upload the geth binary
-  timestamp:
-    uses: storyprotocol/gha-workflows/.github/workflows/reusable-timestamp.yml@main
-
   build_and_push:
-    needs: timestamp
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
 
       - name: Set build arguments
+        env:
+          REPOSITORY_URI: ghcr.io/${{ github.repository_owner }}/story
         run: |
-          echo "REPOSITORY_URI=${{ vars.REPOSITORY_URI }}" >> $GITHUB_ENV
+          echo "REPOSITORY_URI=$REPOSITORY_URI" >> $GITHUB_ENV
           echo "COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           if [ -n "${{ github.event.inputs.version }}" ]; then
             echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
@@ -36,19 +37,10 @@ jobs:
           echo "BUILDNUM=${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ hashFiles('Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ github.ref }}-
-            ${{ runner.os }}-buildx-
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -66,8 +58,8 @@ jobs:
             -t $REPOSITORY_URI:latest \
             -t $REPOSITORY_URI:$COMMIT \
             -t $REPOSITORY_URI:$VERSION \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            --cache-to=type=local,dest=/tmp/.buildx-cache \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
             --push \
             -f ./Dockerfile \
             .


### PR DESCRIPTION
replace ci-docker-hub.yml with push-ghcr.yml from main branch to fix actions/cache v2 deprecation that causes all tag-triggered docker builds to fail

## changes

- remove deprecated actions/cache v2, use buildkit native gha caching
- upgrade docker/setup-buildx-action and docker/login-action to v3 (pinned sha)
- hardcode repository uri instead of relying on repo variable
- add explicit permissions block
- remove timestamp job dependency

## after merge

```bash
gh workflow run push-ghcr.yml --repo piplabs/story --ref release/1.6 -f version=v1.6.1
```

issue: none