### PR TITLE
fix(dkg): drop extra minDelay arg from executeBatch calldata encoding

### DIFF
--- a/contracts/script/upgrades/UpgradeCDR.s.sol
+++ b/contracts/script/upgrades/UpgradeCDR.s.sol
@@ -84,28 +84,24 @@ contract UpgradeCDR is Script {
         );
         payloads[1] = abi.encodeWithSelector(CDR.setMaxBatchSize.selector, maxBatchSize);
 
-        bytes4 selector;
         string memory modeString;
         bytes memory data;
 
         if (mode == MODE.CANCEL) {
             revert("TODO");
+        } else if (mode == MODE.SCHEDULE) {
+            modeString = "Schedule";
+            // scheduleBatch(address[], uint256[], bytes[], bytes32 predecessor, bytes32 salt, uint256 delay)
+            data = abi.encodeCall(
+                TimelockController.scheduleBatch,
+                (targets, values, payloads, bytes32(0), bytes32(0), minDelay)
+            );
         } else {
-            if (mode == MODE.SCHEDULE) {
-                selector = TimelockController.scheduleBatch.selector;
-                modeString = "Schedule";
-            } else {
-                selector = TimelockController.executeBatch.selector;
-                modeString = "Execute";
-            }
-            data = abi.encodeWithSelector(
-                selector,
-                targets,
-                values,
-                payloads,
-                bytes32(0), // predecessor
-                bytes32(0), // salt
-                minDelay
+            modeString = "Execute";
+            // executeBatch(address[], uint256[], bytes[], bytes32 predecessor, bytes32 salt) — no delay
+            data = abi.encodeCall(
+                TimelockController.executeBatch,
+                (targets, values, payloads, bytes32(0), bytes32(0))
             );
         }
 

--- a/contracts/script/upgrades/UpgradeDKG.s.sol
+++ b/contracts/script/upgrades/UpgradeDKG.s.sol
@@ -75,29 +75,24 @@ contract UpgradeDKG is Script {
         payloads[1] = _buildCDRUpgradePayload(newCDRImpl);
         payloads[2] = _buildWhitelistPayload();
 
-        bytes4 selector;
         string memory modeString;
         bytes memory data;
 
         if (mode == MODE.CANCEL) {
             revert("TODO");
+        } else if (mode == MODE.SCHEDULE) {
+            modeString = "Schedule";
+            // scheduleBatch(address[], uint256[], bytes[], bytes32 predecessor, bytes32 salt, uint256 delay)
+            data = abi.encodeCall(
+                TimelockController.scheduleBatch,
+                (targets, values, payloads, bytes32(0), bytes32(0), minDelay)
+            );
         } else {
-            if (mode == MODE.SCHEDULE) {
-                selector = TimelockController.scheduleBatch.selector;
-                modeString = "Schedule";
-            } else {
-                selector = TimelockController.executeBatch.selector;
-                modeString = "Execute";
-            }
-            // Encode the full scheduleBatch call
-            data = abi.encodeWithSelector(
-                selector,
-                targets,
-                values,
-                payloads,
-                bytes32(0), // predecessor
-                bytes32(0), // salt
-                minDelay
+            modeString = "Execute";
+            // executeBatch(address[], uint256[], bytes[], bytes32 predecessor, bytes32 salt) — no delay
+            data = abi.encodeCall(
+                TimelockController.executeBatch,
+                (targets, values, payloads, bytes32(0), bytes32(0))
             );
         }
 


### PR DESCRIPTION
## Summary

`UpgradeCDR.s.sol` and `UpgradeDKG.s.sol` both encode the timelock operation calldata with `abi.encodeWithSelector(selector, ..., minDelay)` regardless of mode. This is correct for `scheduleBatch(..., uint256 delay)` but wrong for `executeBatch(...)` which takes no delay — the extra `minDelay` is encoded as a 6th head arg, shifting all dynamic-arg offsets up by 32 bytes and adding 32 trailing tail bytes.

Solidity ABI decoding tolerates the inserted slot (offsets correctly step past it) so the on-chain `executeBatch` call still succeeds — but the calldata is non-canonical, ~150 gas heavier, and confuses tooling that strict-decodes against `executeBatch`'s 5-arg ABI.

## Empirical evidence

Caught and validated against a live SGX devnet in our e2e suite:

- [`piplabs/story-cdr-e2e#155`](https://github.com/piplabs/story-cdr-e2e/pull/155) **T50 calldata-parity** — Go-encoded canonical executeBatch calldata vs forge-encoded calldata. Forge's is exactly 32 bytes longer; the inserted slot's value is the timelock's `getMinDelay()` returning `10` — confirms the extra arg is `minDelay`.

- [`piplabs/story-cdr-e2e#156`](https://github.com/piplabs/story-cdr-e2e/pull/156) **T21 end-to-end** — drives the upgrade through TimelockController using forge-generated calldata. The upgrade succeeds (Solidity decoder tolerates the inserted slot), but `gasUsed` is 89,652 vs 89,500 for canonical 5-arg encoding — exactly the cost of the extra 32-byte slot.

Word-by-word ABI alignment of the two encodings (truncated):

| Word | canonical (5-arg) | forge-encoded (6-arg) |
|---|---|---|
| #1 targets offset | `0xa0` | `0xc0` (+32) |
| #2 values offset | `0x100` | `0x120` (+32) |
| #3 payloads offset | `0x160` | `0x180` (+32) |
| #4 predecessor | `0x0` | `0x0` |
| #5 salt | `0x0` | `0x0` |
| **#6** | (tail begins) | `0x...0a` = **10 = minDelay** ← extra |
| #7+ | targets length, ... | (everything shifted +32) |

## Scope

Same bug present in two scripts on `dkg/dev` (copy-paste lineage):
- `contracts/script/upgrades/UpgradeCDR.s.sol`
- `contracts/script/upgrades/UpgradeDKG.s.sol`

Both fixed identically.

## Why `abi.encodeCall` (and not just splitting `encodeWithSelector`)

`abi.encodeCall(funcRef, (args...))` is **type-safe at compile time** — the compiler verifies the args match the function signature. The 6-arg form against `executeBatch`'s 5-arg signature would have failed to compile under `encodeCall`, preventing this class of bug from recurring (which it has — same bug in two files now). `encodeWithSelector` accepts any args silently, which is exactly what let this slip through.

## Diff shape

```solidity
// Before
bytes4 selector;
if (mode == MODE.SCHEDULE) selector = TimelockController.scheduleBatch.selector;
else                       selector = TimelockController.executeBatch.selector;
data = abi.encodeWithSelector(
    selector, targets, values, payloads,
    bytes32(0), bytes32(0), minDelay        // wrong for EXECUTE
);

// After
if (mode == MODE.SCHEDULE) {
    data = abi.encodeCall(
        TimelockController.scheduleBatch,
        (targets, values, payloads, bytes32(0), bytes32(0), minDelay)
    );
} else {
    data = abi.encodeCall(
        TimelockController.executeBatch,
        (targets, values, payloads, bytes32(0), bytes32(0))   // no delay
    );
}
```

`bytes4 selector;` local removed in both files (no longer used).

## Test plan

- [x] `forge build script/upgrades/UpgradeCDR.s.sol script/upgrades/UpgradeDKG.s.sol` — compiler run successful, no new warnings introduced
- [ ] `piplabs/story-cdr-e2e` T50 calldata-parity will need its prefix-tolerance assertion updated to expect canonical 5-arg form (currently asserts the bug shape — see comments there). I'll send a follow-up PR on that side after this lands.
- [ ] `piplabs/story-cdr-e2e` T21 (end-to-end via raw forge calldata) will continue to pass with ~150 gas less.

issue: cosmetic calldata bug, not a runtime correctness issue