### PR TITLE
feat(dkg): expose GetCDRPartials through story-api

### DIFF
--- a/client/server/README.md
+++ b/client/server/README.md
@@ -1518,6 +1518,76 @@ Round 1 on Aeneid still has 5 entries in `Verified` status. `enclave_report` is 
 }
 ```
 
+## GetCDRPartials
+
+URL: [GET] /dkg/cdr_partials
+
+Returns the partial decryption submissions stored for a `(uuid, requesterPubKey)` pair, grouped by DKG round and ciphertext. Within each group the response carries the round's `threshold` and a precomputed `threshold_met` flag so callers do not need to query the network separately.
+
+`requester_pub_key_hex` is the hex encoding of the requester's public key as used when the decrypt request was submitted on-chain. A leading `0x` (or `0X`) prefix is accepted and stripped before decoding. Internally the keeper iterates the partial-decryption store under the `(requester_pub_key, label)` prefix where `label` is the 32-byte big-endian encoding of `uuid`.
+
+Bytes-typed fields (`encrypted_partial`, `ephemeral_pub_key`, `pub_share`, `label`, `ciphertext`) are encoded as base64 strings on the wire.
+
+### Query Params
+| Name                  | Type   | Example                                                       | Required |
+|-----------------------|--------|---------------------------------------------------------------|----------|
+| uuid                  | uint32 | 42                                                            |    ✔     |
+| requester_pub_key_hex | string | `0x048a70…` (hex, `0x`/`0X` prefix optional; 65-byte pubkey)  |    ✔     |
+
+The server-wide envelope is `{"code": <int>, "msg": ..., "error": <string>}`. On success, HTTP status is 200, `code` is 200, and `msg` carries the response. On any error (validation, keeper, encoding) the framework currently returns HTTP 500 with `{"code": 500, "msg": null, "error": "<message>"}` regardless of the underlying error category — see `client/server/utils/wrap.go`. Validation errors emitted before the keeper is reached:
+
+- "requester_pub_key_hex is required" — missing/empty (or just `0x` after stripping)
+- "requester_pub_key_hex must be valid hex: …" — non-hex characters or odd-length
+- "requester_pub_key_hex must decode to an uncompressed secp256k1 public key (65 bytes)" — wrong length
+- "uuid out of range" — `uuid > math.MaxUint32-1` (the CDR contract enforces `uuid < type(uint32).max` at allocation)
+
+Keeper-side miss surfaces as `rpc error: code = NotFound desc = partial decryption submission not found` (also HTTP 500 today).
+
+### Response Example
+
+Two of three validators have submitted partials for round 6, ciphertext `Q…`, so `threshold_met` is `false` (threshold is 3). Long byte fields are truncated.
+
+```json
+{
+  "code": 200,
+  "msg": {
+    "submissions": [
+      {
+        "round": 6,
+        "submissions": [
+          {
+            "validator": "0x38D44fC22C6EC6BF43F6776aE986ECCAa55EbA84",
+            "round": 6,
+            "pid": 1,
+            "encrypted_partial": "BD/epjiGun5PcXZxWKOY... (truncated)",
+            "ephemeral_pub_key": "BD/bQKBszsJwi6Ok5LGL... (truncated)",
+            "pub_share": "BD/epjiGun5PcXZxWKOYLytQPn0+yh2sXLFevagcm/muow==",
+            "label": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACo=",
+            "ciphertext": "QwAB... (truncated)"
+          },
+          {
+            "validator": "0x816020985Ffd8ac7852BaA23e7664461E194c1Bc",
+            "round": 6,
+            "pid": 5,
+            "encrypted_partial": "Z5762cEL4N0UG4hW80y/... (truncated)",
+            "ephemeral_pub_key": "FXkfHHve0rkE0EOaJEuo... (truncated)",
+            "pub_share": "BD/bQKBszsJwi6Ok5LGLjDa2ALIIEjTEwk2MiRTXikoWfQ==",
+            "label": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACo=",
+            "ciphertext": "QwAB... (truncated)"
+          }
+        ],
+        "ciphertext": "QwAB... (truncated)",
+        "threshold": 3,
+        "threshold_met": false
+      }
+    ]
+  },
+  "error": ""
+}
+```
+
+`label` decodes to the 32-byte big-endian uuid; the lower 4 bytes carry the value (here `0x0000002a` for uuid `42`), the upper 28 bytes are zero. Submissions in different rounds appear as separate elements in `submissions[]` and are sorted ascending by `(round, ciphertext)`.
+
 ## GetLatestActiveDKGNetwork
 
 URL: [GET] /dkg/latest_active

--- a/client/server/dkg.go
+++ b/client/server/dkg.go
@@ -15,6 +15,7 @@ func (s *Server) initDKGRoute() {
 	s.httpMux.HandleFunc("/dkg/registrations/verified", utils.AutoWrap(s.aminoCodec, s.GetVerifiedDKGRegistrations))
 	s.httpMux.HandleFunc("/dkg/latest_active", utils.SimpleWrap(s.aminoCodec, s.GetLatestActiveDKGNetwork))
 	s.httpMux.HandleFunc("/dkg/global_public_key", utils.SimpleWrap(s.aminoCodec, s.GetDKGGlobalPubKey))
+	s.httpMux.HandleFunc("/dkg/cdr_partials", utils.AutoWrap(s.aminoCodec, s.GetCDRPartials))
 }
 
 func (s *Server) GetDKGNetwork(req *getDKGNetworkRequest, r *http.Request) (resp any, err error) {
@@ -77,6 +78,29 @@ func (s *Server) GetLatestActiveDKGNetwork(r *http.Request) (resp any, err error
 	}
 
 	queryResp, err := s.store.GetDKGKeeper().GetLatestActiveDKGNetwork(queryContext, &dkgtypes.QueryGetLatestActiveDKGNetworkRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return queryResp, nil
+}
+
+// GetCDRPartials returns partial decryption submissions for the given
+// (uuid, requesterPubKey) pair, grouped by DKG round and ciphertext.
+func (s *Server) GetCDRPartials(req *getCDRPartialsRequest, r *http.Request) (resp any, err error) {
+	if err := req.validate(); err != nil {
+		return nil, err
+	}
+
+	queryContext, err := s.createQueryContextByHeader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	queryResp, err := s.store.GetDKGKeeper().GetCDRPartials(queryContext, &dkgtypes.QueryGetCDRPartialsRequest{
+		Uuid:               req.Uuid,
+		RequesterPubKeyHex: req.RequesterPubKeyHex,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/client/server/dkg_test.go
+++ b/client/server/dkg_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCDRPartialsRequest_Validate(t *testing.T) {
+	const validPubKeyHex = "048a706c17a85f0d1acf8789489568c8f154f415642164397c21c16fa6e380642d" +
+		"795e6aceb661560fa5672a73ab9a30252ec4995ed096bde2b378d7991ce1150f"
+	require.Len(t, validPubKeyHex, 2*requesterPubKeyByteLen)
+
+	tests := []struct {
+		name      string
+		req       getCDRPartialsRequest
+		expectErr string
+	}{
+		{
+			name: "valid request",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: validPubKeyHex,
+			},
+		},
+		{
+			name: "valid request with uuid 0",
+			req: getCDRPartialsRequest{
+				Uuid:               0,
+				RequesterPubKeyHex: validPubKeyHex,
+			},
+		},
+		{
+			name: "valid request with uuid at max allowed",
+			req: getCDRPartialsRequest{
+				Uuid:               maxCDRUuid,
+				RequesterPubKeyHex: validPubKeyHex,
+			},
+		},
+		{
+			name: "empty pubkey hex",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: "",
+			},
+			expectErr: "requester_pub_key_hex is required",
+		},
+		{
+			name: "missing pubkey hex (zero value)",
+			req: getCDRPartialsRequest{
+				Uuid: 42,
+			},
+			expectErr: "requester_pub_key_hex is required",
+		},
+		{
+			name: "non-hex characters",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: strings.Repeat("z", 2*requesterPubKeyByteLen),
+			},
+			expectErr: "requester_pub_key_hex must be valid hex",
+		},
+		{
+			name: "odd-length hex",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: validPubKeyHex[:len(validPubKeyHex)-1],
+			},
+			expectErr: "requester_pub_key_hex must be valid hex",
+		},
+		{
+			name: "valid hex but wrong length (too short)",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: "02a1b2c3",
+			},
+			expectErr: "uncompressed secp256k1 public key",
+		},
+		{
+			name: "valid hex but wrong length (too long)",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: validPubKeyHex + "00",
+			},
+			expectErr: "uncompressed secp256k1 public key",
+		},
+		{
+			name: "uuid above max",
+			req: getCDRPartialsRequest{
+				Uuid:               stdmath.MaxUint32,
+				RequesterPubKeyHex: validPubKeyHex,
+			},
+			expectErr: "uuid out of range",
+		},
+		{
+			name: "valid request with 0x prefix",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: "0x" + validPubKeyHex,
+			},
+		},
+		{
+			name: "valid request with 0X prefix",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: "0X" + validPubKeyHex,
+			},
+		},
+		{
+			name: "0x prefix only (empty after strip)",
+			req: getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: "0x",
+			},
+			expectErr: "requester_pub_key_hex is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.validate()
+			if tt.expectErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectErr)
+			}
+		})
+	}
+}
+
+// TestGetCDRPartialsRequest_Validate_StripsHexPrefix verifies that validate()
+// normalizes RequesterPubKeyHex by stripping a leading `0x`/`0X` prefix in
+// place, so the downstream keeper sees the canonical no-prefix form.
+func TestGetCDRPartialsRequest_Validate_StripsHexPrefix(t *testing.T) {
+	const validPubKeyHex = "048a706c17a85f0d1acf8789489568c8f154f415642164397c21c16fa6e380642d" +
+		"795e6aceb661560fa5672a73ab9a30252ec4995ed096bde2b378d7991ce1150f"
+
+	for _, prefix := range []string{"0x", "0X"} {
+		t.Run(prefix, func(t *testing.T) {
+			req := getCDRPartialsRequest{
+				Uuid:               42,
+				RequesterPubKeyHex: prefix + validPubKeyHex,
+			}
+			require.NoError(t, req.validate())
+			require.Equal(t, validPubKeyHex, req.RequesterPubKeyHex)
+		})
+	}
+}

--- a/client/server/payload.go
+++ b/client/server/payload.go
@@ -1,10 +1,24 @@
 package server
 
 import (
+	"encoding/hex"
+	stdmath "math"
+	"strings"
+
 	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"github.com/piplabs/story/lib/errors"
 )
+
+// requesterPubKeyByteLen is the length of an uncompressed secp256k1 public key.
+const requesterPubKeyByteLen = 65
+
+// maxCDRUuid is the maximum vault uuid the CDR contract can allocate. The
+// contract enforces `require($.uuid < type(uint32).max)` before assigning a
+// new uuid, so valid uuids fall in [0, math.MaxUint32-1].
+const maxCDRUuid = stdmath.MaxUint32 - 1
 
 type pagination struct {
 	Key        string `mapstructure:"key"`
@@ -137,6 +151,34 @@ type getVerifiedDKGRegistrationsRequest struct {
 	Round uint32 `mapstructure:"round"`
 	// Deprecated: accepted but ignored — the keeper scopes results only by round.
 	CodeCommitmentHex string `mapstructure:"code_commitment_hex"`
+}
+
+type getCDRPartialsRequest struct {
+	Uuid               uint32 `mapstructure:"uuid"`
+	RequesterPubKeyHex string `mapstructure:"requester_pub_key_hex"`
+}
+
+func (r *getCDRPartialsRequest) validate() error {
+	// Accept both `0x`-prefixed and bare hex; normalize the field in place so
+	// the keeper sees the canonical (no-prefix) form.
+	if len(r.RequesterPubKeyHex) >= 2 && strings.EqualFold(r.RequesterPubKeyHex[:2], "0x") {
+		r.RequesterPubKeyHex = r.RequesterPubKeyHex[2:]
+	}
+	if r.RequesterPubKeyHex == "" {
+		return errors.New("requester_pub_key_hex is required")
+	}
+	pubKey, err := hex.DecodeString(r.RequesterPubKeyHex)
+	if err != nil {
+		return errors.Wrap(err, "requester_pub_key_hex must be valid hex")
+	}
+	if len(pubKey) != requesterPubKeyByteLen {
+		return errors.New("requester_pub_key_hex must decode to an uncompressed secp256k1 public key (65 bytes)")
+	}
+	if r.Uuid > maxCDRUuid {
+		return errors.New("uuid out of range")
+	}
+
+	return nil
 }
 
 type QueryDKGGlobalPublicKeyResponse struct {


### PR DESCRIPTION
## Summary

Wires up a REST handler for the existing `GetCDRPartials` keeper query so clients can collect partial decryption submissions for a given `(uuid, requesterPubKey)` pair over REST. Closes the gap raised in [#803 (comment)](https://github.com/piplabs/story/pull/803#issuecomment-4323990727).

## Endpoint

GET /dkg/cdr_partials?uuid=&requester_pub_key_hex=

The server-wide envelope is `{"code": <int>, "msg": ..., "error": <string>}`. Success → HTTP 200. Any error (validation, keeper miss) → HTTP 500 with the message in `error`. REST-layer validation runs before the keeper:

- empty / `0x`-only pubkey → `requester_pub_key_hex is required`
- non-hex / odd-length → `requester_pub_key_hex must be valid hex`
- decoded length ≠ 65 → must be uncompressed secp256k1 (65 bytes)
- `uuid > math.MaxUint32-1` → `uuid out of range`

A leading `0x`/`0X` prefix is accepted (stripped before decoding).

issue: none