### PR TITLE
feat(cdr): add OwnerWriteCondition — stateless, front-run-safe write condition

### DIFF
--- a/contracts/src/protocol/cdr/OwnerWriteCondition.sol
+++ b/contracts/src/protocol/cdr/OwnerWriteCondition.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+/// @title OwnerWriteCondition
+/// @notice Simplest CDR write condition — only the address encoded in writeConditionData can write.
+///         No register() step needed. The authorized writer is set at allocate time via
+///         writeConditionData = abi.encode(ownerAddress).
+///
+/// Usage:
+///   CDR.allocate(updatable, ownerWriteConditionAddr, readConditionAddr,
+///                abi.encode(yourAddress), readConditionData)
+contract OwnerWriteCondition {
+    function checkWriteCondition(
+        uint32,
+        bytes calldata,
+        bytes calldata writeConditionData,
+        address caller
+    ) external pure returns (bool) {
+        address owner = abi.decode(writeConditionData, (address));
+        return caller == owner;
+    }
+}


### PR DESCRIPTION
## Summary

Add `OwnerWriteCondition` — the simplest CDR write condition that is immune to front-run registration attacks (piplabs/lion-team-sync#533).

## How it works

- Authorized writer address is encoded in `writeConditionData` at allocate time
- `checkWriteCondition` decodes and compares `caller == owner`
- No `register()` step, no on-chain state, no front-run window
- Stateless (pure function) — deploy once, shared by all users

## Usage

```solidity
CDR.allocate(
    updatable,
    ownerWriteConditionAddr,
    readConditionAddr,
    abi.encode(yourAddress),  // writeConditionData
    readConditionData
);
```

## Context

Existing condition contracts (WhitelistCondition, FixedFeeCondition, TimeBasedCondition) in cdr-demo all have a front-run vulnerability: `register(uuid)` can be called by anyone before the vault creator. This contract eliminates the issue by storing the authorized writer in CDR vault data instead of condition contract state.