### PR TITLE
fix: clear stale requests from old sessions

### DIFF
--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -317,7 +317,36 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 	}
 
 	sessions := k.stateManager.ListSessions()
+
+	var maxRound uint32
+	for _, s := range sessions {
+		if s.Round > maxRound {
+			maxRound = s.Round
+		}
+	}
+
 	for _, session := range sessions {
+		// Drop queued requests from sessions that are at least 2 rounds behind the
+		// current round — their keys are no longer relevant and the requests would
+		// never be processed successfully.
+		if maxRound >= 2 && session.Round <= maxRound-2 {
+			dropped := session.DrainDecryptRequests()
+			if len(dropped) > 0 {
+				log.Warn(ctx, "Dropping decrypt requests from stale session", nil,
+					"session", session.GetSessionKey(),
+					"dropped_requests", len(dropped),
+				)
+				incDecryptRequest(labelDecryptStaleDropped, len(dropped))
+				if err := k.stateManager.UpdateSession(ctx, session); err != nil {
+					log.Error(ctx, "Failed to persist stale session after clearing requests", err,
+						"session", session.GetSessionKey(),
+					)
+				}
+			}
+
+			continue
+		}
+
 		// Check session-level preconditions before draining so that requests are
 		// not removed from the queue only to be re-added immediately.
 		if session.Index == 0 {

--- a/client/x/dkg/keeper/dkg_svc_test.go
+++ b/client/x/dkg/keeper/dkg_svc_test.go
@@ -664,6 +664,113 @@ func TestProcessDecryptQueue_PartialStaleRequests(t *testing.T) {
 	require.Empty(t, got.GetDecryptRequests(), "only fresh request processed, nothing re-queued")
 }
 
+// ---------- stale session clearing (round <= maxRound-2) ----------
+
+// TestProcessDecryptQueue_StaleSessionRequestsDropped verifies that requests in a session
+// that is at least 2 rounds behind the latest session are drained and discarded, while
+// requests in sessions within the 2-round window are left untouched.
+func TestProcessDecryptQueue_StaleSessionRequestsDropped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+	mockContract.EXPECT().BlockNumber(gomock.Any()).Return(uint64(100), nil)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	req := types.DecryptRequest{Ciphertext: []byte("ct"), Label: make([]byte, 32)}
+
+	// Round 1 is stale (maxRound=3, 3-2=1, round 1 <= 1).
+	stale := &types.DKGSession{
+		Round: 1, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.DecryptRequest{req},
+	}
+	// Round 3 is current — Index=0 so it will be deferred, not cleared.
+	current := &types.DKGSession{
+		Round: 3, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.DecryptRequest{req},
+	}
+	require.NoError(t, sm.CreateSession(ctx, stale))
+	require.NoError(t, sm.CreateSession(ctx, current))
+
+	k := &Keeper{stateManager: sm, contractClient: mockContract, kernelRouter: NewKernelRouter(nil, nil)}
+	k.processDecryptQueue(ctx)
+
+	gotStale, err := sm.GetSession(1)
+	require.NoError(t, err)
+	require.Empty(t, gotStale.GetDecryptRequests(), "stale session requests must be dropped")
+
+	gotCurrent, err := sm.GetSession(3)
+	require.NoError(t, err)
+	require.Len(t, gotCurrent.GetDecryptRequests(), 1, "current session requests must be preserved")
+}
+
+// TestProcessDecryptQueue_StaleSessionBoundaryPreserved verifies that a session exactly
+// 1 round behind the latest (maxRound-1) is NOT cleared — only sessions >= 2 rounds
+// behind are eligible for stale clearing.
+func TestProcessDecryptQueue_StaleSessionBoundaryPreserved(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+	mockContract.EXPECT().BlockNumber(gomock.Any()).Return(uint64(100), nil)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	req := types.DecryptRequest{Ciphertext: []byte("ct"), Label: make([]byte, 32)}
+
+	// maxRound=3; maxRound-2=1. Round 2 > 1, so it must NOT be cleared.
+	boundary := &types.DKGSession{
+		Round: 2, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.DecryptRequest{req},
+	}
+	latest := &types.DKGSession{
+		Round: 3, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.DecryptRequest{req},
+	}
+	require.NoError(t, sm.CreateSession(ctx, boundary))
+	require.NoError(t, sm.CreateSession(ctx, latest))
+
+	k := &Keeper{stateManager: sm, contractClient: mockContract, kernelRouter: NewKernelRouter(nil, nil)}
+	k.processDecryptQueue(ctx)
+
+	gotBoundary, err := sm.GetSession(2)
+	require.NoError(t, err)
+	require.Len(t, gotBoundary.GetDecryptRequests(), 1, "boundary session (maxRound-1) must not be cleared")
+}
+
+// TestProcessDecryptQueue_SingleSessionNotCleared verifies that when there is only one
+// session the maxRound<2 guard prevents any stale clearing (no uint32 underflow).
+func TestProcessDecryptQueue_SingleSessionNotCleared(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+	mockContract.EXPECT().BlockNumber(gomock.Any()).Return(uint64(100), nil)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	req := types.DecryptRequest{Ciphertext: []byte("ct"), Label: make([]byte, 32)}
+	session := &types.DKGSession{
+		Round: 1, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.DecryptRequest{req},
+	}
+	require.NoError(t, sm.CreateSession(ctx, session))
+
+	k := &Keeper{stateManager: sm, contractClient: mockContract, kernelRouter: NewKernelRouter(nil, nil)}
+	k.processDecryptQueue(ctx)
+
+	got, err := sm.GetSession(1)
+	require.NoError(t, err)
+	require.Len(t, got.GetDecryptRequests(), 1, "single session must not be cleared")
+}
+
 // TestComputePartialDecrypt_PanicRecovery verifies that a panic inside the kernel call
 // is caught by the deferred recover and returned as an error (not a crash).
 func TestComputePartialDecrypt_PanicRecovery(t *testing.T) {


### PR DESCRIPTION
issue: #809 

## Problem
processDecryptQueue iterates over all sessions in StateManager, including sessions from old DKG rounds. Sessions whose Index has not been set yet (registration not yet confirmed on-chain) generate a "Session index not set, deferring decrypt requests to next tick" warning on every worker tick. Because CleanupExpiredSessions is never called from production code, these sessions accumulate and the warning fires from old rounds indefinitely — there is no mechanism to discard their queued requests.

## Solution
At the start of each processDecryptQueue iteration, compute maxRound from the live session list, then drain and discard decrypt requests from any session with round <= maxRound - 2. Sessions that are at least 2 rounds behind can never have their partial decryptions processed (the on-chain round has moved past them), so keeping their requests alive only causes log spam and wasted work. The maxRound >= 2 guard prevents a uint32 underflow when there is only one session.

Dropped requests are counted under the existing stale_dropped metric label.