### PR TITLE
feat(dkg): add Prometheus metrics instrumentation

### DIFF
--- a/client/x/dkg/keeper/dkg_finalization.go
+++ b/client/x/dkg/keeper/dkg_finalization.go
@@ -112,6 +112,7 @@ func (k *Keeper) FinalizeDKGRound(ctx context.Context, latestRound *types.DKGNet
 		}()
 	}
 
+	roundsTotal.WithLabelValues("completed").Inc()
 	log.Info(ctx, "DKG network setup completed", "round", latestRound.Round)
 
 	return nil

--- a/client/x/dkg/keeper/dkg_finalization.go
+++ b/client/x/dkg/keeper/dkg_finalization.go
@@ -112,7 +112,7 @@ func (k *Keeper) FinalizeDKGRound(ctx context.Context, latestRound *types.DKGNet
 		}()
 	}
 
-	roundsTotal.WithLabelValues("completed").Inc()
+	roundsTotal.WithLabelValues(labelRoundCompleted).Inc()
 	log.Info(ctx, "DKG network setup completed", "round", latestRound.Round)
 
 	return nil

--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -82,7 +82,7 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 		"start_block", sdkCtx.BlockHeight(),
 		"is_upgrade", isUpgrade,
 	)
-	roundsTotal.WithLabelValues("initiated").Inc()
+	roundsTotal.WithLabelValues(labelRoundInitiated).Inc()
 
 	if err := k.emitBeginDKGInitialization(ctx, &dkgNetwork); err != nil {
 		return errors.Wrap(err, "failed to emit begin dkg initialization event")

--- a/client/x/dkg/keeper/dkg_initialization.go
+++ b/client/x/dkg/keeper/dkg_initialization.go
@@ -82,6 +82,7 @@ func (k *Keeper) InitiateDKGRound(ctx context.Context, isUpgrade bool) error {
 		"start_block", sdkCtx.BlockHeight(),
 		"is_upgrade", isUpgrade,
 	)
+	roundsTotal.WithLabelValues("initiated").Inc()
 
 	if err := k.emitBeginDKGInitialization(ctx, &dkgNetwork); err != nil {
 		return errors.Wrap(err, "failed to emit begin dkg initialization event")

--- a/client/x/dkg/keeper/dkg_round.go
+++ b/client/x/dkg/keeper/dkg_round.go
@@ -48,6 +48,7 @@ func (*Keeper) shouldTransitionStage(currentHeight int64, dkgNetwork *types.DKGN
 }
 
 func (k *Keeper) SkipToNextRound(ctx context.Context, currentRound *types.DKGNetwork) error {
+	roundsTotal.WithLabelValues("skipped").Inc()
 	// Flush all queues to prevent stale data from the failed round
 	// from being broadcast in the new round's vote extensions.
 	k.FlushAllQueues()

--- a/client/x/dkg/keeper/dkg_round.go
+++ b/client/x/dkg/keeper/dkg_round.go
@@ -48,7 +48,7 @@ func (*Keeper) shouldTransitionStage(currentHeight int64, dkgNetwork *types.DKGN
 }
 
 func (k *Keeper) SkipToNextRound(ctx context.Context, currentRound *types.DKGNetwork) error {
-	roundsTotal.WithLabelValues("skipped").Inc()
+	roundsTotal.WithLabelValues(labelRoundSkipped).Inc()
 	// Flush all queues to prevent stale data from the failed round
 	// from being broadcast in the new round's vote extensions.
 	k.FlushAllQueues()

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -165,6 +165,7 @@ func isSessionStuckForStage(phase types.DKGPhase, stage types.DKGStage) bool {
 // resumeFailedSession dispatches a PhaseFailed session to the appropriate handler
 // based on the current DKG network stage.
 func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSession, dkgNetwork *types.DKGNetwork) {
+	sessionRecoveryTotal.Inc()
 	switch dkgNetwork.Stage {
 	case types.DKGStageRegistration:
 		// Pre-compute registration check while SDK context is available.
@@ -379,6 +380,7 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 				"stale_requests", staleCount,
 				"current_height", currentHeight,
 			)
+			incDecryptRequest("stale_dropped", staleCount)
 		}
 
 		if len(validRequests) == 0 {
@@ -485,14 +487,18 @@ func (k *Keeper) batchSubmitConsumer(ctx context.Context, session *types.DKGSess
 				"session", session.GetSessionKey(),
 				"batch_size", len(batch),
 			)
+			incDecryptBatch("error", len(batch))
 			for _, r := range batch {
 				session.AddDecryptRequest(r.req)
 			}
+			incDecryptRequest("requeued", len(batch))
 		} else {
 			log.Info(ctx, "Successfully submitted partial decryption batch",
 				"session", session.GetSessionKey(),
 				"batch_size", len(batch),
 			)
+			incDecryptBatch("success", len(batch))
+			incDecryptRequest("submitted", len(batch))
 		}
 		batch = batch[:0]
 	}
@@ -505,6 +511,7 @@ func (k *Keeper) batchSubmitConsumer(ctx context.Context, session *types.DKGSess
 				"round", r.req.Round,
 			)
 			session.AddDecryptRequest(r.req)
+			incDecryptRequest("kernel_failed", 1)
 			continue
 		}
 		batch = append(batch, r)
@@ -544,6 +551,7 @@ func (k *Keeper) computePartialDecrypt(ctx context.Context, session *types.DKGSe
 		RequesterPubKey: req.RequesterPubKey,
 	})
 	kernelDuration := time.Since(kernelStart)
+	observeKernelCall("partial_decrypt_tdh2", kernelStart, err)
 
 	if err != nil {
 		result.err = errors.Wrap(err, "generating partial decrypt failed")
@@ -633,13 +641,24 @@ func labelToUUID(label []byte) (uint32, error) {
 // If the initial lookup fails, it attempts to reconnect any disconnected endpoints
 // and retries the lookup once. This handles the case where story started before kernel.
 func (k *Keeper) getClientWithReconnect(codeCommitment []byte) (types.KernelServiceClient, error) {
+	start := time.Now()
+
 	client, err := k.kernelRouter.GetClient(codeCommitment)
 	if err == nil {
+		kernelClientLookupDuration.WithLabelValues("hit").Observe(time.Since(start).Seconds())
 		return client, nil
 	}
 
 	k.kernelRouter.TryReconnect()
 	log.Info(context.Background(), "Retrying kernel client lookup after reconnect", "code_commitment", hex.EncodeToString(codeCommitment))
 
-	return k.kernelRouter.GetClient(codeCommitment)
+	client, err = k.kernelRouter.GetClient(codeCommitment)
+	if err != nil {
+		kernelClientLookupDuration.WithLabelValues("error").Observe(time.Since(start).Seconds())
+		return nil, err
+	}
+
+	kernelClientLookupDuration.WithLabelValues("reconnect").Observe(time.Since(start).Seconds())
+
+	return client, nil
 }

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -380,7 +380,7 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 				"stale_requests", staleCount,
 				"current_height", currentHeight,
 			)
-			incDecryptRequest("stale_dropped", staleCount)
+			incDecryptRequest(labelDecryptStaleDropped, staleCount)
 		}
 
 		if len(validRequests) == 0 {
@@ -487,18 +487,18 @@ func (k *Keeper) batchSubmitConsumer(ctx context.Context, session *types.DKGSess
 				"session", session.GetSessionKey(),
 				"batch_size", len(batch),
 			)
-			incDecryptBatch("error", len(batch))
+			incDecryptBatch(labelBatchError, len(batch))
 			for _, r := range batch {
 				session.AddDecryptRequest(r.req)
 			}
-			incDecryptRequest("requeued", len(batch))
+			incDecryptRequest(labelDecryptRequeued, len(batch))
 		} else {
 			log.Info(ctx, "Successfully submitted partial decryption batch",
 				"session", session.GetSessionKey(),
 				"batch_size", len(batch),
 			)
-			incDecryptBatch("success", len(batch))
-			incDecryptRequest("submitted", len(batch))
+			incDecryptBatch(labelBatchSuccess, len(batch))
+			incDecryptRequest(labelDecryptSubmitted, len(batch))
 		}
 		batch = batch[:0]
 	}
