### PR TITLE
fix(dkg): skip caching duplicate deals rejected by kernel

### DIFF
--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -5,10 +5,14 @@ import (
 	"context"
 	"encoding/hex"
 	"slices"
+	"strings"
 
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // handleDKGDealing handles the dealing phase event.
@@ -189,6 +193,17 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 
 		return nil
 	}); err != nil {
+		// "all N submitted deals were rejected" means every deal was already processed
+		// by kyber (duplicate delivery via consecutive vote extensions). Retrying the
+		// same data will always fail, so drop instead of caching.
+		if status.Code(err) == codes.InvalidArgument && strings.Contains(status.Convert(err).Message(), "submitted deals were rejected") {
+			log.Warn(ctx, "All deals already processed by kernel; dropping duplicates", err,
+				"round", dkgNetwork.Round,
+			)
+
+			return
+		}
+
 		// Cache unprocessed deals in memory for retry when kernel recovers.
 		// Not persisted to disk — process restart loses them (round will fail and retry).
 		cached := cachePendingIncomingDeals(deals, session.Index)

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -152,33 +152,39 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 		return
 	}
 
+	// Filter deals addressed to this validator before entering retry loop.
+	filteredDeals := make([]types.Deal, 0, len(deals))
+	for _, deal := range deals {
+		// RecipientIndex is 0-based (Kyber), session.Index is 1-based (on-chain).
+		// Guard against unset index (0) to avoid uint32 underflow.
+		if session.Index > 0 && deal.RecipientIndex == session.Index-1 {
+			filteredDeals = append(filteredDeals, deal)
+		}
+	}
+
+	if len(filteredDeals) == 0 {
+		log.Info(ctx, "No deals addressed to this validator; skipping",
+			"round", dkgNetwork.Round,
+			"total_deals", len(deals),
+		)
+
+		return
+	}
+
 	var resp *types.ProcessDealsResponse
 
 	if err := retry(ctx, func(ctx context.Context) error {
 		log.Info(ctx, "ProcessDeals call to kernel client",
 			"round", session.Round,
-			"num_deals", len(deals),
+			"total_deals", len(deals),
+			"filtered_deals", len(filteredDeals),
 		)
 
 		req := &types.ProcessDealsRequest{
 			CodeCommitment: session.CodeCommitment,
 			Round:          session.Round,
-			Deals:          []types.Deal{},
+			Deals:          filteredDeals,
 			IsResharing:    session.IsResharing,
-		}
-
-		for _, deal := range deals {
-			// RecipientIndex is 0-based (Kyber), session.Index is 1-based (on-chain).
-			// Guard against unset index (0) to avoid uint32 underflow.
-			if session.Index > 0 && deal.RecipientIndex == session.Index-1 {
-				req.Deals = append(req.Deals, deal)
-			}
-		}
-
-		if len(req.Deals) == 0 {
-			log.Info(ctx, "No deals to process. Skip to request")
-
-			return nil
 		}
 
 		client, cErr := k.getClientWithReconnect(session.CodeCommitment)
@@ -206,7 +212,7 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 
 		// Cache unprocessed deals in memory for retry when kernel recovers.
 		// Not persisted to disk — process restart loses them (round will fail and retry).
-		cached := cachePendingIncomingDeals(deals, session.Index)
+		cached := cachePendingIncomingDeals(filteredDeals, session.Index)
 
 		log.Error(ctx, "Failed to process deals; cached for retry", err,
 			"round", dkgNetwork.Round,
@@ -220,6 +226,8 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 
 	log.Info(ctx, "Process deals complete",
 		"round", session.Round,
+		"submitted_deals", len(filteredDeals),
+		"responses_generated", len(resp.GetResponses()),
 	)
 }
 
@@ -303,6 +311,8 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 		return
 	}
 
+	var totalJustifications int
+
 	for _, cc := range ccsToProcess {
 		var processResp *types.ProcessResponsesResponse
 
@@ -351,6 +361,7 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 		// and the dealer needs to reveal the plaintext deal to prove its validity.
 		if processResp != nil && len(processResp.GetJustifications()) > 0 {
 			k.EnqueueJustifications(processResp.GetJustifications())
+			totalJustifications += len(processResp.GetJustifications())
 
 			log.Info(ctx, "Enqueued justifications for broadcast",
 				"code_commitment", hex.EncodeToString(cc),
@@ -362,6 +373,8 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 
 	log.Info(ctx, "Process responses complete",
 		"round", session.Round,
+		"submitted_responses", len(filteredResponses),
+		"justifications_received", totalJustifications,
 	)
 }
 
@@ -416,6 +429,11 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 			return
 		}
 	}
+
+	log.Info(ctx, "Process justifications complete",
+		"round", session.Round,
+		"submitted_justifications", len(justifications),
+	)
 }
 
 func (k *Keeper) shouldDeal(ctx context.Context, dkgNetwork *types.DKGNetwork) (bool, error) {


### PR DESCRIPTION
## Summary

  - Fix infinite retry loop where already-processed DKG deals were continuously re-sent to the kernel
  - Add detailed processing count logs for deals, responses, and justifications

  ## Problem

  Due to CometBFT's vote extension lifecycle (`ExtendVote` runs before `FinalizeBlock`), the same deals can arrive in two consecutive blocks. The first delivery is processed successfully, but the second delivery is rejected by the kernel with `"all N submitted deals were rejected"` (kyber rejects duplicate deals).


  Previously, `handleDKGProcessDeals` treated all errors uniformly — including this rejection — and cached them for retry via `reprocessPendingIncomingData`. Since retrying the same duplicate deals always produces the same rejection, this created an **infinite retry loop** that never resolves.

  Notably, responses don't have this issue because the kernel's `ProcessResponses` does not return an error for duplicates — it silently skips them and returns success.

  ## Fix

  Detect the specific `"submitted deals were rejected"` error message with `InvalidArgument` gRPC status code and drop the deals instead of caching. Other `InvalidArgument` errors (e.g., invalid round, empty deals) and transient errors (`Unavailable`, `Internal`) are still cached for retry as before.

issue: none
