### PR TITLE
feat(dkg): let SGXValidationHook follow standard TCB via Automata verifier

### DIFF
--- a/contracts/script/upgrades/UpgradeSGXValidationHook_V1_0_1.s.sol
+++ b/contracts/script/upgrades/UpgradeSGXValidationHook_V1_0_1.s.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+/* solhint-disable no-console */
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+// solhint-disable-next-line max-line-length
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import { SGXValidationHook } from "../../src/protocol/SGXValidationHook.sol";
+import { Predeploys } from "../../src/libraries/Predeploys.sol";
+import { Create3 } from "../../src/deploy/Create3.sol";
+import { EIP1967Helper } from "../utils/EIP1967Helper.sol";
+
+/**
+ * @title UpgradeSGXValidationHook_V1_0_1
+ * @notice Deploys the new SGXValidationHook implementation via Create3 and prepares a Safe
+ *         transaction that drives a TimelockController operation to upgrade the already-deployed
+ *         proxy on Aeneid to the new implementation. The new implementation calls the
+ *         parameterless `verifyAndAttestOnChain` overload, so no additional state needs to be set
+ *         on the proxy after the upgrade.
+ * @dev Run with `--rpc-url $AENEID --broadcast` for the first run (deploys the implementation and
+ *      logs the timelock calldata). Subsequent runs without `--broadcast` skip the deploy (Create3
+ *      address is deterministic) and just regenerate the calldata — useful for switching between
+ *      SCHEDULE and EXECUTE modes after submitting the schedule.
+ *
+ *      Required env vars:
+ *        DEPLOYER_PRIVATE_KEY — deployer's private key (must be the same address used for the
+ *                               Create3 prediction across runs)
+ *        TIMELOCK_ADDRESS     — TimelockController address
+ *        TIMELOCK_MIN_DELAY   — Timelock min delay (seconds), used for schedule only
+ *        SGX_HOOK_PROXY       — already-deployed SGXValidationHook proxy address
+ */
+contract UpgradeSGXValidationHook_V1_0_1 is Script {
+    enum MODE {
+        SCHEDULE,
+        EXECUTE,
+        CANCEL
+    }
+
+    MODE mode = MODE.SCHEDULE;
+
+    bytes32 constant IMPL_SALT = keccak256(abi.encodePacked("SGXValidationHook_Implementation_v1_0_1"));
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        address timelockAddr = vm.envAddress("TIMELOCK_ADDRESS");
+        uint256 minDelay = vm.envUint("TIMELOCK_MIN_DELAY");
+        address sgxHookProxy = vm.envAddress("SGX_HOOK_PROXY");
+
+        Create3 create3 = Create3(Predeploys.Create3);
+        address newImpl = create3.getDeployed(deployer, IMPL_SALT);
+
+        // Deploy the new implementation if it has not been deployed yet at the predicted address.
+        // Idempotent across re-runs: subsequent invocations (e.g. when switching from SCHEDULE to
+        // EXECUTE mode) skip this branch.
+        if (newImpl.code.length == 0) {
+            vm.startBroadcast(deployerPrivateKey);
+            bytes memory creationCode = abi.encodePacked(
+                type(SGXValidationHook).creationCode,
+                abi.encode(Predeploys.DKG)
+            );
+            address deployed = create3.deploy(IMPL_SALT, creationCode);
+            require(deployed == newImpl, "Create3 address mismatch");
+            vm.stopBroadcast();
+            console2.log("New SGXValidationHook implementation deployed at:", newImpl);
+        } else {
+            console2.log("SGXValidationHook implementation already deployed at:", newImpl);
+        }
+
+        // Read ProxyAdmin from the proxy's EIP-1967 admin slot
+        address proxyAdmin = EIP1967Helper.getAdmin(sgxHookProxy);
+
+        console2.log("SGXValidationHook proxy:", sgxHookProxy);
+        console2.log("SGXValidationHook ProxyAdmin:", proxyAdmin);
+
+        // Single timelock operation: pure proxy upgrade. initialize() must not be re-run (the v1.0.1
+        // impl does not introduce a reinitializer), and no extra owner state needs to be set after
+        // the upgrade — the new implementation calls verifyAndAttestOnChain(bytes) which lets the
+        // Automata verifier resolve the standard TCB Evaluation Data Number on-chain.
+        bytes memory upgradePayload = abi.encodeCall(
+            ProxyAdmin.upgradeAndCall,
+            (ITransparentUpgradeableProxy(sgxHookProxy), newImpl, bytes(""))
+        );
+
+        string memory modeString;
+        bytes memory data;
+
+        if (mode == MODE.CANCEL) {
+            revert("TODO");
+        } else if (mode == MODE.SCHEDULE) {
+            modeString = "Schedule";
+            data = abi.encodeCall(
+                TimelockController.schedule,
+                (proxyAdmin, 0, upgradePayload, bytes32(0), bytes32(0), minDelay)
+            );
+        } else {
+            modeString = "Execute";
+            data = abi.encodeCall(TimelockController.execute, (proxyAdmin, 0, upgradePayload, bytes32(0), bytes32(0)));
+        }
+
+        // Output Safe transaction parameters
+        console2.log("=== Safe Transaction Parameters ===");
+        console2.log("To (TimelockController):", timelockAddr);
+        console2.log("Mode:", modeString);
+        console2.log("Value: 0");
+        console2.log("Data (hex):");
+        console2.logBytes(data);
+    }
+}