@@ -511,7 +511,7 @@ func (k *Keeper) batchSubmitConsumer(ctx context.Context, session *types.DKGSess
 				"round", r.req.Round,
 			)
 			session.AddDecryptRequest(r.req)
-			incDecryptRequest("kernel_failed", 1)
+			incDecryptRequest(labelDecryptKernelFailed, 1)
 			continue
 		}
 		batch = append(batch, r)
@@ -551,7 +551,7 @@ func (k *Keeper) computePartialDecrypt(ctx context.Context, session *types.DKGSe
 		RequesterPubKey: req.RequesterPubKey,
 	})
 	kernelDuration := time.Since(kernelStart)
-	observeKernelCall("partial_decrypt_tdh2", kernelStart, err)
+	observeKernelCall(labelOpPartialDecryptTDH2, kernelStart, err)
 
 	if err != nil {
 		result.err = errors.Wrap(err, "generating partial decrypt failed")
@@ -645,7 +645,7 @@ func (k *Keeper) getClientWithReconnect(codeCommitment []byte) (types.KernelServ
 
 	client, err := k.kernelRouter.GetClient(codeCommitment)
 	if err == nil {
-		kernelClientLookupDuration.WithLabelValues("hit").Observe(time.Since(start).Seconds())
+		kernelClientLookupDuration.WithLabelValues(labelLookupHit).Observe(time.Since(start).Seconds())
 		return client, nil
 	}
 
@@ -654,11 +654,11 @@ func (k *Keeper) getClientWithReconnect(codeCommitment []byte) (types.KernelServ
 
 	client, err = k.kernelRouter.GetClient(codeCommitment)
 	if err != nil {
-		kernelClientLookupDuration.WithLabelValues("error").Observe(time.Since(start).Seconds())
+		kernelClientLookupDuration.WithLabelValues(labelLookupError).Observe(time.Since(start).Seconds())
 		return nil, err
 	}
 
-	kernelClientLookupDuration.WithLabelValues("reconnect").Observe(time.Since(start).Seconds())
+	kernelClientLookupDuration.WithLabelValues(labelLookupReconnect).Observe(time.Since(start).Seconds())
 
 	return client, nil
 }

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -94,7 +94,7 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 
 		return nil
 	})
