### PR TITLE
fix(evmengine): delete upgrade-info.json on cancelupgrade

### DIFF
--- a/client/x/evmengine/keeper/upgrades.go
+++ b/client/x/evmengine/keeper/upgrades.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strconv"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
@@ -193,14 +194,18 @@ func (k *Keeper) CancelUpgrade(ctx sdk.Context, isTerence bool) (err error) {
 		if err = k.ResetPendingUpgrade(ctx); err != nil {
 			return errors.Wrap(err, "failed to reset upgrade")
 		}
-
-		return nil
+	} else {
+		if err = k.upgradeKeeper.ClearUpgradePlan(ctx); errors.Is(err, sdkerrors.ErrInvalidRequest) {
+			return errors.WrapErrWithCode(errors.InvalidRequest, err)
+		} else if err != nil {
+			return errors.Wrap(err, "failed to clear upgrade plan")
+		}
 	}
 
-	if err = k.upgradeKeeper.ClearUpgradePlan(ctx); errors.Is(err, sdkerrors.ErrInvalidRequest) {
-		return errors.WrapErrWithCode(errors.InvalidRequest, err)
-	} else if err != nil {
-		return errors.Wrap(err, "failed to clear upgrade plan")
+	if infoPath, pathErr := k.upgradeKeeper.GetUpgradeInfoPath(); pathErr == nil {
+		if removeErr := os.Remove(infoPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			clog.Warn(ctx, "Failed to delete upgrade-info.json after cancel", removeErr)
+		}
 	}
 
 	return nil

--- a/client/x/evmengine/keeper/upgrades_internal_test.go
+++ b/client/x/evmengine/keeper/upgrades_internal_test.go
@@ -250,6 +250,7 @@ func TestKeeper_ProcessCancelUpgrade(t *testing.T) {
 			name: "pass: valid cancel upgrade - before Terence upgrade",
 			setupMock: func(uk *moduletestutil.MockUpgradeKeeper) {
 				uk.EXPECT().ClearUpgradePlan(gomock.Any()).Return(nil)
+				uk.EXPECT().GetUpgradeInfoPath().Return("/tmp/test-upgrade-info.json", nil)
 			},
 		},
 		{
@@ -259,6 +260,9 @@ func TestKeeper_ProcessCancelUpgrade(t *testing.T) {
 				sdkCtx = sdkCtx.WithBlockHeight(51)
 
 				return sdkCtx
+			},
+			setupMock: func(uk *moduletestutil.MockUpgradeKeeper) {
+				uk.EXPECT().GetUpgradeInfoPath().Return("/tmp/test-upgrade-info.json", nil)
 			},
 			postCheck: func(ctx sdk.Context, keeper *Keeper) {
 				_, err := keeper.getPendingUpgrade(ctx)

--- a/client/x/evmengine/testutil/expected_keepers_mocks.go
+++ b/client/x/evmengine/testutil/expected_keepers_mocks.go
@@ -243,6 +243,21 @@ func (mr *MockUpgradeKeeperMockRecorder) ClearUpgradePlan(ctx any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearUpgradePlan", reflect.TypeOf((*MockUpgradeKeeper)(nil).ClearUpgradePlan), ctx)
 }
 
+// GetUpgradeInfoPath mocks base method.
+func (m *MockUpgradeKeeper) GetUpgradeInfoPath() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpgradeInfoPath")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUpgradeInfoPath indicates an expected call of GetUpgradeInfoPath.
+func (mr *MockUpgradeKeeperMockRecorder) GetUpgradeInfoPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpgradeInfoPath", reflect.TypeOf((*MockUpgradeKeeper)(nil).GetUpgradeInfoPath))
+}
+
 // DumpUpgradeInfoToDisk mocks base method.
 func (m *MockUpgradeKeeper) DumpUpgradeInfoToDisk(height int64, p types.Plan) error {
 	m.ctrl.T.Helper()

--- a/client/x/evmengine/types/expected_keepers.go
+++ b/client/x/evmengine/types/expected_keepers.go
@@ -35,6 +35,7 @@ type UpgradeKeeper interface {
 	ClearUpgradePlan(ctx context.Context) error
 	ScheduleUpgrade(ctx context.Context, plan upgradetypes.Plan) error
 	DumpUpgradeInfoToDisk(height int64, p upgradetypes.Plan) error
+	GetUpgradeInfoPath() (string, error)
 }
 
 type DistrKeeper interface {


### PR DESCRIPTION
cancelUpgrade clears on-chain pending state but did not delete data/upgrade-info.json from disk, causing cosmovisor to still switch binaries at the originally planned height after cancel.

- Add GetUpgradeInfoPath to UpgradeKeeper interface
- Call os.Remove on upgrade-info.json in both isTerence and non-isTerence paths of CancelUpgrade
- Update mock and unit tests

Verified on devnet: planUpgrade then cancelUpgrade deletes upgrade-info.json on all 4 validators.

issue: closes #757