### PR TITLE
fix(dkg): track pending txs in ContractClient to avoid nonce gaps on timeout

### DIFF
--- a/client/x/dkg/keeper/contract_client.go
+++ b/client/x/dkg/keeper/contract_client.go
@@ -514,9 +514,13 @@ func (c *ContractClient) checkAndResumePendingTx(ctx context.Context, key string
 		return nil, nil
 	}
 
-	receipt, _ := c.ethClient.TransactionReceipt(ctx, tx.Hash())
+	receipt, err := c.ethClient.TransactionReceipt(ctx, tx.Hash())
 	if receipt == nil {
-		return nil, errors.New("previous tx still pending, skipping to avoid nonce gap",
+		if errors.Is(err, ethereum.NotFound) {
+			return nil, errors.New("previous tx still pending, skipping to avoid nonce gap",
+				"key", key, "tx_hash", tx.Hash().Hex())
+		}
+		return nil, errors.Wrap(err, "failed to check pending transaction receipt",
 			"key", key, "tx_hash", tx.Hash().Hex())
 	}
 

--- a/client/x/dkg/keeper/contract_client.go
+++ b/client/x/dkg/keeper/contract_client.go
@@ -522,6 +522,10 @@ func (c *ContractClient) checkAndResumePendingTx(ctx context.Context, key string
 
 	c.clearPendingTx(key)
 	if receipt.Status == types.ReceiptStatusSuccessful {
+		log.Info(ctx, key+" succeeded",
+			"tx_hash", tx.Hash().Hex(),
+			"gas_used", receipt.GasUsed)
+
 		return receipt, nil
 	}
 	return nil, nil

--- a/client/x/dkg/keeper/contract_client.go
+++ b/client/x/dkg/keeper/contract_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -75,6 +76,13 @@ type ContractClient struct {
 	privateKey      *ecdsa.PrivateKey
 	fromAddress     common.Address
 	chainID         *big.Int
+
+	// pendingTxs tracks the last-sent tx for each operation key (e.g. "register_1").
+	// If waitForTransaction times out, the tx may still be in the mempool.
+	// The next invocation of the same operation checks this map first to avoid
+	// sending a new tx with a higher nonce while the previous one is still pending.
+	pendingTxMu sync.Mutex
+	pendingTxs  map[string]*types.Transaction
 }
 
 // ContractConfig holds configuration for contract interaction.
@@ -143,6 +151,7 @@ func NewContractClient(ctx context.Context, engineEndpoint string, engineChainID
 		privateKey:      privateKey,
 		fromAddress:     fromAddress,
 		chainID:         chainID,
+		pendingTxs:      make(map[string]*types.Transaction),
 	}
 
 	log.Info(ctx, "Created contract client",
@@ -200,9 +209,22 @@ func (c *ContractClient) Register(ctx context.Context, round uint32, enclaveType
 
 	log.Info(ctx, "DKG registration fee queried", "fee_wei", fee.String())
 
-	return c.sendWithRetry(ctx, "Register", c.dkgContractAddr, callData, fee, func(auth *bind.TransactOpts) (*types.Transaction, error) {
-		return c.dkgContract.Register(auth, enclaveReport, enclaveInstanceData, startBlockHeightBig, startBlockHash32, []byte{})
+	pendingKey := fmt.Sprintf("register_%d", round)
+	if receipt, err := c.checkAndResumePendingTx(ctx, pendingKey); receipt != nil || err != nil {
+		return receipt, err
+	}
+
+	receipt, err := c.sendWithRetry(ctx, "Register", c.dkgContractAddr, callData, fee, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		tx, txErr := c.dkgContract.Register(auth, enclaveReport, enclaveInstanceData, startBlockHeightBig, startBlockHash32, []byte{})
+		if txErr == nil {
+			c.storePendingTx(pendingKey, tx)
+		}
+		return tx, txErr
 	})
+	if err == nil {
+		c.clearPendingTx(pendingKey)
+	}
+	return receipt, err
 }
 
 // Finalize calls the finalize contract method.
@@ -242,9 +264,22 @@ func (c *ContractClient) Finalize(
 
 	log.Info(ctx, "DKG finalization fee queried", "fee_wei", fee.String())
 
-	return c.sendWithRetry(ctx, "Finalize", c.dkgContractAddr, callData, fee, func(auth *bind.TransactOpts) (*types.Transaction, error) {
-		return c.dkgContract.Finalize(auth, round, c.fromAddress, enclaveType, participantsRoot32, globalPubKey, publicCoeffs, pubKeyShare, signature)
+	pendingKey := fmt.Sprintf("finalize_%d", round)
+	if receipt, err := c.checkAndResumePendingTx(ctx, pendingKey); receipt != nil || err != nil {
+		return receipt, err
+	}
+
+	receipt, err := c.sendWithRetry(ctx, "Finalize", c.dkgContractAddr, callData, fee, func(auth *bind.TransactOpts) (*types.Transaction, error) {
+		tx, txErr := c.dkgContract.Finalize(auth, round, c.fromAddress, enclaveType, participantsRoot32, globalPubKey, publicCoeffs, pubKeyShare, signature)
+		if txErr == nil {
+			c.storePendingTx(pendingKey, tx)
+		}
+		return tx, txErr
 	})
+	if err == nil {
+		c.clearPendingTx(pendingKey)
+	}
+	return receipt, err
 }
 
 // SubmitEncryptedPartialDecryption calls the submitEncryptedPartialDecryption contract method.
@@ -452,4 +487,42 @@ func (c *ContractClient) sendWithRetry(
 	}
 
 	return nil, errors.New(fmt.Sprintf("[%s] transaction failed after %d attempts", methodName, maxRetries))
+}
+
+func (c *ContractClient) storePendingTx(key string, tx *types.Transaction) {
+	c.pendingTxMu.Lock()
+	c.pendingTxs[key] = tx
+	c.pendingTxMu.Unlock()
+}
+
+func (c *ContractClient) clearPendingTx(key string) {
+	c.pendingTxMu.Lock()
+	delete(c.pendingTxs, key)
+	c.pendingTxMu.Unlock()
+}
+
+// checkAndResumePendingTx looks up a previously sent tx that may still be in the
+// mempool after a waitForTransaction timeout. It returns:
+//   - (receipt, nil)  if the tx was mined successfully — caller should return immediately
+//   - (nil, err)      if the tx is still pending — caller should abort to avoid a nonce gap
+//   - (nil, nil)      if no pending tx exists or it was mined but failed — caller should proceed normally
+func (c *ContractClient) checkAndResumePendingTx(ctx context.Context, key string) (*types.Receipt, error) {
+	c.pendingTxMu.Lock()
+	tx, ok := c.pendingTxs[key]
+	c.pendingTxMu.Unlock()
+	if !ok {
+		return nil, nil
+	}
+
+	receipt, _ := c.ethClient.TransactionReceipt(ctx, tx.Hash())
+	if receipt == nil {
+		return nil, errors.New("previous tx still pending, skipping to avoid nonce gap",
+			"key", key, "tx_hash", tx.Hash().Hex())
+	}
+
+	c.clearPendingTx(key)
+	if receipt.Status == types.ReceiptStatusSuccessful {
+		return receipt, nil
+	}
+	return nil, nil
 }

--- a/client/x/dkg/keeper/contract_client_test.go
+++ b/client/x/dkg/keeper/contract_client_test.go
@@ -858,7 +858,7 @@ func TestCheckAndResumePendingTx_StillPending(t *testing.T) {
 	pendingTx := makeTx(99)
 	mock := &mockEthClient{
 		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
-			return nil, nil // not yet mined
+			return nil, ethereum.NotFound // not yet mined
 		},
 	}
 	client := newTestContractClient(t, mock)
@@ -930,7 +930,7 @@ func TestRegister_PendingTxStillPending(t *testing.T) {
 	pendingTx := makeTx(99)
 	ethMock := &mockEthClient{
 		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
-			return nil, nil // all txs still pending
+			return nil, ethereum.NotFound // all txs still pending
 		},
 	}
 	dkgMock := &mockDKGContract{
@@ -1060,7 +1060,7 @@ func TestFinalize_PendingTxStillPending(t *testing.T) {
 	pendingTx := makeTx(99)
 	ethMock := &mockEthClient{
 		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
-			return nil, nil
+			return nil, ethereum.NotFound
 		},
 	}
 	dkgMock := &mockDKGContract{

--- a/client/x/dkg/keeper/contract_client_test.go
+++ b/client/x/dkg/keeper/contract_client_test.go
@@ -161,6 +161,7 @@ func newTestContractClient(t *testing.T, mock *mockEthClient) *ContractClient {
 		privateKey:  pk,
 		fromAddress: addr,
 		chainID:     big.NewInt(1),
+		pendingTxs:  make(map[string]*types.Transaction),
 	}
 }
 
@@ -188,6 +189,7 @@ func newFullTestContractClient(t *testing.T, ethMock *mockEthClient, dkgMock *mo
 		privateKey:      pk,
 		fromAddress:     addr,
 		chainID:         big.NewInt(1),
+		pendingTxs:      make(map[string]*types.Transaction),
 	}
 }
 
@@ -837,6 +839,279 @@ func TestMaxRetriesConstant(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, 3, maxRetries)
+}
+
+// ---------- checkAndResumePendingTx ----------
+
+func TestCheckAndResumePendingTx_NoPendingTx(t *testing.T) {
+	t.Parallel()
+
+	client := newTestContractClient(t, &mockEthClient{})
+	receipt, err := client.checkAndResumePendingTx(context.Background(), "register_1")
+	require.NoError(t, err)
+	require.Nil(t, receipt)
+}
+
+func TestCheckAndResumePendingTx_StillPending(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	mock := &mockEthClient{
+		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+			return nil, nil // not yet mined
+		},
+	}
+	client := newTestContractClient(t, mock)
+	client.storePendingTx("register_1", pendingTx)
+
+	receipt, err := client.checkAndResumePendingTx(context.Background(), "register_1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "still pending")
+	require.Nil(t, receipt)
+
+	// tx must remain in the map so the next call can try again
+	client.pendingTxMu.Lock()
+	_, ok := client.pendingTxs["register_1"]
+	client.pendingTxMu.Unlock()
+	require.True(t, ok)
+}
+
+func TestCheckAndResumePendingTx_MinedSuccess(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	expectedReceipt := &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 50000}
+	mock := &mockEthClient{
+		transactionReceiptFn: func(_ context.Context, hash common.Hash) (*types.Receipt, error) {
+			require.Equal(t, pendingTx.Hash(), hash)
+			return expectedReceipt, nil
+		},
+	}
+	client := newTestContractClient(t, mock)
+	client.storePendingTx("register_1", pendingTx)
+
+	receipt, err := client.checkAndResumePendingTx(context.Background(), "register_1")
+	require.NoError(t, err)
+	require.Equal(t, expectedReceipt, receipt)
+
+	client.pendingTxMu.Lock()
+	_, ok := client.pendingTxs["register_1"]
+	client.pendingTxMu.Unlock()
+	require.False(t, ok, "key must be cleared after mined success")
+}
+
+func TestCheckAndResumePendingTx_MinedFailed(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	mock := &mockEthClient{
+		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+			return &types.Receipt{Status: types.ReceiptStatusFailed, GasUsed: 50000}, nil
+		},
+	}
+	client := newTestContractClient(t, mock)
+	client.storePendingTx("register_1", pendingTx)
+
+	receipt, err := client.checkAndResumePendingTx(context.Background(), "register_1")
+	require.NoError(t, err)
+	require.Nil(t, receipt, "failed tx returns nil to signal caller should retry fresh")
+
+	client.pendingTxMu.Lock()
+	_, ok := client.pendingTxs["register_1"]
+	client.pendingTxMu.Unlock()
+	require.False(t, ok, "key must be cleared after mined failure")
+}
+
+// ---------- Register (pending tx) ----------
+
+func TestRegister_PendingTxStillPending(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	ethMock := &mockEthClient{
+		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+			return nil, nil // all txs still pending
+		},
+	}
+	dkgMock := &mockDKGContract{
+		feeFn: func(_ *bind.CallOpts) (*big.Int, error) { return big.NewInt(0), nil },
+	}
+	client := newFullTestContractClient(t, ethMock, dkgMock, &mockCDRContract{})
+	client.storePendingTx("register_1", pendingTx)
+
+	sendCalls := 0
+	dkgMock.registerFn = func(opts *bind.TransactOpts, _ []byte, _ bindings.IDKGEnclaveInstanceData, _ *big.Int, _ [32]byte, _ []byte) (*types.Transaction, error) {
+		sendCalls++
+		return makeTx(opts.Nonce.Uint64()), nil
+	}
+
+	_, err := client.Register(context.Background(), 1, [32]byte{0x01}, 100, make([]byte, 32),
+		[]byte("dkg"), []byte("comm"), []byte("report"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "still pending")
+	require.Equal(t, 0, sendCalls, "must not send a new tx while previous is still pending")
+}
+
+func TestRegister_PendingTxSucceeded(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	expectedReceipt := &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 60000}
+	ethMock := &mockEthClient{
+		transactionReceiptFn: func(_ context.Context, hash common.Hash) (*types.Receipt, error) {
+			if hash == pendingTx.Hash() {
+				return expectedReceipt, nil
+			}
+			return nil, nil
+		},
+	}
+	dkgMock := &mockDKGContract{
+		feeFn: func(_ *bind.CallOpts) (*big.Int, error) { return big.NewInt(0), nil },
+	}
+	client := newFullTestContractClient(t, ethMock, dkgMock, &mockCDRContract{})
+	client.storePendingTx("register_1", pendingTx)
+
+	sendCalls := 0
+	dkgMock.registerFn = func(opts *bind.TransactOpts, _ []byte, _ bindings.IDKGEnclaveInstanceData, _ *big.Int, _ [32]byte, _ []byte) (*types.Transaction, error) {
+		sendCalls++
+		return makeTx(opts.Nonce.Uint64()), nil
+	}
+
+	receipt, err := client.Register(context.Background(), 1, [32]byte{0x01}, 100, make([]byte, 32),
+		[]byte("dkg"), []byte("comm"), []byte("report"))
+	require.NoError(t, err)
+	require.Equal(t, expectedReceipt, receipt)
+	require.Equal(t, 0, sendCalls, "must reuse the pending tx receipt without sending a new tx")
+}
+
+func TestRegister_PendingTxFailed_SendsNewTx(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	freshReceipt := &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 50000}
+	ethMock := &mockEthClient{
+		estimateGasFn: func(_ context.Context, _ ethereum.CallMsg) (uint64, error) { return 100000, nil },
+		transactionReceiptFn: func(_ context.Context, hash common.Hash) (*types.Receipt, error) {
+			if hash == pendingTx.Hash() {
+				return &types.Receipt{Status: types.ReceiptStatusFailed}, nil
+			}
+			return freshReceipt, nil
+		},
+	}
+	dkgMock := &mockDKGContract{
+		feeFn: func(_ *bind.CallOpts) (*big.Int, error) { return big.NewInt(0), nil },
+	}
+	client := newFullTestContractClient(t, ethMock, dkgMock, &mockCDRContract{})
+	client.storePendingTx("register_1", pendingTx)
+
+	sendCalls := 0
+	dkgMock.registerFn = func(opts *bind.TransactOpts, _ []byte, _ bindings.IDKGEnclaveInstanceData, _ *big.Int, _ [32]byte, _ []byte) (*types.Transaction, error) {
+		sendCalls++
+		return makeTx(opts.Nonce.Uint64()), nil
+	}
+
+	receipt, err := client.Register(context.Background(), 1, [32]byte{0x01}, 100, make([]byte, 32),
+		[]byte("dkg"), []byte("comm"), []byte("report"))
+	require.NoError(t, err)
+	require.Equal(t, freshReceipt, receipt)
+	require.Equal(t, 1, sendCalls, "must send a new tx after the pending tx failed on-chain")
+}
+
+func TestRegister_StoresPendingTxOnWaitTimeout(t *testing.T) {
+	t.Parallel()
+
+	var sentTxHash common.Hash
+	ethMock := &mockEthClient{
+		estimateGasFn: func(_ context.Context, _ ethereum.CallMsg) (uint64, error) { return 100000, nil },
+		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+			return nil, ethereum.NotFound // never mines
+		},
+	}
+	dkgMock := &mockDKGContract{
+		feeFn: func(_ *bind.CallOpts) (*big.Int, error) { return big.NewInt(0), nil },
+		registerFn: func(opts *bind.TransactOpts, _ []byte, _ bindings.IDKGEnclaveInstanceData, _ *big.Int, _ [32]byte, _ []byte) (*types.Transaction, error) {
+			tx := makeTx(opts.Nonce.Uint64())
+			sentTxHash = tx.Hash()
+			return tx, nil
+		},
+	}
+	client := newFullTestContractClient(t, ethMock, dkgMock, &mockCDRContract{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancelled → waitForTransaction times out right away
+
+	_, err := client.Register(ctx, 1, [32]byte{0x01}, 100, make([]byte, 32),
+		[]byte("dkg"), []byte("comm"), []byte("report"))
+	require.Error(t, err)
+
+	// The tx must be preserved so the next Register call can check it instead of sending again.
+	client.pendingTxMu.Lock()
+	storedTx, ok := client.pendingTxs["register_1"]
+	client.pendingTxMu.Unlock()
+	require.True(t, ok, "pending tx must be stored after waitForTransaction timeout")
+	require.Equal(t, sentTxHash, storedTx.Hash())
+}
+
+// ---------- Finalize (pending tx) ----------
+
+func TestFinalize_PendingTxStillPending(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	ethMock := &mockEthClient{
+		transactionReceiptFn: func(_ context.Context, _ common.Hash) (*types.Receipt, error) {
+			return nil, nil
+		},
+	}
+	dkgMock := &mockDKGContract{
+		feeFn: func(_ *bind.CallOpts) (*big.Int, error) { return big.NewInt(0), nil },
+	}
+	client := newFullTestContractClient(t, ethMock, dkgMock, &mockCDRContract{})
+	client.storePendingTx("finalize_1", pendingTx)
+
+	sendCalls := 0
+	dkgMock.finalizeFn = func(opts *bind.TransactOpts, _ uint32, _ common.Address, _ [32]byte, _ [32]byte, _ []byte, _ [][]byte, _ []byte, _ []byte) (*types.Transaction, error) {
+		sendCalls++
+		return makeTx(opts.Nonce.Uint64()), nil
+	}
+
+	_, err := client.Finalize(context.Background(), 1, [32]byte{0x01}, make([]byte, 32),
+		[]byte("gpk"), [][]byte{}, []byte("share"), []byte("sig"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "still pending")
+	require.Equal(t, 0, sendCalls)
+}
+
+func TestFinalize_PendingTxSucceeded(t *testing.T) {
+	t.Parallel()
+
+	pendingTx := makeTx(99)
+	expectedReceipt := &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 70000}
+	ethMock := &mockEthClient{
+		transactionReceiptFn: func(_ context.Context, hash common.Hash) (*types.Receipt, error) {
+			if hash == pendingTx.Hash() {
+				return expectedReceipt, nil
+			}
+			return nil, nil
+		},
+	}
+	dkgMock := &mockDKGContract{
+		feeFn: func(_ *bind.CallOpts) (*big.Int, error) { return big.NewInt(0), nil },
+	}
+	client := newFullTestContractClient(t, ethMock, dkgMock, &mockCDRContract{})
+	client.storePendingTx("finalize_1", pendingTx)
+
+	sendCalls := 0
+	dkgMock.finalizeFn = func(opts *bind.TransactOpts, _ uint32, _ common.Address, _ [32]byte, _ [32]byte, _ []byte, _ [][]byte, _ []byte, _ []byte) (*types.Transaction, error) {
+		sendCalls++
+		return makeTx(opts.Nonce.Uint64()), nil
+	}
+
+	receipt, err := client.Finalize(context.Background(), 1, [32]byte{0x01}, make([]byte, 32),
+		[]byte("gpk"), [][]byte{}, []byte("share"), []byte("sig"))
+	require.NoError(t, err)
+	require.Equal(t, expectedReceipt, receipt)
+	require.Equal(t, 0, sendCalls, "must reuse the pending tx receipt without sending a new tx")
 }
 
 // errSentinel is a test sentinel error.

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -81,7 +81,13 @@ func releaseDKGSvc(round uint32) {
 // communicate with the story-kernel. These goroutines must NOT use the CometBFT
 // consensus context because it gets canceled when block processing completes,
 // which can abort in-flight gRPC calls to the story-kernel.
-const dkgAsyncTimeout = 1 * time.Minute
+//
+// The budget must cover a TEE kernel call plus one waitForTransaction call
+// (which has its own 60s inner timeout). 2 minutes gives ~60s for the kernel
+// operation and ~60s for the on-chain transaction to be mined. If the async
+// context expires before waitForTransaction's inner timeout fires, the tx wait
+// is cut short — so this value must stay above 60s to be meaningful.
+const dkgAsyncTimeout = 2 * time.Minute
 
 // dkgAsyncContext creates a new context for async DKG service goroutines with a timeout.
 // This replaces the consensus context that would otherwise be canceled after block processing.


### PR DESCRIPTION
issue: #808 

## Problem
When `waitForTransaction` times out (60s), the transaction may still be in the mempool — it was never dropped, just not yet mined. If the caller retries the operation on the next tick, `sendWithRetry` fetches a fresh nonce (N+1) and broadcasts a new transaction while the original (nonce N) is still pending. This creates a nonce gap: the new transaction at N+1 is stuck until N is resolved, stalling all subsequent transactions from that validator.

For CDR operations like `Register` and `Finalize`, a duplicate submission is also wasteful — the contract rejects the second call, but the gas is still spent.

## Solution

Add a `pendingTxs map[string]*types.Transaction` to `ContractClient`, keyed by operation + round (e.g. `"register_1"`).

The `sendTx` closure stores the tx hash **before** `waitForTransaction` is called, so the hash survives a timeout. On the next invocation of the same operation for the same round, `checkAndResumePendingTx` inspects the stored tx:

- **Still pending** (receipt == nil) → return error, abort. No new tx is sent.
- **Mined + success** → return the existing receipt directly.
- **Mined + failed** → clear the entry, proceed to send a fresh tx.

`sendWithRetry` itself is unchanged. The pending-tx check is an entry-point guard in `Register` and `Finalize`.

Also extends `dkgAsyncTimeout` from 1min to 2min with a comment explaining the budget: ~60s for TEE kernel operations + ~60s for `waitForTransaction`.

## Test Plan

- `TestCheckAndResumePendingTx_NoPendingTx` — no entry, returns (nil, nil)
- `TestCheckAndResumePendingTx_StillPending` — receipt nil, returns error, map not cleared
- `TestCheckAndResumePendingTx_MinedSuccess` — returns receipt, map cleared
- `TestCheckAndResumePendingTx_MinedFailed` — returns (nil, nil), map cleared
- `TestRegister_PendingTxStillPending` — aborts before sending, sendCalls == 0
- `TestRegister_PendingTxSucceeded` — reuses receipt, sendCalls == 0
- `TestRegister_PendingTxFailed_SendsNewTx` — sends fresh tx after on-chain failure
- `TestRegister_StoresPendingTxOnWaitTimeout` — confirms hash is preserved after context cancellation
- `TestFinalize_PendingTxStillPending` / `TestFinalize_PendingTxSucceeded` — same coverage for Finalize
