### PR TITLE
fix: drain and add back decrypt queue

### DIFF
--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -293,7 +293,9 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 
 	sessions := k.stateManager.ListSessions()
 	for _, session := range sessions {
-		requests := session.GetDecryptRequests()
+		// Atomically drain the queue so that requests added by the ABCI thread
+		// during processing are not overwritten when we persist the remaining failures.
+		requests := session.DrainDecryptRequests()
 		if len(requests) == 0 {
 			continue
 		}
@@ -307,7 +309,6 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 				"code_commitment", hex.EncodeToString(session.CodeCommitment),
 				"dropped_requests", len(requests),
 			)
-			session.SetDecryptRequests(nil)
 
 			if err := k.stateManager.UpdateSession(ctx, session); err != nil {
 				log.Error(ctx, "Failed to clear stale decrypt requests", err,
@@ -339,9 +340,8 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 		}
 
 		if len(validRequests) == 0 {
-			session.SetDecryptRequests(nil)
 			if err := k.stateManager.UpdateSession(ctx, session); err != nil {
-				log.Error(ctx, "Failed to clear stale decrypt requests", err,
+				log.Error(ctx, "Failed to persist session after clearing stale requests", err,
 					"session", session.GetSessionKey(),
 				)
 			}
@@ -355,7 +355,6 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 			"pending_requests", len(requests),
 		)
 
-		remaining := make([]types.DecryptRequest, 0, len(requests))
 		for _, req := range requests {
 			if err := k.handleDecryptRequest(ctx, session, req); err != nil {
 				log.Error(ctx, "Failed to process decrypt request", err,
@@ -365,7 +364,9 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 					"label_len", len(req.Label),
 					"requester_pub_key_len", len(req.RequesterPubKey),
 				)
-				remaining = append(remaining, req) // keep for retry
+				// Re-add failed request; this appends to the live queue, preserving
+				// any new requests the ABCI thread added while we were processing.
+				session.AddDecryptRequest(req)
 
 				continue
 			}
@@ -376,12 +377,9 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 			)
 		}
 
-		session.SetDecryptRequests(remaining)
-
 		if err := k.stateManager.UpdateSession(ctx, session); err != nil {
 			log.Error(ctx, "Failed to update session after processing decrypt queue", err,
 				"session", session.GetSessionKey(),
-				"remaining_requests", len(remaining),
 			)
 		}
 	}

--- a/client/x/dkg/types/dkg.go
+++ b/client/x/dkg/types/dkg.go
@@ -162,3 +162,17 @@ func (s *DKGSession) SetDecryptRequests(remaining []DecryptRequest) {
 	s.DecryptRequests = remaining
 	s.LastUpdate = time.Now()
 }
+
+// DrainDecryptRequests atomically returns all pending decrypt requests and clears the queue.
+// This prevents the TOCTOU race where GetDecryptRequests + SetDecryptRequests could
+// overwrite requests added between the two calls by the ABCI thread.
+func (s *DKGSession) DrainDecryptRequests() []DecryptRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	reqs := s.DecryptRequests
+	s.DecryptRequests = make([]DecryptRequest, 0)
+	s.LastUpdate = time.Now()
+
+	return reqs
+}

--- a/client/x/dkg/types/dkg_test.go
+++ b/client/x/dkg/types/dkg_test.go
@@ -216,4 +216,42 @@ func TestDKGSession_DecryptRequests(t *testing.T) {
 		reqs := session.GetDecryptRequests()
 		require.Empty(t, reqs)
 	})
+
+	t.Run("drain decrypt requests clears queue and returns contents", func(t *testing.T) {
+		t.Parallel()
+
+		session := types.NewDKGSession(1, nil, false, [32]byte{})
+		session.AddDecryptRequest(types.DecryptRequest{Round: 1, Ciphertext: []byte("ct1")})
+		session.AddDecryptRequest(types.DecryptRequest{Round: 1, Ciphertext: []byte("ct2")})
+
+		drained := session.DrainDecryptRequests()
+		require.Len(t, drained, 2)
+		require.Equal(t, []byte("ct1"), drained[0].Ciphertext)
+		require.Equal(t, []byte("ct2"), drained[1].Ciphertext)
+
+		// Queue should be empty after drain
+		require.Empty(t, session.GetDecryptRequests())
+	})
+
+	t.Run("drain then add preserves new requests", func(t *testing.T) {
+		t.Parallel()
+
+		// Simulates the race: worker drains, ABCI adds a new request,
+		// worker re-adds failures — the new request must survive.
+		session := types.NewDKGSession(1, nil, false, [32]byte{})
+		session.AddDecryptRequest(types.DecryptRequest{Round: 1, Ciphertext: []byte("uuid50")})
+
+		// Worker drains
+		drained := session.DrainDecryptRequests()
+		require.Len(t, drained, 1)
+
+		// ABCI thread adds uuid51 while worker is processing uuid50
+		session.AddDecryptRequest(types.DecryptRequest{Round: 1, Ciphertext: []byte("uuid51")})
+
+		// Worker finishes uuid50 successfully — no failures to re-add
+		// Queue should still contain uuid51
+		reqs := session.GetDecryptRequests()
+		require.Len(t, reqs, 1)
+		require.Equal(t, []byte("uuid51"), reqs[0].Ciphertext)
+	})
 }


### PR DESCRIPTION
Fix a TOCTOU race in `processDecryptQueue` where the background decrypt worker's `GetDecryptRequests` → process → `SetDecryptRequests(remaining)` pattern silently overwrites requests added by the ABCI thread during the 3-6s processing window (kernel RPC + contract tx). This caused sequential same-wallet VaultRead requests to receive zero partial decryptions when the second read landed while the first was being processed.

Replace the get-process-set pattern with drain-and-addback: `DrainDecryptRequests` atomically swaps out the queue, the worker processes its private copy without holding locks, and failed requests are re-added via `AddDecryptRequest` — preserving any new requests the ABCI thread appended during processing.