-	observeKernelCall("generate_deals", start, retryErr)
+	observeKernelCall(labelOpGenerateDeals, start, retryErr)
 
 	if retryErr != nil {
 		log.Error(ctx, "Failed to generate deals", retryErr)
@@ -205,7 +205,7 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 
 		return nil
 	})
-	observeKernelCall("process_deals", start, retryErr)
+	observeKernelCall(labelOpProcessDeals, start, retryErr)
 
 	if retryErr != nil {
 		// "all N submitted deals were rejected" means every deal was already processed
@@ -259,7 +259,7 @@ func cachePendingIncomingDeals(allDeals []types.Deal, sessionIndex uint32) int {
 		}
 	}
 
-	incPendingData("deals", "cached", cached)
+	incPendingData(labelPendingDeals, labelPendingCached, cached)
 
 	return cached
 }
@@ -353,7 +353,7 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 
 			return nil
 		})
-		observeKernelCall("process_responses", start, retryErr)
+		observeKernelCall(labelOpProcessResponses, start, retryErr)
 
 		if retryErr != nil {
 			log.Error(ctx, "Failed to process responses", retryErr,
@@ -434,7 +434,7 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 
 			return nil
 		})
-		observeKernelCall("process_justifications", start, retryErr)
+		observeKernelCall(labelOpProcessJustifications, start, retryErr)
 
 		if retryErr != nil {
 			cached := cachePendingIncomingJustifications(justifications)
@@ -489,7 +489,7 @@ func cachePendingIncomingResponses(filteredResponses []types.Response) {
 	}
 
 	pendingIncomingResponses = append(pendingIncomingResponses, filteredResponses...)
-	incPendingData("responses", "cached", len(filteredResponses))
+	incPendingData(labelPendingResponses, labelPendingCached, len(filteredResponses))
 }
 
 // cachePendingIncomingJustifications saves justifications that failed kernel processing for later retry.
@@ -508,7 +508,7 @@ func cachePendingIncomingJustifications(justifications []types.Justification) in
 	}
 
 	pendingIncomingJustifications = append(pendingIncomingJustifications, justifications...)
