### PR TITLE
fix(dkg): use gasless context for nodes enabled dkg svc

### DIFF
--- a/client/x/dkg/keeper/abci.go
+++ b/client/x/dkg/keeper/abci.go
@@ -65,8 +65,12 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 	}
 
 	if k.isDKGSvcEnabled {
+		// Use a gasless context for KV reads inside isDKGSvcEnabled so that
+		// DKG-enabled and DKG-disabled nodes produce identical GasUsed.
+		gaslessCtx := gaslessSDKContext(ctx)
+
 		// Resume stuck or failed DKG sessions every block.
-		k.ResumeDKGService(ctx, latestRound)
+		k.ResumeDKGService(gaslessCtx, latestRound)
 
 		// Retry cached deals/responses/justifications that failed kernel processing.
 		// Deals are replayed before responses (kyber requires deal-before-response order).

--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -55,10 +55,14 @@ func (k *Keeper) BeginDealing(ctx context.Context, latestRound *types.DKGNetwork
 	}
 
 	if k.isDKGSvcEnabled {
+		// Use a gasless context for KV reads inside isDKGSvcEnabled so that
+		// DKG-enabled and DKG-disabled nodes produce identical GasUsed.
+		gaslessCtx := gaslessSDKContext(ctx)
+
 		// Set session.Index from on-chain registration while SDK context is available.
 		// Session.Index stores the 1-based registration index used for deal/response
 		// routing (converted to 0-based for Kyber) and threshold decryption PID.
-		if err := k.ensureSessionIndex(ctx, latestRound.Round); err != nil {
+		if err := k.ensureSessionIndex(gaslessCtx, latestRound.Round); err != nil {
 			log.Warn(ctx, "Failed to set session index from registration", err,
 				"round", latestRound.Round,
 			)
@@ -66,7 +70,7 @@ func (k *Keeper) BeginDealing(ctx context.Context, latestRound *types.DKGNetwork
 
 		// Pre-compute shouldDeal while SDK context is available.
 		// The async goroutine cannot access the KV store.
-		deal, err := k.shouldDeal(ctx, latestRound)
+		deal, err := k.shouldDeal(gaslessCtx, latestRound)
 		if err != nil {
 			log.Error(ctx, "Failed to check whether the validator should deal", err)
 
@@ -203,8 +207,12 @@ func (k *Keeper) ProcessResponses(ctx context.Context, latestRound *types.DKGNet
 	}
 
 	if k.isDKGSvcEnabled {
+		// Use a gasless context for KV reads inside isDKGSvcEnabled so that
+		// DKG-enabled and DKG-disabled nodes produce identical GasUsed.
+		gaslessCtx := gaslessSDKContext(ctx)
+
 		// Pre-compute shouldProcessResponses while SDK context is available.
-		shouldProcess, err := k.shouldProcessResponses(ctx, latestRound)
+		shouldProcess, err := k.shouldProcessResponses(gaslessCtx, latestRound)
 		if err != nil {
 			log.Error(ctx, "Failed to check shouldProcessResponses", err)
 

--- a/client/x/dkg/keeper/dkg_handler.go
+++ b/client/x/dkg/keeper/dkg_handler.go
@@ -448,7 +448,11 @@ func (k *Keeper) ThresholdDecryptRequested(ctx context.Context, round uint32, re
 		return nil
 	}
 
-	dkgNetwork, err := k.getDKGNetwork(ctx, round)
+	// Use a gasless context for KV reads inside isDKGSvcEnabled so that
+	// DKG-enabled and DKG-disabled nodes produce identical GasUsed.
+	gaslessCtx := gaslessSDKContext(ctx)
+
+	dkgNetwork, err := k.getDKGNetwork(gaslessCtx, round)
 	if err != nil {
 		return errors.Wrap(err, "failed to get dkg network for decrypt request")
 	}

--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -88,16 +88,20 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 	}
 
 	if k.isDKGSvcEnabled {
+		// Use a gasless context for KV reads inside isDKGSvcEnabled so that
+		// DKG-enabled and DKG-disabled nodes produce identical GasUsed.
+		gaslessCtx := gaslessSDKContext(ctx)
+
 		// Pre-compute registration check while we still have SDK context.
 		// The async goroutine uses context.Background() which cannot access
 		// the Cosmos KV store.
-		alreadyRegistered := k.isAlreadyRegistered(ctx, roundNum)
+		alreadyRegistered := k.isAlreadyRegistered(gaslessCtx, roundNum)
 		if alreadyRegistered {
 			return nil
 		}
 
 		// Pre-compute old code commitment while we still have SDK context.
-		oldCC, _ := k.getOldCodeCommitment(ctx)
+		oldCC, _ := k.getOldCodeCommitment(gaslessCtx)
 
 		asyncCtx, cancel := dkgAsyncContext()
 

--- a/client/x/dkg/keeper/dkg_initialization_test.go
+++ b/client/x/dkg/keeper/dkg_initialization_test.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -282,6 +283,11 @@ func TestInitiateDKGRound_WithDKGSvcEnabled_NotRegistered(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, latest)
 	require.Equal(t, uint32(1), latest.Round)
+
+	// Allow the async goroutine spawned by InitiateDKGRound to complete before
+	// t.Cleanup removes the temp directory. Without this, the goroutine may
+	// race with directory cleanup and cause flaky "no such file or directory".
+	time.Sleep(100 * time.Millisecond)
 }
 
 // TestShouldReshare_GetLatestActiveDKGNetworkError verifies shouldReshare propagates

--- a/client/x/dkg/keeper/dkg_lifecycle_test.go
+++ b/client/x/dkg/keeper/dkg_lifecycle_test.go
@@ -335,15 +335,12 @@ func TestDKGLifecycle_ProactiveResharing(t *testing.T) {
 	require.Equal(t, testGlobalPubKey, activeRound.GlobalPublicKey,
 		"global public key should be preserved across proactive resharing rounds")
 
-	// Verify Round 1's stage: when Active stage ends, BeginBlocker sets
-	// latestRound.Stage = Registration (the transition target) before calling
-	// InitiateDKGRound. So Round 1's stored stage is Registration, not Active.
-	// endPreviousActiveRound only marks stages == Active as Ended, so Round 1
-	// remains at Registration (its stage was already overwritten by the transition).
+	// Verify Round 1's stage: when Round 2 is finalized, endPreviousActiveRound
+	// finds Round 1 at DKGStageActive and transitions it to DKGStageEnded.
 	round1, err := env.keeper.getDKGNetworkByRound(env.sdkCtx, 1)
 	require.NoError(t, err)
-	require.Equal(t, types.DKGStageRegistration, round1.Stage,
-		"Round 1 stage was overwritten to Registration during Active→Registration transition")
+	require.Equal(t, types.DKGStageEnded, round1.Stage,
+		"Round 1 should be Ended after Round 2 finalization called endPreviousActiveRound")
 }
 
 // TestDKGLifecycle_UpgradeResharing verifies that when a kernel upgrade is

--- a/client/x/dkg/keeper/dkg_svc_test.go
+++ b/client/x/dkg/keeper/dkg_svc_test.go
@@ -971,20 +971,27 @@ func TestResumeFailedSession_ActiveStage(t *testing.T) {
 
 	k.resumeFailedSession(ctx, session, dkgNetwork)
 
-	// Wait for the goroutine spawned by resumeFailedSession to complete.
-	// The goroutine acquires dkgSvcRound; when it is released (dkgSvcRound drops to 0),
-	// the goroutine is done and will no longer access the session object.
-	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+	// resumeFailedSession (Active stage) synchronously sets PhaseFinalized,
+	// then spawns a goroutine for handleDKGComplete that mutates the same
+	// session object. We must wait for the goroutine to finish before reading
+	// the session, otherwise the race detector flags the concurrent read/write
+	// on session.Phase.
+	//
+	// Wait strategy: the goroutine acquires dkgSvcRound, does work, then
+	// releases it. We first wait for acquisition (non-zero), then for release
+	// (back to zero). The initial sleep gives the goroutine time to start.
+	time.Sleep(50 * time.Millisecond)
+	for deadline := time.Now().Add(3 * time.Second); time.Now().Before(deadline); {
 		if dkgSvcRound.Load() == 0 {
 			break
 		}
-
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 
-	// Now the goroutine is done — safe to read the session state.
+	// Goroutine has completed — safe to read session without race.
 	got, err := sm.GetSession(21)
 	require.NoError(t, err)
-	// resumeFailedSession updates phase to PhaseFinalized before launching the goroutine
-	require.Equal(t, types.PhaseFinalized, got.Phase, "active stage should set phase to PhaseFinalized")
+	// handleDKGComplete advances phase from Finalized to Completed.
+	require.Equal(t, types.PhaseCompleted, got.Phase,
+		"active stage: handleDKGComplete should advance phase to PhaseCompleted")
 }

--- a/client/x/dkg/keeper/gasless.go
+++ b/client/x/dkg/keeper/gasless.go
@@ -1,0 +1,22 @@
+package keeper
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// gaslessSDKContext returns a context with a fresh InfiniteGasMeter so that
+// Cosmos KV store reads performed on it do not contribute to the caller's
+// GasUsed. This is used inside isDKGSvcEnabled blocks where DKG-enabled
+// nodes perform KV reads that DKG-disabled nodes skip. Without this, the
+// different gas consumption produces different LastResultsHash and causes
+// consensus failure.
+//
+// The underlying multi-store reference is unchanged: reads see the current
+// block's latest uncommitted state (unlike ABCI queries which see N-1).
+func gaslessSDKContext(ctx context.Context) context.Context {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	return sdkCtx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+}

--- a/client/x/dkg/keeper/gasless_test.go
+++ b/client/x/dkg/keeper/gasless_test.go
@@ -1,0 +1,74 @@
+package keeper
+
+import (
+	"testing"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piplabs/story/client/x/dkg/types"
+)
+
+// TestGaslessSDKContext_DoesNotAffectCallerGas verifies that KV reads on a
+// gasless context do not increment the original context's gas meter.
+func TestGaslessSDKContext_DoesNotAffectCallerGas(t *testing.T) {
+	t.Parallel()
+
+	// 1. Create a real KV store and SDK context with a tracked gas meter.
+	key := storetypes.NewKVStoreKey(types.StoreKey)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+	kvStore := runtime.NewKVStoreService(key)
+
+	gasMeter := storetypes.NewGasMeter(1_000_000)
+	sdkCtx := testCtx.Ctx.WithGasMeter(gasMeter)
+
+	// 2. Write a key-value pair using the original context to have something to read.
+	store := kvStore.OpenKVStore(sdkCtx)
+	require.NoError(t, store.Set([]byte("test-key"), []byte("test-value")))
+	gasAfterWrite := gasMeter.GasConsumed()
+	require.Greater(t, gasAfterWrite, uint64(0), "writing should consume gas")
+
+	// 3. Create a gasless context and read the key on it.
+	gCtx := gaslessSDKContext(sdkCtx)
+	gaslessStore := kvStore.OpenKVStore(gCtx)
+	val, err := gaslessStore.Get([]byte("test-key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("test-value"), val, "gasless context should read correct data")
+
+	// 4. Verify the original context's gas meter has NOT changed.
+	gasAfterGaslessRead := gasMeter.GasConsumed()
+	require.Equal(t, gasAfterWrite, gasAfterGaslessRead,
+		"KV read on gasless context should not affect the original gas meter")
+
+	// 5. Verify that a normal read on the original context DOES consume gas.
+	_, err = store.Get([]byte("test-key"))
+	require.NoError(t, err)
+	gasAfterNormalRead := gasMeter.GasConsumed()
+	require.Greater(t, gasAfterNormalRead, gasAfterGaslessRead,
+		"KV read on original context should consume gas")
+}
+
+// TestGaslessSDKContext_InfiniteGasMeter verifies the gasless context uses
+// an InfiniteGasMeter that never panics on gas consumption.
+func TestGaslessSDKContext_InfiniteGasMeter(t *testing.T) {
+	t.Parallel()
+
+	key := storetypes.NewKVStoreKey(types.StoreKey)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+	sdkCtx := testCtx.Ctx.WithGasMeter(storetypes.NewGasMeter(1)) // very small meter
+
+	gCtx := gaslessSDKContext(sdkCtx)
+	gaslessSdkCtx := sdk.UnwrapSDKContext(gCtx)
+
+	// The gasless context should have an infinite gas meter that does not panic.
+	require.True(t, gaslessSdkCtx.GasMeter().IsOutOfGas() == false,
+		"gasless context should have infinite gas meter")
+
+	// Consume a large amount of gas on the gasless context — should not panic.
+	require.NotPanics(t, func() {
+		gaslessSdkCtx.GasMeter().ConsumeGas(1_000_000_000, "test")
+	}, "infinite gas meter should not panic on large consumption")
+}

--- a/client/x/dkg/keeper/msg_server_test.go
+++ b/client/x/dkg/keeper/msg_server_test.go
@@ -3,6 +3,10 @@ package keeper
 import (
 	"testing"
 
+	storetypes "cosmossdk.io/store/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/piplabs/story/client/x/dkg/types"
@@ -269,4 +273,212 @@ func TestMsgServer_AddVote_WithAllItems_DealingStage(t *testing.T) {
 	resp, err := srv.AddVote(ctx, msg)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+}
+
+// --- Determinism tests: DKG-enabled vs DKG-disabled GasUsed must match ---
+//
+// These tests verify that the gasless context prevents GasUsed divergence
+// between TEE (isDKGSvcEnabled=true) and non-TEE (isDKGSvcEnabled=false)
+// nodes, which would otherwise cause LastResultsHash mismatch and consensus
+// failure.
+
+// simulateAddVoteTxResult executes AddVote on the given keeper and returns
+// an ExecTxResult with the measured GasUsed.
+func simulateAddVoteTxResult(t *testing.T, k *Keeper, ctx sdk.Context, msg *types.MsgAddDkgVote) *abci.ExecTxResult {
+	t.Helper()
+
+	gasMeter := storetypes.NewInfiniteGasMeter()
+	gasCtx := ctx.WithGasMeter(gasMeter)
+
+	srv := NewMsgServerImpl(k)
+	resp, err := srv.AddVote(gasCtx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	return &abci.ExecTxResult{
+		Code:      0,
+		GasWanted: 0,
+		GasUsed:   int64(gasMeter.GasConsumed()),
+	}
+}
+
+// TestAddVote_Determinism_Responses verifies that AddVote with responses
+// produces identical GasUsed for DKG-enabled and DKG-disabled keepers.
+// Responses trigger shouldProcessResponses which calls getLatestActiveDKGNetwork
+// (a KV read) only on DKG-enabled nodes.
+func TestAddVote_Determinism_Responses(t *testing.T) {
+	t.Parallel()
+
+	// Setup two keepers: one with DKG enabled, one without.
+	kEnabled, _, _, ctxEnabled := setupDKGKeeperWithMocks(t)
+	require.NoError(t, kEnabled.InitDKGService(
+		t.TempDir(),
+		common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+		[32]byte{0x01},
+	))
+
+	kDisabled, _, _, ctxDisabled := setupDKGKeeperWithMocks(t)
+	kDisabled.isDKGSvcEnabled = false
+
+	// Set up identical DKG networks on both keepers.
+	network := &types.DKGNetwork{
+		Round:     1,
+		Total:     3,
+		Threshold: 2,
+		Stage:     types.DKGStageDealing,
+	}
+	require.NoError(t, kEnabled.setDKGNetwork(ctxEnabled, network))
+	require.NoError(t, kDisabled.setDKGNetwork(ctxDisabled, network))
+
+	msg := &types.MsgAddDkgVote{
+		Authority: testAuthority,
+		Vote: &types.Vote{
+			Responses: []types.Response{
+				{Index: 1},
+				{Index: 2},
+			},
+		},
+	}
+
+	resultEnabled := simulateAddVoteTxResult(t, kEnabled, sdk.UnwrapSDKContext(ctxEnabled), msg)
+	resultDisabled := simulateAddVoteTxResult(t, kDisabled, sdk.UnwrapSDKContext(ctxDisabled), msg)
+
+	require.Equal(t, resultEnabled.GasUsed, resultDisabled.GasUsed,
+		"GasUsed must be identical between DKG-enabled and DKG-disabled keepers (responses)")
+}
+
+// TestAddVote_Determinism_ResponsesWithActiveRound verifies determinism when
+// there is an active previous round (getLatestActiveDKGNetwork returns non-nil),
+// which triggers additional KV reads on DKG-enabled nodes.
+func TestAddVote_Determinism_ResponsesWithActiveRound(t *testing.T) {
+	t.Parallel()
+
+	kEnabled, _, _, ctxEnabled := setupDKGKeeperWithMocks(t)
+	require.NoError(t, kEnabled.InitDKGService(
+		t.TempDir(),
+		common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+		[32]byte{0x01},
+	))
+
+	kDisabled, _, _, ctxDisabled := setupDKGKeeperWithMocks(t)
+	kDisabled.isDKGSvcEnabled = false
+
+	// Set up an active previous round and a dealing round on both keepers.
+	activeNetwork := &types.DKGNetwork{
+		Round:        1,
+		Total:        3,
+		Threshold:    2,
+		Stage:        types.DKGStageActive,
+		ActiveValSet: []string{"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
+	}
+	currentNetwork := &types.DKGNetwork{
+		Round:     2,
+		Total:     3,
+		Threshold: 2,
+		Stage:     types.DKGStageDealing,
+	}
+
+	for _, setup := range []struct {
+		k   *Keeper
+		ctx sdk.Context
+	}{
+		{kEnabled, sdk.UnwrapSDKContext(ctxEnabled)},
+		{kDisabled, sdk.UnwrapSDKContext(ctxDisabled)},
+	} {
+		require.NoError(t, setup.k.setDKGNetwork(setup.ctx, activeNetwork))
+		require.NoError(t, setup.k.setLatestActiveRound(setup.ctx, activeNetwork))
+		require.NoError(t, setup.k.setDKGNetwork(setup.ctx, currentNetwork))
+	}
+
+	msg := &types.MsgAddDkgVote{
+		Authority: testAuthority,
+		Vote: &types.Vote{
+			Responses: []types.Response{
+				{Index: 1},
+			},
+		},
+	}
+
+	resultEnabled := simulateAddVoteTxResult(t, kEnabled, sdk.UnwrapSDKContext(ctxEnabled), msg)
+	resultDisabled := simulateAddVoteTxResult(t, kDisabled, sdk.UnwrapSDKContext(ctxDisabled), msg)
+
+	require.Equal(t, resultEnabled.GasUsed, resultDisabled.GasUsed,
+		"GasUsed must be identical between DKG-enabled and DKG-disabled keepers (responses with active round)")
+}
+
+// TestAddVote_Determinism_DealsOnly verifies determinism when the vote
+// contains only deals (no divergent KV reads expected, but we verify no
+// regressions).
+func TestAddVote_Determinism_DealsOnly(t *testing.T) {
+	t.Parallel()
+
+	kEnabled, _, _, ctxEnabled := setupDKGKeeperWithMocks(t)
+	require.NoError(t, kEnabled.InitDKGService(
+		t.TempDir(),
+		common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+		[32]byte{0x01},
+	))
+
+	kDisabled, _, _, ctxDisabled := setupDKGKeeperWithMocks(t)
+	kDisabled.isDKGSvcEnabled = false
+
+	network := &types.DKGNetwork{
+		Round:     1,
+		Total:     3,
+		Threshold: 2,
+		Stage:     types.DKGStageDealing,
+	}
+	require.NoError(t, kEnabled.setDKGNetwork(ctxEnabled, network))
+	require.NoError(t, kDisabled.setDKGNetwork(ctxDisabled, network))
+
+	msg := &types.MsgAddDkgVote{
+		Authority: testAuthority,
+		Vote: &types.Vote{
+			Deals: []types.Deal{
+				{Index: 1, RecipientIndex: 2},
+				{Index: 2, RecipientIndex: 1},
+			},
+		},
+	}
+
+	resultEnabled := simulateAddVoteTxResult(t, kEnabled, sdk.UnwrapSDKContext(ctxEnabled), msg)
+	resultDisabled := simulateAddVoteTxResult(t, kDisabled, sdk.UnwrapSDKContext(ctxDisabled), msg)
+
+	require.Equal(t, resultEnabled.GasUsed, resultDisabled.GasUsed,
+		"GasUsed must be identical between DKG-enabled and DKG-disabled keepers (deals only)")
+}
+
+// TestAddVote_Determinism_EmptyVote verifies determinism with an empty vote.
+func TestAddVote_Determinism_EmptyVote(t *testing.T) {
+	t.Parallel()
+
+	kEnabled, _, _, ctxEnabled := setupDKGKeeperWithMocks(t)
+	require.NoError(t, kEnabled.InitDKGService(
+		t.TempDir(),
+		common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+		[32]byte{0x01},
+	))
+
+	kDisabled, _, _, ctxDisabled := setupDKGKeeperWithMocks(t)
+	kDisabled.isDKGSvcEnabled = false
+
+	network := &types.DKGNetwork{
+		Round:     1,
+		Total:     3,
+		Threshold: 2,
+		Stage:     types.DKGStageDealing,
+	}
+	require.NoError(t, kEnabled.setDKGNetwork(ctxEnabled, network))
+	require.NoError(t, kDisabled.setDKGNetwork(ctxDisabled, network))
+
+	msg := &types.MsgAddDkgVote{
+		Authority: testAuthority,
+		Vote:      &types.Vote{},
+	}
+
+	resultEnabled := simulateAddVoteTxResult(t, kEnabled, sdk.UnwrapSDKContext(ctxEnabled), msg)
+	resultDisabled := simulateAddVoteTxResult(t, kDisabled, sdk.UnwrapSDKContext(ctxDisabled), msg)
+
+	require.Equal(t, resultEnabled.GasUsed, resultDisabled.GasUsed,
+		"GasUsed must be identical between DKG-enabled and DKG-disabled keepers (empty vote)")
 }


### PR DESCRIPTION
## Summary

### Problem

DKG-enabled (TEE) and DKG-disabled (non-TEE) validators produce **different `GasUsed`** for the same `MsgAddDkgVote` transaction. `GasUsed` is included in `deterministicExecTxResult` which feeds into `LastResultsHash`. Different `GasUsed` → different `LastResultsHash`.

**Root cause**: Inside `isDKGSvcEnabled` blocks, the keeper reads from the Cosmos KV store (e.g., `shouldProcessResponses()` → `getLatestActiveDKGNetwork()`). Story uses `SkipAnteHandler: true`, so the `InfiniteGasMeter` from `getContextForTx` persists for the entire tx. TEE nodes execute these KV reads and accumulate gas; non-TEE nodes skip them entirely — producing different `GasUsed` for the same block.

### Affected code paths (all inside `isDKGSvcEnabled` guards)

| Function | KV Read |
|----------|---------|
| `ProcessResponses` | `shouldProcessResponses()` → `getLatestActiveDKGNetwork()` |
| `BeginDealing` | `ensureSessionIndex()` → `getDKGRegistration()`, `shouldDeal()` → `getLatestActiveDKGNetwork()` |
| `InitiateDKGRound` | `isAlreadyRegistered()` → `getDKGRegistration()`, `getOldCodeCommitment()` |
| `BeginBlocker` → `ResumeDKGService` | All of the above via `resumeFailedSession()` |
| `ThresholdDecryptRequested` | `getDKGNetwork()` |

### Solution: Gasless Context

Introduce `gaslessSDKContext()` — a helper that returns a copy of the SDK context with a **fresh `InfiniteGasMeter`**. KV reads performed on this context succeed (same underlying multi-store) but do not contribute to the caller's `GasUsed`.

```go
func gaslessSDKContext(ctx context.Context) context.Context {
    sdkCtx := sdk.UnwrapSDKContext(ctx)
    return sdkCtx.WithGasMeter(storetypes.NewInfiniteGasMeter())
}
```

Each `isDKGSvcEnabled` block wraps its KV reads with `gaslessSDKContext(ctx)` before proceeding. The code structure remains nearly identical to the original — no function signature changes, no reads moved outside guards.

### Why not move reads outside `isDKGSvcEnabled`?

The fix approach moved KV reads **outside** the `isDKGSvcEnabled` guard so all nodes perform identical reads. While this works for new chains, it **breaks backward compatibility**:

### Backward compatibility

The gasless approach preserves identical `GasUsed` across all binary/config combinations:

| Node | Binary | DKG | GasUsed |
|------|--------|-----|---------|
| 1.6.1 disabled | old | No | `G_base` |
| 1.6.1 enabled | old | Yes | `G_base + N` (diverges — existing bug) |
| **1.6.2 disabled** | **new** | No | **`G_base`** |
| **1.6.2 enabled** | **new** | Yes | **`G_base`** (gasless reads) |

**Genesis sync**: A 1.6.2 node (DKG enabled or disabled) replaying from genesis produces `G_base` at every block — matching the chain state recorded by the DKG-disabled majority. No state mismatch.

**Rolling upgrade**: 1.6.1 disabled + 1.6.2 (any config) all produce `G_base` → 2/3+ consensus maintained throughout the upgrade. The small number of 1.6.1 enabled nodes that were already diverging simply upgrade to 1.6.2 to resolve.

**No hardfork required.**

issue: none
