### PR TITLE
fix(dkg): run threshold decrypt requested dkg service work asynchronously

### DIFF
--- a/client/x/dkg/keeper/dkg_handler.go
+++ b/client/x/dkg/keeper/dkg_handler.go
@@ -475,38 +475,64 @@ func (k *Keeper) ThresholdDecryptRequested(ctx context.Context, round uint32, re
 		return nil
 	}
 
-	log.Info(ctx, "DKG ThresholdDecryptRequested event received",
-		"round", round,
-		"requester_pubkey_len", len(requesterPubKey),
-		"ciphertext_len", len(ciphertext),
-		"label_len", len(label),
-		"block_height", blockHeight,
-	)
-
-	session, err := k.stateManager.GetSession(round)
-	if err != nil {
-		return errors.Wrap(err, "failed to get DKG session for decrypt request")
-	}
-
-	// Record the request so the off-chain service can pick it up and produce a TDH2 partial decrypt.
-	session.AddDecryptRequest(types.DecryptRequest{
+	// Pre-compute values that require SDK context, then dispatch async.
+	decryptReq := types.DecryptRequest{
 		Round:           round,
 		Ciphertext:      ciphertext,
 		Label:           label[:],
 		RequesterPubKey: requesterPubKey,
 		Height:          blockHeight,
-	})
+	}
+
+	asyncCtx, cancel := dkgAsyncContext()
+
+	go func() {
+		defer cancel()
+
+		k.handleThresholdDecryptRequest(asyncCtx, round, decryptReq)
+	}()
+
+	return nil
+}
+
+// handleThresholdDecryptRequest queues a threshold decrypt request to the DKG session
+// for the decrypt worker to pick up. Runs asynchronously to avoid blocking FinalizeBlock.
+func (k *Keeper) handleThresholdDecryptRequest(ctx context.Context, round uint32, req types.DecryptRequest) {
+	log.Info(ctx, "Handling threshold decrypt request",
+		"round", round,
+		"label", hex.EncodeToString(req.Label),
+		"requester_pubkey_len", len(req.RequesterPubKey),
+		"ciphertext_len", len(req.Ciphertext),
+		"block_height", req.Height,
+	)
+
+	session, err := k.stateManager.GetSession(round)
+	if err != nil {
+		log.Error(ctx, "Failed to get DKG session for decrypt request", err,
+			"round", round,
+		)
+
+		return
+	}
+
+	session.AddDecryptRequest(req)
 
 	if err := k.stateManager.UpdateSession(ctx, session); err != nil {
-		return errors.Wrap(err, "failed to persist decrypt request")
+		log.Error(ctx, "Failed to persist decrypt request to session", err,
+			"round", round,
+			"label", hex.EncodeToString(req.Label),
+			"session", session.GetSessionKey(),
+		)
+
+		return
 	}
 
 	log.Info(ctx, "Queued threshold decrypt request",
 		"session", session.GetSessionKey(),
+		"round", round,
+		"label", hex.EncodeToString(req.Label),
 		"pending_requests", len(session.GetDecryptRequests()),
 	)
-
-	return nil
 }
 
 // PartialDecryptionSubmitted handles TDH2 partial decrypt submissions emitted by the contract.

--- a/client/x/dkg/keeper/dkg_handler_internal_test.go
+++ b/client/x/dkg/keeper/dkg_handler_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	storetypes "cosmossdk.io/store/types"
 
@@ -1497,7 +1498,8 @@ func TestThresholdDecryptRequested_ValidatorNotInCommittee(t *testing.T) {
 
 // TestThresholdDecryptRequested_ValidatorInCommitteeSessionNotFound verifies that when
 // the validator is in the active committee and DKG service is enabled but no session
-// exists for the round, ThresholdDecryptRequested returns an error.
+// exists for the round, ThresholdDecryptRequested returns nil (session error is handled
+// asynchronously in the goroutine and logged, not returned to the caller).
 func TestThresholdDecryptRequested_ValidatorInCommitteeSessionNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -1516,15 +1518,15 @@ func TestThresholdDecryptRequested_ValidatorInCommitteeSessionNotFound(t *testin
 	}
 	require.NoError(t, k.setDKGNetwork(ctx, network))
 
-	// No session created for round 7 → GetSession returns "not found" error
+	// No session created for round 7 → handleThresholdDecryptRequest logs error asynchronously.
+	// ThresholdDecryptRequested itself returns nil because the async goroutine handles the error.
 	err := k.ThresholdDecryptRequested(ctx, 7, []byte("req-key"), []byte("cipher"), []byte("label"), 100)
-	require.Error(t, err, "missing session should return an error")
-	require.Contains(t, err.Error(), "failed to get DKG session for decrypt request")
+	require.NoError(t, err, "async dispatch should not return error to caller")
 }
 
 // TestThresholdDecryptRequested_ValidatorInCommitteeWithSession verifies the happy
 // path: when DKG service is enabled, validator is in committee, and a session exists,
-// the request is added to the session.
+// the request is added to the session asynchronously.
 func TestThresholdDecryptRequested_ValidatorInCommitteeWithSession(t *testing.T) {
 	t.Parallel()
 
@@ -1549,10 +1551,15 @@ func TestThresholdDecryptRequested_ValidatorInCommitteeWithSession(t *testing.T)
 	err := k.ThresholdDecryptRequested(ctx, 8, []byte("req-key"), []byte("cipher"), []byte("label"), 100)
 	require.NoError(t, err)
 
-	// Verify the session has the queued decrypt request
-	session, err := k.stateManager.GetSession(8)
-	require.NoError(t, err)
-	require.Len(t, session.GetDecryptRequests(), 1, "session should have one pending decrypt request")
+	// Wait for the async goroutine to complete
+	require.Eventually(t, func() bool {
+		session, err := k.stateManager.GetSession(8)
+		if err != nil {
+			return false
+		}
+
+		return len(session.GetDecryptRequests()) == 1
+	}, 5*time.Second, 50*time.Millisecond, "session should have one pending decrypt request after async processing")
 }
 
 // TestPartialDecryptionSubmitted_RequestNotFound verifies that when the


### PR DESCRIPTION
## Summary

  Move DKG-service-specific work in `ThresholdDecryptRequested` to an async goroutine to avoid blocking `FinalizeBlock` on DKG-enabled nodes.

  ## Problem

  `ThresholdDecryptRequested` runs synchronously inside `FinalizeBlock`. On DKG-enabled nodes, after passing the early return guards, it performs session lookup (`stateManager.GetSession`), appends the decrypt request (`AddDecryptRequest`), and persists the session (`UpdateSession`) — all while holding up block finalization.

  For blocks containing many `ThresholdDecryptRequested` events, this adds latency to `FinalizeBlock` on DKG-enabled nodes compared to DKG-disabled nodes.

  ## Fix

  Extract the DKG-service work into `handleThresholdDecryptRequest` and dispatch it via `dkgAsyncContext()` goroutine, following the same pattern used by `ProcessDeals`, `ProcessResponses`, and `BeginDealing`.

Close: #777

issue: #777 