-	incPendingData("justifications", "cached", len(justifications))
+	incPendingData(labelPendingJustifications, labelPendingCached, len(justifications))
 
 	return len(justifications)
 }
@@ -578,7 +578,7 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 			)
 
 			k.handleDKGProcessDeals(asyncCtx, dkgNetwork, drainedDeals)
-			incPendingData("deals", "replayed", len(drainedDeals))
+			incPendingData(labelPendingDeals, labelPendingReplayed, len(drainedDeals))
 		}
 
 		// Then process responses.
@@ -591,7 +591,7 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 			)
 
 			k.handleDKGProcessResponses(asyncCtx, dkgNetwork, drainedResponses, true)
-			incPendingData("responses", "replayed", len(drainedResponses))
+			incPendingData(labelPendingResponses, labelPendingReplayed, len(drainedResponses))
 		}
 
 		// Finally process justifications (already verified before caching,
@@ -605,7 +605,7 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 			)
 
 			k.handleDKGProcessJustifications(asyncCtx, dkgNetwork, drainedJustifications)
-			incPendingData("justifications", "replayed", len(drainedJustifications))
+			incPendingData(labelPendingJustifications, labelPendingReplayed, len(drainedJustifications))
 		}
 	}()
 }

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
@@ -69,7 +70,8 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 
 	var resp *types.GenerateDealsResponse
 