--- a/contracts/src/interfaces/ICDR.sol
+++ b/contracts/src/interfaces/ICDR.sol
@@ -108,13 +108,7 @@ interface ICDR {
     /// @param pid The participant index of the validator
     /// @param uuid The UUID of the vault
     /// @param index The index of the item within the batch
-    event InvalidPartialDecryption(
-        address indexed validator,
-        uint32 round,
-        uint32 pid,
-        uint32 uuid,
-        uint256 index
-    );
+    event InvalidPartialDecryption(address indexed validator, uint32 round, uint32 pid, uint32 uuid, uint256 index);
 
     /// @notice Emitted when a CDR fee is collected
     /// @param payer The address that paid the fee (msg.sender)

--- a/contracts/src/interfaces/external/IAutomataDcapAttestationFee.sol
+++ b/contracts/src/interfaces/external/IAutomataDcapAttestationFee.sol
@@ -2,6 +2,17 @@
 pragma solidity 0.8.23;
 
 interface IAutomataDcapAttestationFee {
+    /// @notice Verify a raw SGX quote using the *standard* TCB Evaluation Data Number resolved
+    ///         on-chain by the Automata PCCS Router per Intel's TCB Recovery policy (the highest
+    ///         evaluation data number whose recovery event date is ≥ 12 months before
+    ///         `block.timestamp`). Use this overload to follow Intel-defined standard transitions
+    ///         automatically rather than pinning a specific evaluation data number.
+    function verifyAndAttestOnChain(
+        bytes calldata rawQuote
+    ) external payable returns (bool success, bytes memory output);
+
+    /// @notice Verify a raw SGX quote against a caller-supplied TCB Evaluation Data Number.
+    /// @dev Passing `0` is equivalent to the no-arg overload (falls back to the standard version).
     function verifyAndAttestOnChain(
         bytes calldata rawQuote,
         uint32 tcbEvaluationDataNumber

--- a/contracts/src/protocol/SGXValidationHook.sol
+++ b/contracts/src/protocol/SGXValidationHook.sol
@@ -13,7 +13,10 @@ contract SGXValidationHook is ISGXValidationHook, Ownable2StepUpgradeable, Pausa
 
     /// @dev Storage structure for the SGXValidationHook
     /// @param automataValidationAddr The address of the automata validation contract
-    /// @param tcbEvaluationDataNumber The tcb evaluation data number
+    /// @param tcbEvaluationDataNumber The TCB evaluation data number. Retained for storage and
+    ///        interface backward compatibility; no longer consumed by `validateReport`, which now
+    ///        calls the parameterless `verifyAndAttestOnChain` overload so the verifier resolves
+    ///        the standard TCB evaluation data number on-chain per Intel's TCB Recovery policy.
     /// @custom:storage-location erc7201:story.SGXValidationHook
     struct SGXValidationHookStorage {
         address automataValidationAddr;
@@ -60,6 +63,9 @@ contract SGXValidationHook is ISGXValidationHook, Ownable2StepUpgradeable, Pausa
 
     /// @notice Sets the TCB evaluation data number
     /// @param newTcbEvaluationDataNumber The TCB evaluation data number
+    /// @dev Retained for backward compatibility. The stored value is no longer read by
+    ///      `validateReport`; the standard TCB evaluation data number is resolved by the verifier
+    ///      on every call instead.
     function setTcbEvaluationDataNumber(uint32 newTcbEvaluationDataNumber) external onlyOwner {
         _setTcbEvaluationDataNumber(newTcbEvaluationDataNumber);
     }
@@ -85,10 +91,14 @@ contract SGXValidationHook is ISGXValidationHook, Ownable2StepUpgradeable, Pausa
         require(expectedCodeCommitment != bytes32(0), "SGXValidationHook: Zero code commitment");
         require(expectedDataCommitment != bytes32(0), "SGXValidationHook: Zero data commitment");
         SGXValidationHookStorage storage $ = _getSGXValidationHookStorage();
-        // see verifyAndAttestOnChain in automata-dcap-attestation:
-        // AutomataDcapAttestationFee.sol#L23
-        (bool success, bytes memory output) = IAutomataDcapAttestationFee($.automataValidationAddr)
-            .verifyAndAttestOnChain(enclaveReport, $.tcbEvaluationDataNumber);
+
+        // Use the parameterless verifyAndAttestOnChain overload. The Automata verifier resolves
+        // the standard TCB Evaluation Data Number on-chain per Intel's TCB Recovery policy
+        // (highest evaluation data number whose recovery event date is ≥ 12 months before
+        // block.timestamp), so version transitions take effect automatically without any owner
+        // action. See AutomataDcapAttestationFee.sol#L23 (1-arg overload delegates to
+        // `_verifyAndAttestOnChain(rawQuote, 0)`, and the `0` triggers the standard lookup).
+        (bool success, ) = IAutomataDcapAttestationFee($.automataValidationAddr).verifyAndAttestOnChain(enclaveReport);
         require(success, "SGXAttestationReportValidator: Attestation failed");
 
         // check report code commitment against expectedCodeCommitment
@@ -116,7 +126,8 @@ contract SGXValidationHook is ISGXValidationHook, Ownable2StepUpgradeable, Pausa
         return _getSGXValidationHookStorage().automataValidationAddr;
     }
 
-    /// @notice Gets the TCB evaluation data number
+    /// @notice Gets the TCB evaluation data number stored at initialization time.
+    /// @dev Retained for backward compatibility. This value is no longer used by `validateReport`.
     /// @return The TCB evaluation data number
     function tcbEvaluationDataNumber() external view returns (uint32) {
         return _getSGXValidationHookStorage().tcbEvaluationDataNumber;

--- a/contracts/test/cdr/cdr.t.sol
+++ b/contracts/test/cdr/cdr.t.sol
@@ -141,17 +141,18 @@ contract CDRTest is Test {
 
     /// @dev Builds a valid PartialDecryptionRequest for use in batch tests.
     function _makeRequest(uint32 uuid) internal pure returns (ICDR.PartialDecryptionRequest memory) {
-        return ICDR.PartialDecryptionRequest({
-            round: 1,
-            pid: 2,
-            encryptedPartial: bytes("encrypted-partial"),
-            ephemeralPubKey: bytes("eph-pub"),
-            pubShare: bytes("pub-share"),
-            requesterPubKey: bytes("requester-pub"),
-            ciphertext: bytes("ciphertext"),
-            uuid: uuid,
-            signature: bytes("sig")
-        });
+        return
+            ICDR.PartialDecryptionRequest({
+                round: 1,
+                pid: 2,
+                encryptedPartial: bytes("encrypted-partial"),
+                ephemeralPubKey: bytes("eph-pub"),
+                pubShare: bytes("pub-share"),
+                requesterPubKey: bytes("requester-pub"),
+                ciphertext: bytes("ciphertext"),
+                uuid: uuid,
+                signature: bytes("sig")
+            });
     }
 
     function testCDR_SubmitBatch_EmptyBatch() public {
@@ -192,8 +193,17 @@ contract CDRTest is Test {
 
         vm.expectEmit(true, false, false, false);
         emit ICDR.EncryptedPartialDecryptionSubmitted(
-            address(this), 1, 2, bytes("encrypted-partial"), bytes("eph-pub"),
-            bytes("pub-share"), bytes("requester-pub"), bytes("ciphertext"), 0, bytes("sig"), 0
+            address(this),
+            1,
+            2,
+            bytes("encrypted-partial"),
+            bytes("eph-pub"),
+            bytes("pub-share"),
+            bytes("requester-pub"),
+            bytes("ciphertext"),
+            0,
+            bytes("sig"),
+            0
         );
 
         cdr.submitEncryptedPartialDecryptionBatch(requests);


### PR DESCRIPTION
## Summary

`SGXValidationHook.validateReport` calls the parameterless `IAutomataDcapAttestationFee.verifyAndAttestOnChain(bytes)` overload. The Automata verifier internally treats this as "resolve the standard TCB Evaluation Data Number from the PCCS Router per Intel's TCB Recovery policy" (highest evaluation data number whose `tcbRecoveryEventDate` is ≥ 12 months before `block.timestamp`), so Intel-defined standard transitions (e.g. v18 → v19 on **2026-05-13**) take effect automatically without any owner action.

The change is additive and storage-layout / ABI compatible with the proxy already deployed on Aeneid: the existing implementation can be swapped in place without state migration.

## Contract changes

`SGXValidationHook.validateReport` now calls:

```solidity
(bool success, ) = IAutomataDcapAttestationFee($.automataValidationAddr).verifyAndAttestOnChain(enclaveReport);
```

instead of forwarding the stored `tcbEvaluationDataNumber`. The 1-arg overload internally delegates to `_verifyAndAttestOnChain(rawQuote, 0)` and the verifier resolves the standard version on-chain. The hook needs no knowledge of the PCCS Router address.

`IAutomataDcapAttestationFee` (local minimal interface) gains the 1-arg overload declaration to match the deployed Automata contract.

## Backward compatibility

- **Storage layout — unchanged.** The namespaced struct remains 2 fields:
```solidity
struct SGXValidationHookStorage {
    address automataValidationAddr;     // slot 0 [0:20]
    uint32  tcbEvaluationDataNumber;    // slot 0 [20:24]
}
```