### PR TITLE
feat(upgrade): add seneca upgrade reducing MaxValidators to 21

### DIFF
--- a/client/app/upgrades/seneca/constants.go
+++ b/client/app/upgrades/seneca/constants.go
@@ -1,0 +1,9 @@
+package seneca
+
+import "github.com/piplabs/story/lib/netconf"
+
+const UpgradeName = netconf.Seneca
+
+// NewMaxValidators is the target active validator set size after the seneca
+// upgrade. See SIP-00011 for the rationale of reducing from 80 to 21.
+var NewMaxValidators uint32 = 21

--- a/client/x/evmstaking/keeper/abci.go
+++ b/client/x/evmstaking/keeper/abci.go
@@ -6,10 +6,13 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/piplabs/story/client/app/upgrades/seneca"
 	"github.com/piplabs/story/client/x/evmstaking/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
+	"github.com/piplabs/story/lib/netconf"
 	"github.com/piplabs/story/lib/promutil"
 )
 
@@ -19,6 +22,13 @@ func (k *Keeper) EndBlock(ctx context.Context) (abci.ValidatorUpdates, error) {
 	log.Debug(ctx, "EndBlock.evmstaking")
 
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
+
+	// Apply deferred MaxValidators reduction BEFORE singularity check and
+	// staking EndBlocker. This mirrors gov.EndBlocker → staking.EndBlocker
+	// ordering in standard Cosmos SDK.
+	if err := k.applyDeferredMaxValidatorsChange(ctx); err != nil {
+		return nil, errors.Wrap(err, "apply deferred max validators change")
+	}
 
 	isSingularity, err := k.IsSingularity(ctx)
 	if err != nil {
@@ -51,4 +61,37 @@ func (k *Keeper) EndBlock(ctx context.Context) (abci.ValidatorUpdates, error) {
 	promutil.EVMStakingRewardQueueDepth.Set(float64(k.RewardWithdrawalQueue.Len(ctx)))
 
 	return valUpdates, nil
+}
+
+// applyDeferredMaxValidatorsChange sets MaxValidators at the exact seneca
+// upgrade height. This is a no-op for chains that have not registered Seneca
+// in their upgrade history.
+func (k *Keeper) applyDeferredMaxValidatorsChange(ctx context.Context) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	senecaHeight, err := netconf.GetUpgradeHeight(sdkCtx.ChainID(), netconf.Seneca)
+	if err != nil {
+		return nil // Seneca not registered for this chain — skip
+	}
+
+	if sdkCtx.BlockHeight() != senecaHeight {
+		return nil
+	}
+
+	params, err := k.stakingKeeper.GetParams(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get staking params for max validators change")
+	}
+
+	if params.MaxValidators <= seneca.NewMaxValidators {
+		return nil
+	}
+
+	params.MaxValidators = seneca.NewMaxValidators
+	if err := k.stakingKeeper.SetParams(ctx, params); err != nil {
+		return errors.Wrap(err, "set staking params for max validators change")
+	}
+
+	log.Info(ctx, "Applied deferred MaxValidators reduction", "max_validators", seneca.NewMaxValidators)
+
+	return nil
 }

--- a/client/x/evmstaking/keeper/deferred_maxval_test.go
+++ b/client/x/evmstaking/keeper/deferred_maxval_test.go
@@ -1,0 +1,236 @@
+package keeper
+
+// Internal test file (package keeper, not keeper_test) to access private
+// methods directly. Tests the deferred MaxValidators reduction flow:
+//   applyDeferredMaxValidatorsChange → staking ApplyAndReturnValidatorSetUpdates
+//
+// Uses the real staking keeper to verify that ABCI validator updates are
+// produced correctly.
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttime "github.com/cometbft/cometbft/types/time"
+
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	skeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	estestutil "github.com/piplabs/story/client/x/evmstaking/testutil"
+	"github.com/piplabs/story/client/x/evmstaking/types"
+	"github.com/piplabs/story/lib/ethclient"
+	"github.com/piplabs/story/lib/netconf"
+)
+
+var initBech32Once sync.Once
+
+func initBech32Prefixes() {
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount("story", "storypub")
+	cfg.SetBech32PrefixForValidator("storyvaloper", "storyvaloperpub")
+	cfg.SetBech32PrefixForConsensusNode("storyvalcons", "storyvalconspub")
+}
+
+func TestDeferredMaxValidatorsChange_EndToEnd(t *testing.T) {
+	const numValidators = 25
+
+	initBech32Once.Do(initBech32Prefixes)
+
+	key := storetypes.NewKVStoreKey("test")
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient"))
+	ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Time: cmttime.Now()}).WithChainID(netconf.TestChainID)
+
+	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(interfaceRegistry)
+	authtypes.RegisterInterfaces(interfaceRegistry)
+	banktypes.RegisterInterfaces(interfaceRegistry)
+	stypes.RegisterInterfaces(interfaceRegistry)
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+
+	ctrl := gomock.NewController(t)
+	ak := estestutil.NewMockAccountKeeper(ctrl)
+	bk := estestutil.NewMockBankKeeper(ctrl)
+	dk := estestutil.NewMockDistributionKeeper(ctrl)
+	slk := estestutil.NewMockSlashingKeeper(ctrl)
+	dkgk := estestutil.NewMockDKGKeeper(ctrl)
+
+	ak.EXPECT().AddressCodec().Return(authcodec.NewBech32Codec("story")).AnyTimes()
+	ak.EXPECT().GetModuleAddress(gomock.Any()).Return(authtypes.NewModuleAddress(types.ModuleName)).AnyTimes()
+	bk.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	sk := skeeper.NewKeeper(cdc, storeService, ak, bk,
+		authtypes.NewModuleAddress(stypes.ModuleName).String(),
+		address.NewBech32Codec("storyvaloper"),
+		address.NewBech32Codec("storyvalcons"))
+
+	params := stypes.NewParams(
+		7*24*time.Hour, // unbonding time — long enough
+		uint32(numValidators),
+		stypes.DefaultMaxEntries,
+		stypes.DefaultHistoricalEntries,
+		sdk.DefaultBondDenom,
+		stypes.DefaultMinCommissionRate,
+		math.NewInt(2),
+		stypes.DefaultFlexiblePeriodType,
+		stypes.DefaultPeriods,
+		stypes.DefaultLockedTokenType,
+		stypes.DefaultTokenTypes,
+		0, // singularity disabled
+	)
+	require.NoError(t, sk.SetParams(ctx, params))
+
+	ethCl, err := ethclient.NewEngineMock(key)
+	require.NoError(t, err)
+
+	esk := NewKeeper(cdc, storeService, ak, bk, slk, sk, dk, dkgk,
+		authtypes.NewModuleAddress(types.ModuleName).String(),
+		ethCl,
+		address.NewBech32Codec("storyvaloper"))
+	require.NoError(t, esk.SetParams(ctx, types.DefaultParams()))
+
+	// Create bonded validators
+	for i := 0; i < numValidators; i++ {
+		privKey := secp256k1.GenPrivKey()
+		pubKey := privKey.PubKey()
+		valAddr := sdk.ValAddress(pubKey.Address())
+		val, err := stypes.NewValidator(valAddr.String(), pubKey, stypes.Description{Moniker: "test"}, 0)
+		require.NoError(t, err)
+		val.Commission = stypes.NewCommission(
+			math.LegacyNewDecWithPrec(1000, 4),
+			math.LegacyNewDecWithPrec(5000, 4),
+			math.LegacyNewDecWithPrec(1000, 4),
+		)
+		valTokens := sk.TokensFromConsensusPower(ctx, 10)
+		validator, _, _ := val.AddTokensFromDel(valTokens, math.LegacyNewDecFromInt(valTokens).Quo(math.LegacyNewDec(2)))
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		_ = skeeper.TestingUpdateValidator(sk, sdkCtx, validator, true)
+		require.NoError(t, sk.SetValidatorByConsAddr(ctx, validator))
+	}
+
+	// Verify pre-state
+	bonded, err := sk.GetBondedValidatorsByPower(ctx)
+	require.NoError(t, err)
+	require.Len(t, bonded, numValidators, "pre: %d validators bonded", numValidators)
+
+	// Step 1: applyDeferredMaxValidatorsChange at Seneca height
+	ctx = sdk.UnwrapSDKContext(ctx).WithBlockHeight(300) // TestChainID Seneca = 300
+	err = esk.applyDeferredMaxValidatorsChange(ctx)
+	require.NoError(t, err)
+
+	p, err := sk.GetParams(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint32(21), p.MaxValidators, "MaxValidators should be 21")
+
+	// Step 2: staking ApplyAndReturnValidatorSetUpdates (same as EndBlocker would call)
+	updates, err := sk.ApplyAndReturnValidatorSetUpdates(ctx)
+	require.NoError(t, err)
+
+	expectedRemovals := numValidators - 21
+	require.Len(t, updates, expectedRemovals,
+		"Apply should return %d removal updates", expectedRemovals)
+
+	for i, u := range updates {
+		require.Equal(t, int64(0), u.Power, "update[%d] should be zero-power", i)
+	}
+
+	// Step 3: bonded set is now 21
+	bonded, err = sk.GetBondedValidatorsByPower(ctx)
+	require.NoError(t, err)
+	require.Len(t, bonded, 21, "post: exactly 21 bonded")
+}
+
+func TestDeferredMaxValidatorsChange_NotUpgradeHeight(t *testing.T) {
+	key := storetypes.NewKVStoreKey("test")
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient"))
+	ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Time: cmttime.Now()}).WithChainID(netconf.TestChainID)
+
+	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(interfaceRegistry)
+	stypes.RegisterInterfaces(interfaceRegistry)
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+
+	ctrl := gomock.NewController(t)
+	ak := estestutil.NewMockAccountKeeper(ctrl)
+	bk := estestutil.NewMockBankKeeper(ctrl)
+
+	ak.EXPECT().AddressCodec().Return(authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())).AnyTimes()
+	ak.EXPECT().GetModuleAddress(gomock.Any()).Return(authtypes.NewModuleAddress(types.ModuleName)).AnyTimes()
+
+	sk := skeeper.NewKeeper(cdc, storeService, ak, bk,
+		authtypes.NewModuleAddress(stypes.ModuleName).String(),
+		address.NewBech32Codec("storyvaloper"),
+		address.NewBech32Codec("storyvalcons"))
+	require.NoError(t, sk.SetParams(ctx, stypes.DefaultParams()))
+
+	esk := &Keeper{stakingKeeper: sk}
+
+	origParams, _ := sk.GetParams(ctx)
+	origMax := origParams.MaxValidators
+
+	// Height 100 — not Seneca (300)
+	ctx = sdk.UnwrapSDKContext(ctx).WithBlockHeight(100)
+	err := esk.applyDeferredMaxValidatorsChange(ctx)
+	require.NoError(t, err)
+
+	p, _ := sk.GetParams(ctx)
+	require.Equal(t, origMax, p.MaxValidators, "should not change at non-upgrade height")
+}
+
+func TestDeferredMaxValidatorsChange_AlreadyBelow(t *testing.T) {
+	key := storetypes.NewKVStoreKey("test")
+	storeService := runtime.NewKVStoreService(key)
+	testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient"))
+	ctx := testCtx.Ctx.WithBlockHeader(cmtproto.Header{Time: cmttime.Now()}).WithChainID(netconf.TestChainID)
+
+	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(interfaceRegistry)
+	stypes.RegisterInterfaces(interfaceRegistry)
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+
+	ctrl := gomock.NewController(t)
+	ak := estestutil.NewMockAccountKeeper(ctrl)
+	bk := estestutil.NewMockBankKeeper(ctrl)
+
+	ak.EXPECT().AddressCodec().Return(authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())).AnyTimes()
+	ak.EXPECT().GetModuleAddress(gomock.Any()).Return(authtypes.NewModuleAddress(types.ModuleName)).AnyTimes()
+
+	sk := skeeper.NewKeeper(cdc, storeService, ak, bk,
+		authtypes.NewModuleAddress(stypes.ModuleName).String(),
+		address.NewBech32Codec("storyvaloper"),
+		address.NewBech32Codec("storyvalcons"))
+
+	params := stypes.DefaultParams()
+	params.MaxValidators = 10
+	require.NoError(t, sk.SetParams(ctx, params))
+
+	esk := &Keeper{stakingKeeper: sk}
+
+	ctx = sdk.UnwrapSDKContext(ctx).WithBlockHeight(300)
+	err := esk.applyDeferredMaxValidatorsChange(ctx)
+	require.NoError(t, err)
+
+	p, _ := sk.GetParams(ctx)
+	require.Equal(t, uint32(10), p.MaxValidators, "should not increase")
+}