-	if err := retry(ctx, func(ctx context.Context) error {
+	start := time.Now()
+	retryErr := retry(ctx, func(ctx context.Context) error {
 		log.Info(ctx, "GenerateDeals call to kernel client",
 			"round", session.Round,
 			"is_upgrade", dkgNetwork.IsUpgrade,
@@ -91,8 +93,11 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 		}
 
 		return nil
-	}); err != nil {
-		log.Error(ctx, "Failed to generate deals", err)
+	})
+	observeKernelCall("generate_deals", start, retryErr)
+
+	if retryErr != nil {
+		log.Error(ctx, "Failed to generate deals", retryErr)
 		k.stateManager.MarkFailed(ctx, session)
 
 		return
@@ -173,7 +178,8 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 
 	var resp *types.ProcessDealsResponse
 
-	if err := retry(ctx, func(ctx context.Context) error {
+	start := time.Now()
+	retryErr := retry(ctx, func(ctx context.Context) error {
 		log.Info(ctx, "ProcessDeals call to kernel client",
 			"round", session.Round,
 			"total_deals", len(deals),
@@ -198,12 +204,15 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 		}
 
 		return nil
-	}); err != nil {
+	})
+	observeKernelCall("process_deals", start, retryErr)
+
+	if retryErr != nil {
 		// "all N submitted deals were rejected" means every deal was already processed
 		// by kyber (duplicate delivery via consecutive vote extensions). Retrying the
 		// same data will always fail, so drop instead of caching.
-		if status.Code(err) == codes.InvalidArgument && strings.Contains(status.Convert(err).Message(), "submitted deals were rejected") {
-			log.Warn(ctx, "All deals already processed by kernel; dropping duplicates", err,
+		if status.Code(retryErr) == codes.InvalidArgument && strings.Contains(status.Convert(retryErr).Message(), "submitted deals were rejected") {
+			log.Warn(ctx, "All deals already processed by kernel; dropping duplicates", retryErr,
 				"round", dkgNetwork.Round,
 			)
 
@@ -214,7 +223,7 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 		// Not persisted to disk — process restart loses them (round will fail and retry).
 		cached := cachePendingIncomingDeals(filteredDeals, session.Index)
 
-		log.Error(ctx, "Failed to process deals; cached for retry", err,
+		log.Error(ctx, "Failed to process deals; cached for retry", retryErr,
 			"round", dkgNetwork.Round,
 			"cached_deals", cached,
 		)
@@ -249,6 +258,8 @@ func cachePendingIncomingDeals(allDeals []types.Deal, sessionIndex uint32) int {
 			cached++
 		}
 	}
+
+	incPendingData("deals", "cached", cached)
 
 	return cached
 }
@@ -316,7 +327,8 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 	for _, cc := range ccsToProcess {
 		var processResp *types.ProcessResponsesResponse
 
-		if err := retry(ctx, func(ctx context.Context) error {
+		start := time.Now()
+		retryErr := retry(ctx, func(ctx context.Context) error {
 			log.Info(ctx, "ProcessResponses call to kernel client",
 				"round", session.Round,
 				"num_responses", len(filteredResponses),
@@ -340,8 +352,11 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 			}
 
 			return nil
-		}); err != nil {
-			log.Error(ctx, "Failed to process responses", err,
+		})
+		observeKernelCall("process_responses", start, retryErr)
+
+		if retryErr != nil {
+			log.Error(ctx, "Failed to process responses", retryErr,
 				"code_commitment", hex.EncodeToString(cc),
 			)
 
@@ -399,7 +414,8 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 	}
 
 	for _, cc := range ccsToProcess {
-		if err := retry(ctx, func(ctx context.Context) error {
+		start := time.Now()
+		retryErr := retry(ctx, func(ctx context.Context) error {
 			req := &types.ProcessJustificationRequest{
 				CodeCommitment: cc,
 				Round:          session.Round,
@@ -417,10 +433,13 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 			}
 
 			return nil
-		}); err != nil {
+		})
+		observeKernelCall("process_justifications", start, retryErr)
+
+		if retryErr != nil {
 			cached := cachePendingIncomingJustifications(justifications)
 
-			log.Error(ctx, "Failed to process justifications via kernel; cached for retry", err,
+			log.Error(ctx, "Failed to process justifications via kernel; cached for retry", retryErr,
 				"round", dkgNetwork.Round,
 				"code_commitment", hex.EncodeToString(cc),
 				"cached_justifications", cached,
@@ -470,6 +489,7 @@ func cachePendingIncomingResponses(filteredResponses []types.Response) {
 	}
 
 	pendingIncomingResponses = append(pendingIncomingResponses, filteredResponses...)
+	incPendingData("responses", "cached", len(filteredResponses))
 }
 
 // cachePendingIncomingJustifications saves justifications that failed kernel processing for later retry.
@@ -488,6 +508,7 @@ func cachePendingIncomingJustifications(justifications []types.Justification) in
 	}
 
 	pendingIncomingJustifications = append(pendingIncomingJustifications, justifications...)
+	incPendingData("justifications", "cached", len(justifications))
 
 	return len(justifications)
 }
@@ -557,6 +578,7 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 			)
 
 			k.handleDKGProcessDeals(asyncCtx, dkgNetwork, drainedDeals)
+			incPendingData("deals", "replayed", len(drainedDeals))
 		}
 
 		// Then process responses.
@@ -569,6 +591,7 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 			)
 
 			k.handleDKGProcessResponses(asyncCtx, dkgNetwork, drainedResponses, true)
+			incPendingData("responses", "replayed", len(drainedResponses))
 		}
 
 		// Finally process justifications (already verified before caching,
@@ -582,6 +605,7 @@ func (k *Keeper) reprocessPendingIncomingData(dkgNetwork *types.DKGNetwork) {
 			)
 
 			k.handleDKGProcessJustifications(asyncCtx, dkgNetwork, drainedJustifications)
+			incPendingData("justifications", "replayed", len(drainedJustifications))
 		}
 	}()
 }

--- a/client/x/dkg/keeper/dkg_svc_finalization.go
+++ b/client/x/dkg/keeper/dkg_svc_finalization.go
@@ -117,7 +117,7 @@ func (k *Keeper) callTEEFinalizeDKG(ctx context.Context, session *types.DKGSessi
 
 		return nil
 	})
-	observeKernelCall("finalize_dkg", start, retryErr)
+	observeKernelCall(labelOpFinalizeDKG, start, retryErr)
 
 	if retryErr != nil {
 		return errors.Wrap(retryErr, "kernel client Finalize request failed")

--- a/client/x/dkg/keeper/dkg_svc_finalization.go
+++ b/client/x/dkg/keeper/dkg_svc_finalization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"slices"
+	"time"
 
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
@@ -96,7 +97,8 @@ func (k *Keeper) callTEEFinalizeDKG(ctx context.Context, session *types.DKGSessi
 		resp *types.FinalizeDKGResponse
 		err  error
 	)
-	if err := retry(ctx, func(ctx context.Context) error {
+	start := time.Now()
+	retryErr := retry(ctx, func(ctx context.Context) error {
 		req := &types.FinalizeDKGRequest{
 			CodeCommitment: session.CodeCommitment,
 			Round:          session.Round,
@@ -114,8 +116,11 @@ func (k *Keeper) callTEEFinalizeDKG(ctx context.Context, session *types.DKGSessi
 		}
 
 		return nil
-	}); err != nil {
-		return errors.Wrap(err, "kernel client Finalize request failed")
+	})
+	observeKernelCall("finalize_dkg", start, retryErr)
+
+	if retryErr != nil {
+		return errors.Wrap(retryErr, "kernel client Finalize request failed")
 	}
 
 	session.ParticipantsRoot = resp.GetParticipantsRoot()

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"slices"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -153,7 +154,8 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 		resp *types.GenerateAndSealKeyResponse
 		err  error
 	)
-	if err := retry(ctx, func(ctx context.Context) error {
+	start := time.Now()
+	retryErr := retry(ctx, func(ctx context.Context) error {
 		req := &types.GenerateAndSealKeyRequest{
 			Address:        k.validatorEVMAddr,
 			CodeCommitment: session.CodeCommitment,
@@ -166,8 +168,11 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 		}
 
 		return nil
-	}); err != nil {
-		return errors.Wrap(err, "kernel client GenerateAndSealKey request failed")
+	})
+	observeKernelCall("generate_and_seal_key", start, retryErr)
+
+	if retryErr != nil {
+		return errors.Wrap(retryErr, "kernel client GenerateAndSealKey request failed")
 	}
 
 	// Persist the code commitment from the TEE response for future routing

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -169,7 +169,7 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 
 		return nil
 	})
-	observeKernelCall("generate_and_seal_key", start, retryErr)
+	observeKernelCall(labelOpGenerateAndSealKey, start, retryErr)
 
 	if retryErr != nil {
 		return errors.Wrap(retryErr, "kernel client GenerateAndSealKey request failed")

--- a/client/x/dkg/keeper/metrics.go
+++ b/client/x/dkg/keeper/metrics.go
@@ -1,0 +1,110 @@
+package keeper
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	roundsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "rounds_total",
+		Help:      "Total number of DKG rounds by result (initiated, completed, skipped)",
+	}, []string{"result"})
+
+	kernelCallDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "kernel_call_duration_seconds",
+		Help:      "Duration of kernel gRPC calls in seconds by operation",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"operation"})
+
+	kernelCallTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "kernel_call_total",
+		Help:      "Total number of kernel gRPC calls by operation and result",
+	}, []string{"operation", "result"})
+
+	decryptRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "decrypt_request_total",
+		Help:      "Total number of decrypt requests by result (stale_dropped, kernel_failed, requeued, submitted)",
+	}, []string{"result"})
+
+	decryptBatchTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "decrypt_batch_total",
+		Help:      "Total number of decrypt batch submissions by result",
+	}, []string{"result"})
+
+	decryptBatchSize = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "decrypt_batch_size",
+		Help:      "Number of partial decryptions per successful batch submission",
+		Buckets:   []float64{1, 5, 10, 15, 20, 25},
+	})
+
+	pendingDataTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "pending_data_total",
+		Help:      "Total DKG pending data items by type (deals, responses, justifications) and op (cached, replayed)",
+	}, []string{"type", "op"})
+
+	sessionRecoveryTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "session_recovery_total",
+		Help:      "Total number of failed DKG sessions dispatched for recovery",
+	})
+
+	kernelClientLookupDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "story",
+		Subsystem: "dkg",
+		Name:      "kernel_client_lookup_duration_seconds",
+		Help:      "Duration of getClientWithReconnect by result (hit, reconnect, error)",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"result"})
+)
+
+// observeKernelCall records duration and result for a single kernel gRPC operation.
+// Call it immediately after the retry block resolves, passing the start time and
+// the error returned by retry (nil on success).
+func observeKernelCall(operation string, start time.Time, err error) {
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+
+	kernelCallDuration.WithLabelValues(operation).Observe(time.Since(start).Seconds())
+	kernelCallTotal.WithLabelValues(operation, result).Inc()
+}
+
+// incDecryptRequest adds n to the decrypt_request_total counter for result.
+// result values: "stale_dropped", "kernel_failed", "requeued", "submitted".
+func incDecryptRequest(result string, n int) {
+	decryptRequestTotal.WithLabelValues(result).Add(float64(n))
+}
+
+// incDecryptBatch records a batch submission attempt.
+// On success it also observes the batch size histogram.
+func incDecryptBatch(result string, size int) {
+	decryptBatchTotal.WithLabelValues(result).Inc()
+	if result == "success" {
+		decryptBatchSize.Observe(float64(size))
+	}
+}
+
+// incPendingData adds n to the pending_data_total counter for (typ, op).
+// typ: "deals", "responses", "justifications". op: "cached", "replayed".
+func incPendingData(typ, op string, n int) {
+	pendingDataTotal.WithLabelValues(typ, op).Add(float64(n))
+}

