### PR TITLE
chore(github): add qa reviewers to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @LeoHChen @jdubpark @edisonz0718 @gezerui0124 @limengformal @0xHansLee @ramtinms @stevemilk
+* @LeoHChen @jdubpark @edisonz0718 @gezerui0124 @limengformal @0xHansLee @ramtinms @stevemilk @chao-peng-story @lucas2brh
 
 /.github @wo-o @limengformal @jack-piplabs


### PR DESCRIPTION
add chao-peng-story and lucas2brh to codeowners for qa review coverage

issue: none