### PR TITLE
fix(dkg): preserve active round decrypt queue when successor session is created

### DIFF
--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -325,10 +325,11 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 
 	sessions := k.stateManager.ListSessions()
 
-	var maxRound uint32
+	// Anchor drain on the latest IsFinalized round (issue piplabs/story#826).
+	var latestActivated uint32
 	for _, s := range sessions {
-		if s.Round > maxRound {
-			maxRound = s.Round
+		if s.IsFinalized && s.Round > latestActivated {
+			latestActivated = s.Round
 		}
 	}
 
@@ -336,12 +337,13 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 		// Drop queued requests from sessions that are at least 2 rounds behind the
 		// current round — their keys are no longer relevant and the requests would
 		// never be processed successfully.
-		if maxRound >= 2 && session.Round <= maxRound-2 {
+		if latestActivated >= 2 && session.Round <= latestActivated-2 {
 			dropped := session.DrainDecryptRequests()
 			if len(dropped) > 0 {
 				log.Warn(ctx, "Dropping decrypt requests from stale session", nil,
 					"session", session.GetSessionKey(),
 					"dropped_requests", len(dropped),
+					"latest_activated_round", latestActivated,
 				)
 				incDecryptRequest(labelDecryptStaleDropped, len(dropped))
 				if err := k.stateManager.UpdateSession(ctx, session); err != nil {

--- a/client/x/dkg/keeper/dkg_svc_test.go
+++ b/client/x/dkg/keeper/dkg_svc_test.go
@@ -664,11 +664,9 @@ func TestProcessDecryptQueue_PartialStaleRequests(t *testing.T) {
 	require.Empty(t, got.GetDecryptRequests(), "only fresh request processed, nothing re-queued")
 }
 
-// ---------- stale session clearing (round <= maxRound-2) ----------
+// ---------- stale session clearing (round <= latestActivated-2) ----------
 
-// TestProcessDecryptQueue_StaleSessionRequestsDropped verifies that requests in a session
-// that is at least 2 rounds behind the latest session are drained and discarded, while
-// requests in sessions within the 2-round window are left untouched.
+// Drain requests from sessions >=2 rounds behind the latest activated round.
 func TestProcessDecryptQueue_StaleSessionRequestsDropped(t *testing.T) {
 	t.Parallel()
 
@@ -682,15 +680,16 @@ func TestProcessDecryptQueue_StaleSessionRequestsDropped(t *testing.T) {
 
 	req := types.DecryptRequest{Ciphertext: []byte("ct"), Label: make([]byte, 32)}
 
-	// Round 1 is stale (maxRound=3, 3-2=1, round 1 <= 1).
+	// latestActivated=3 → drain round <=1.
 	stale := &types.DKGSession{
 		Round: 1, Index: 0, GlobalPubKey: []byte("pub"),
 		DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+		IsFinalized:     true,
 	}
-	// Round 3 is current — Index=0 so it will be deferred, not cleared.
 	current := &types.DKGSession{
 		Round: 3, Index: 0, GlobalPubKey: []byte("pub"),
 		DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+		IsFinalized:     true,
 	}
 	require.NoError(t, sm.CreateSession(ctx, stale))
 	require.NoError(t, sm.CreateSession(ctx, current))
@@ -700,16 +699,14 @@ func TestProcessDecryptQueue_StaleSessionRequestsDropped(t *testing.T) {
 
 	gotStale, err := sm.GetSession(1)
 	require.NoError(t, err)
-	require.Empty(t, gotStale.GetDecryptRequests(), "stale session requests must be dropped")
+	require.Empty(t, gotStale.GetDecryptRequests())
 
 	gotCurrent, err := sm.GetSession(3)
 	require.NoError(t, err)
-	require.Len(t, gotCurrent.GetDecryptRequests(), 1, "current session requests must be preserved")
+	require.Len(t, gotCurrent.GetDecryptRequests(), 1)
 }
 
-// TestProcessDecryptQueue_StaleSessionBoundaryPreserved verifies that a session exactly
-// 1 round behind the latest (maxRound-1) is NOT cleared — only sessions >= 2 rounds
-// behind are eligible for stale clearing.
+// Boundary at latestActivated-1 is preserved (one-round buffer).
 func TestProcessDecryptQueue_StaleSessionBoundaryPreserved(t *testing.T) {
 	t.Parallel()
 
@@ -723,14 +720,16 @@ func TestProcessDecryptQueue_StaleSessionBoundaryPreserved(t *testing.T) {
 
 	req := types.DecryptRequest{Ciphertext: []byte("ct"), Label: make([]byte, 32)}
 
-	// maxRound=3; maxRound-2=1. Round 2 > 1, so it must NOT be cleared.
+	// latestActivated=3 → drain round <=1; round 2 preserved.
 	boundary := &types.DKGSession{
 		Round: 2, Index: 0, GlobalPubKey: []byte("pub"),
 		DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+		IsFinalized:     true,
 	}
 	latest := &types.DKGSession{
 		Round: 3, Index: 0, GlobalPubKey: []byte("pub"),
 		DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+		IsFinalized:     true,
 	}
 	require.NoError(t, sm.CreateSession(ctx, boundary))
 	require.NoError(t, sm.CreateSession(ctx, latest))
@@ -740,11 +739,10 @@ func TestProcessDecryptQueue_StaleSessionBoundaryPreserved(t *testing.T) {
 
 	gotBoundary, err := sm.GetSession(2)
 	require.NoError(t, err)
-	require.Len(t, gotBoundary.GetDecryptRequests(), 1, "boundary session (maxRound-1) must not be cleared")
+	require.Len(t, gotBoundary.GetDecryptRequests(), 1)
 }
 
-// TestProcessDecryptQueue_SingleSessionNotCleared verifies that when there is only one
-// session the maxRound<2 guard prevents any stale clearing (no uint32 underflow).
+// latestActivated<2 guard prevents uint32 underflow.
 func TestProcessDecryptQueue_SingleSessionNotCleared(t *testing.T) {
 	t.Parallel()
 
@@ -760,6 +758,7 @@ func TestProcessDecryptQueue_SingleSessionNotCleared(t *testing.T) {
 	session := &types.DKGSession{
 		Round: 1, Index: 0, GlobalPubKey: []byte("pub"),
 		DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+		IsFinalized:     true,
 	}
 	require.NoError(t, sm.CreateSession(ctx, session))
 
@@ -768,7 +767,85 @@ func TestProcessDecryptQueue_SingleSessionNotCleared(t *testing.T) {
 
 	got, err := sm.GetSession(1)
 	require.NoError(t, err)
-	require.Len(t, got.GetDecryptRequests(), 1, "single session must not be cleared")
+	require.Len(t, got.GetDecryptRequests(), 1)
+}
+
+// Issue piplabs/story#826: stuck N+1 + created N+2 must not drain active N.
+func TestProcessDecryptQueue_StuckRoundPreservesActive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+	mockContract.EXPECT().BlockNumber(gomock.Any()).Return(uint64(100), nil)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	req := types.DecryptRequest{Ciphertext: []byte("ct"), Label: make([]byte, 32)}
+
+	// Round 10: chain's latest_active. Index=0 → deferred, not cleared.
+	active := &types.DKGSession{
+		Round: 10, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+		IsFinalized:     true,
+	}
+	// Round 11: stuck mid-finalization.
+	stuck := &types.DKGSession{
+		Round: 11, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.PendingDecryptRequest{},
+		IsFinalized:     false,
+	}
+	// Round 12: registration phase just started.
+	pending := &types.DKGSession{
+		Round: 12, Index: 0, GlobalPubKey: []byte("pub"),
+		DecryptRequests: []types.PendingDecryptRequest{},
+		IsFinalized:     false,
+	}
+	require.NoError(t, sm.CreateSession(ctx, active))
+	require.NoError(t, sm.CreateSession(ctx, stuck))
+	require.NoError(t, sm.CreateSession(ctx, pending))
+
+	k := &Keeper{stateManager: sm, contractClient: mockContract, kernelRouter: NewKernelRouter(nil, nil)}
+	k.processDecryptQueue(ctx)
+
+	gotActive, err := sm.GetSession(10)
+	require.NoError(t, err)
+	require.Len(t, gotActive.GetDecryptRequests(), 1,
+		"active round's queue must survive stuck/created successors")
+}
+
+// Fresh node with no activated session must not drain (memory > silent loss).
+func TestProcessDecryptQueue_NoActivatedSessionsNoDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+	mockContract.EXPECT().BlockNumber(gomock.Any()).Return(uint64(100), nil)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	req := types.DecryptRequest{Ciphertext: []byte("ct"), Label: make([]byte, 32)}
+
+	for _, r := range []uint32{1, 2, 3, 5, 8} {
+		s := &types.DKGSession{
+			Round: r, Index: 0, GlobalPubKey: []byte("pub"),
+			DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+			IsFinalized:     false,
+		}
+		require.NoError(t, sm.CreateSession(ctx, s))
+	}
+
+	k := &Keeper{stateManager: sm, contractClient: mockContract, kernelRouter: NewKernelRouter(nil, nil)}
+	k.processDecryptQueue(ctx)
+
+	for _, r := range []uint32{1, 2, 3, 5, 8} {
+		got, err := sm.GetSession(r)
+		require.NoError(t, err)
+		require.Len(t, got.GetDecryptRequests(), 1, "round %d", r)
+	}
 }
 
 // TestComputePartialDecrypt_PanicRecovery verifies that a panic inside the kernel call


### PR DESCRIPTION
## Summary

`processDecryptQueue` previously anchored its stale-drain heuristic on `max(s.Round)` across all in-memory sessions. When round `N+1` got stuck and round `N+2`'s session was created, that anchor jumped to `N+2` and unconditionally drained the still-serving round `N`'s decrypt queue.

This change anchors the drain on the latest round with `IsFinalized=true` (set by `handleDKGComplete` when the round transitions to `PhaseCompleted`), so a stuck or in-progress successor cannot drain the active round's queue.

issue: #826 