--- a/client/x/dkg/keeper/metrics.go
+++ b/client/x/dkg/keeper/metrics.go
@@ -7,6 +7,58 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Label values for roundsTotal "result" label.
+const (
+	labelRoundInitiated = "initiated"
+	labelRoundCompleted = "completed"
+	labelRoundSkipped   = "skipped"
+)
+
+// Label values for kernelCallDuration/Total "operation" label.
+const (
+	labelOpGenerateAndSealKey    = "generate_and_seal_key"
+	labelOpGenerateDeals         = "generate_deals"
+	labelOpProcessDeals          = "process_deals"
+	labelOpProcessResponses      = "process_responses"
+	labelOpProcessJustifications = "process_justifications"
+	labelOpFinalizeDKG           = "finalize_dkg"
+	labelOpPartialDecryptTDH2    = "partial_decrypt_tdh2"
+)
+
+// Label values for decryptRequestTotal "result" label.
+const (
+	labelDecryptStaleDropped = "stale_dropped"
+	labelDecryptKernelFailed = "kernel_failed"
+	labelDecryptRequeued     = "requeued"
+	labelDecryptSubmitted    = "submitted"
+)
+
+// Label values for decryptBatchTotal "result" label.
+const (
+	labelBatchSuccess = "success"
+	labelBatchError   = "error"
+)
+
+// Label values for pendingDataTotal "type" label.
+const (
+	labelPendingDeals          = "deals"
+	labelPendingResponses      = "responses"
+	labelPendingJustifications = "justifications"
+)
+
+// Label values for pendingDataTotal "op" label.
+const (
+	labelPendingCached   = "cached"
+	labelPendingReplayed = "replayed"
+)
+
+// Label values for kernelClientLookupDuration "result" label.
+const (
+	labelLookupHit       = "hit"
+	labelLookupReconnect = "reconnect"
+	labelLookupError     = "error"
+)
+
 var (
 	roundsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "story",


### PR DESCRIPTION
## Summary
Add Prometheus metrics to the DKG module to make the round lifecycle, kernel gRPC calls, threshold-decrypt queue, pending-data cache, and kernel client routing observable at runtime.

All metrics are exposed via CometBFT's existing /metrics endpoint (enabled by setting `prometheus = true` in `config.toml`) — no additional HTTP server or code changes required.

### Metrics Added
Metric | Type | Labels | Description
-- | -- | -- | --
story_dkg_rounds_total | Counter | result | Rounds initiated / completed / skipped
story_dkg_kernel_call_duration_seconds | Histogram | operation | Kernel gRPC call latency
story_dkg_kernel_call_total | Counter | operation, result | Kernel gRPC call count by outcome
story_dkg_kernel_client_lookup_duration_seconds | Histogram | result | getClientWithReconnect latency (hit / reconnect / error)
story_dkg_decrypt_request_total | Counter | result | Decrypt requests by disposition (submitted / stale_dropped / kernel_failed / requeued)
story_dkg_decrypt_batch_total | Counter | result | Batch submission count
story_dkg_decrypt_batch_size | Histogram | — | Items per successful batch submission
story_dkg_pending_data_total | Counter | type, op | Pending cache activity (cached / replayed) for deals, responses, justifications
story_dkg_session_recovery_total | Counter | — | Failed sessions dispatched for recovery