--- a/client/x/evmstaking/testutil/expected_keepers_mocks.go
+++ b/client/x/evmstaking/testutil/expected_keepers_mocks.go
@@ -400,6 +400,35 @@ func (m *MockStakingKeeper) EXPECT() *MockStakingKeeperMockRecorder {
 	return m.recorder
 }
 
+// GetParams mocks base method.
+func (m *MockStakingKeeper) GetParams(ctx context.Context) (types2.Params, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetParams", ctx)
+	ret0, _ := ret[0].(types2.Params)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetParams indicates an expected call of GetParams.
+func (mr *MockStakingKeeperMockRecorder) GetParams(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParams", reflect.TypeOf((*MockStakingKeeper)(nil).GetParams), ctx)
+}
+
+// SetParams mocks base method.
+func (m *MockStakingKeeper) SetParams(ctx context.Context, params types2.Params) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetParams", ctx, params)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetParams indicates an expected call of SetParams.
+func (mr *MockStakingKeeperMockRecorder) SetParams(ctx, params any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParams", reflect.TypeOf((*MockStakingKeeper)(nil).SetParams), ctx, params)
+}
+
 // BondDenom mocks base method.
 func (m *MockStakingKeeper) BondDenom(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/client/x/evmstaking/types/expected_keepers.go
+++ b/client/x/evmstaking/types/expected_keepers.go
@@ -78,6 +78,9 @@ type StakingKeeper interface {
 	GetTokenTypeInfo(ctx context.Context, tokenType int32) (stakingtypes.TokenTypeInfo, error)
 
 	GetSingularityHeight(ctx context.Context) (uint64, error)
+
+	GetParams(ctx context.Context) (stakingtypes.Params, error)
+	SetParams(ctx context.Context, params stakingtypes.Params) error
 }
 
 // SlashingKeeper defines the expected interface for the slashing module.

--- a/lib/netconf/upgrades.go
+++ b/lib/netconf/upgrades.go
@@ -16,6 +16,8 @@ const (
 
 	Horace = "horace"
 	V160   = "v1.6.0"
+
+	Seneca = "seneca"
 )
 
 var (
@@ -32,6 +34,7 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Terence: 50,
 		V142:    50,
 		Horace:  100,
+		Seneca:  300,
 	},
 	LocalChainID: {
 		V121:    0,
@@ -53,6 +56,7 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Terence:  10886688,
 		V142:     12088950,
 		Horace:   14017000,
+		Seneca:   18550000,
 	},
 	StoryChainID: {
 		Virgil:   809988,
@@ -122,4 +126,13 @@ func IsV142(chainID string, blockNumber int64) (bool, error) {
 	}
 
 	return blockNumber >= v142Block, nil
+}
+
+func IsSeneca(chainID string, blockNumber int64) (bool, error) {
+	senecaBlock, err := GetUpgradeHeight(chainID, Seneca)
+	if err != nil {
+		return false, err
+	}
+
+	return blockNumber >= senecaBlock, nil
 }


### PR DESCRIPTION
## Summary

Adds the `seneca` upgrade ([SIP-00011](https://forum.story.foundation/t/proposal-sip-00011-reducing-the-active-validator-set-from-80-to-21/37481)) that reduces the active validator set size from 80 to 21.

Scheduled on Aeneid at block [`18550000`](https://aeneid.storyscan.io/block/countdown/18550000).

## Implementation Notes

The `MaxValidators` param change is applied in `evmstaking.EndBlock` (not in an upgrade handler) to mirror the standard Cosmos SDK flow where `gov.EndBlocker` applies param changes before `staking.EndBlocker` prunes the validator set. This ensures:

1. `BeginBlocker`'s `GetLastValidators` does not panic — `MaxValidators` still holds the old value during `BeginBlock` of the upgrade block.
2. ABCI validator updates from `ApplyAndReturnValidatorSetUpdates` flow through the normal `EndBlock` return path to CometBFT.

issue: none