### PR TITLE
fix(server): base64 decode pagination key in rest query handlers

### DIFF
--- a/client/server/payload.go
+++ b/client/server/payload.go
@@ -4,14 +4,19 @@ import (
 	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"github.com/piplabs/story/client/server/utils"
 )
 
 type pagination struct {
-	Key        string `mapstructure:"key"`
-	Offset     uint64 `mapstructure:"offset"`
-	Limit      uint64 `mapstructure:"limit"`
-	CountTotal bool   `mapstructure:"count_total"`
-	Reverse    bool   `mapstructure:"reverse"`
+	// Key is base64-decoded from the query string by utils.QueryMapToVal so
+	// callers can pass back PageResponse.NextKey (amino-encoded as base64) as
+	// pagination.key without manual decoding.
+	Key        utils.Base64Bytes `mapstructure:"key"`
+	Offset     uint64            `mapstructure:"offset"`
+	Limit      uint64            `mapstructure:"limit"`
+	CountTotal bool              `mapstructure:"count_total"`
+	Reverse    bool              `mapstructure:"reverse"`
 }
 
 type getSupplyByDenomRequest struct {

--- a/client/server/utils/querymap.go
+++ b/client/server/utils/querymap.go
@@ -2,6 +2,7 @@
 package utils
 
 import (
+	"encoding/base64"
 	"math"
 	"math/big"
 	"net/url"
@@ -11,7 +12,11 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/piplabs/story/lib/errors"
 )
+
+var base64BytesType = reflect.TypeOf(Base64Bytes(nil))
 
 // QueryMapToVal implements an all-in-one decoder to decode requests' query parameters to
 // structured value.
@@ -21,6 +26,7 @@ func QueryMapToVal(query url.Values, val any) error {
 		Result:           val,
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			stringArrayToBase64Bytes(),
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 			stringArrayToNative(),
@@ -32,6 +38,30 @@ func QueryMapToVal(query url.Values, val any) error {
 	}
 
 	return decoder.Decode(buildMap(query))
+}
+
+// stringArrayToBase64Bytes decodes a single query-string value into Base64Bytes
+// using standard base64 (matching how amino MarshalJSON serializes []byte in
+// responses, e.g. pagination next_key). This lets callers round-trip the
+// next_key field without manual decoding.
+func stringArrayToBase64Bytes() mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if t != base64BytesType {
+			return data, nil
+		}
+
+		as, ok := data.([]string)
+		if !ok || len(as) == 0 || as[0] == "" {
+			return Base64Bytes(nil), nil
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(as[0])
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid base64 value", "target_type", t.String())
+		}
+
+		return Base64Bytes(decoded), nil
+	}
 }
 
 func stringArrayToNativePtr() mapstructure.DecodeHookFunc {

--- a/client/server/utils/querymap_test.go
+++ b/client/server/utils/querymap_test.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"encoding/base64"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryMapToVal_Base64BytesPaginationKey covers the chain-side fix for the
+// pagination bug where /staking/validators page 2 returned zero entries:
+// PageResponse.NextKey is amino-serialized as a base64 string, but the request
+// handler previously cast pagination.key directly to []byte without decoding,
+// turning a 21-byte validator iterator key into 28 ASCII bytes that pointed
+// outside the prefix store. The hook decodes base64 once at the query-parse
+// boundary so handlers can hand the value straight to query.PageRequest.Key.
+func TestQueryMapToVal_Base64BytesPaginationKey(t *testing.T) {
+	t.Parallel()
+
+	type req struct {
+		Key Base64Bytes `mapstructure:"key"`
+	}
+
+	// 21-byte validator store key: 0x14 length-prefix + 20-byte address. This
+	// is the exact shape emitted by cosmos-sdk x/staking GetValidatorKey.
+	raw := []byte{
+		0x14,
+		0x86, 0x5e, 0xeb, 0x8c, 0x35, 0x9c, 0xc1, 0x13,
+		0x77, 0x11, 0xf7, 0xa2, 0xcc, 0x15, 0xd1, 0x95,
+		0x18, 0x3f, 0x64, 0x93,
+	}
+	encoded := base64.StdEncoding.EncodeToString(raw)
+
+	q := url.Values{}
+	q.Set("key", encoded)
+
+	var got req
+	require.NoError(t, QueryMapToVal(q, &got))
+	require.Equal(t, Base64Bytes(raw), got.Key, "base64 query value must decode to raw store key")
+}
+
+// TestQueryMapToVal_Base64BytesEmpty ensures the hook treats an absent or empty
+// pagination.key as an empty slice (matching how cosmos-sdk paginate() handles
+// nil page-request keys).
+func TestQueryMapToVal_Base64BytesEmpty(t *testing.T) {
+	t.Parallel()
+
+	type req struct {
+		Key Base64Bytes `mapstructure:"key"`
+	}
+
+	// Empty value.
+	q := url.Values{}
+	q.Set("key", "")
+
+	var got req
+	require.NoError(t, QueryMapToVal(q, &got))
+	require.Empty(t, got.Key)
+
+	// Missing field entirely.
+	var got2 req
+	require.NoError(t, QueryMapToVal(url.Values{}, &got2))
+	require.Empty(t, got2.Key)
+}
+
+// TestQueryMapToVal_Base64BytesInvalid rejects malformed base64 instead of
+// silently casting to raw ASCII bytes (which is what the bug did).
+func TestQueryMapToVal_Base64BytesInvalid(t *testing.T) {
+	t.Parallel()
+
+	type req struct {
+		Key Base64Bytes `mapstructure:"key"`
+	}
+
+	q := url.Values{}
+	q.Set("key", "not!valid!base64!")
+
+	var got req
+	require.Error(t, QueryMapToVal(q, &got))
+}

--- a/client/server/utils/types.go
+++ b/client/server/utils/types.go
@@ -1,0 +1,10 @@
+package utils
+
+// Base64Bytes is a []byte that is base64-decoded from a string when populated
+// from HTTP query parameters by QueryMapToVal. It exists so handlers can keep
+// taking raw bytes for fields like cosmos-sdk PageRequest.Key, while the wire
+// representation (set by amino MarshalJSON on []byte) stays as standard
+// base64-encoded strings. Without this round-trip, page 2 requests submit the
+// undecoded base64 ASCII as the iterator start key and silently return zero
+// results.
+type Base64Bytes []byte


### PR DESCRIPTION
## Summary

`/staking/validators` and 12 other paginated REST endpoints silently return 0 entries on page 2+. `PageResponse.NextKey` is amino-encoded as a base64 string, but the request side casts `pagination.key` straight to `[]byte`. The chain interprets the 28-char base64 ASCII as a raw store-iterator key, lands outside the prefix store, and returns an empty page.

This is the chain-side root cause for story-staking-api#76 (APR fix) having no effect on Aeneid (APR stuck at 557.05%).

## Fix

Decode at the query-parse boundary instead of patching every handler:

1. New named type utils.Base64Bytes []byte.
2. New mapstructure decode hook that base64-decodes the value when the target is Base64Bytes, registered first in ComposeDecodeHookFunc.
3. Switch payload.pagination.Key from string to utils.Base64Bytes.

Because Base64Bytes is just a named []byte, the existing []byte(req.Pagination.Key) casts in all 13 handlers (staking.go × 10, distribution.go × 1, evmstaking.go × 2) become identity conversions. No handler code changes; any future paginated endpoint inherits the fix through the shared pagination struct. Bad base64 now returns 400 instead of silently corrupting the iterator key.

issue: none