### PR TITLE
fix(dkg): invalidate finalized validators whose share is off the consensus polynomial

### DIFF
--- a/client/x/dkg/keeper/dkg_finalization.go
+++ b/client/x/dkg/keeper/dkg_finalization.go
@@ -3,6 +3,10 @@ package keeper
 import (
 	"context"
 
+	"cosmossdk.io/collections"
+
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
@@ -27,14 +31,22 @@ func (k *Keeper) BeginFinalization(ctx context.Context, latestRound *types.DKGNe
 }
 
 func (k *Keeper) FinalizeDKGRound(ctx context.Context, latestRound *types.DKGNetwork) error {
-	// Guard: global public key must be set before finalizing. If it's empty,
-	// the round did not complete key generation and should not be activated.
-	if len(latestRound.GlobalPublicKey) == 0 {
-		log.Info(ctx, "Global public key not set, skipping to next round",
+	// Guard: consensus key material must be set before finalizing. If it's empty, the
+	// round did not complete key generation and should not be activated.
+	if len(latestRound.GlobalPublicKey) == 0 || len(latestRound.PublicCoeffs) == 0 {
+		log.Info(ctx, "Consensus key material not set, skipping to next round",
 			"round", latestRound.Round,
 		)
 
 		return k.SkipToNextRound(ctx, latestRound)
+	}
+
+	// Drop finalized validators whose finalize vote diverged from the consensus
+	// polynomial before counting.
+	if k.isV190Round(ctx, latestRound) {
+		if err := k.invalidateNonConsensusFinalizations(ctx, latestRound); err != nil {
+			return errors.Wrap(err, "failed to invalidate non-consensus finalizations")
+		}
 	}
 
 	finalizedCount, err := k.countDKGRegistrationsByStatus(ctx, latestRound.Round, types.DKGRegStatusFinalized)
@@ -114,6 +126,74 @@ func (k *Keeper) FinalizeDKGRound(ctx context.Context, latestRound *types.DKGNet
 
 	roundsTotal.WithLabelValues(labelRoundCompleted).Inc()
 	log.Info(ctx, "DKG network setup completed", "round", latestRound.Round)
+
+	return nil
+}
+
+// pruneRoundFinalizeVotes removes all recorded finalize votes for a round, used when the
+// round is abandoned via SkipToNextRound (the success path prunes them in
+// invalidateNonConsensusFinalizations).
+func (k *Keeper) pruneRoundFinalizeVotes(ctx context.Context, round uint32) error {
+	regs, err := k.getDKGRegistrationsByRound(ctx, round)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch DKG registrations")
+	}
+
+	for i := range regs {
+		key := finalizeVoteStoreKey(round, common.HexToAddress(regs[i].ValidatorAddr))
+		if err := k.FinalizeVotes.Remove(ctx, key); err != nil {
+			return errors.Wrap(err, "failed to prune finalize vote", "validator", regs[i].ValidatorAddr)
+		}
+	}
+
+	return nil
+}
+
+// invalidateNonConsensusFinalizations invalidates finalized validators whose finalize
+// vote (globalPubKey + publicCoeffs) does not match the consensus polynomial. Because
+// the kernel derives globalPubKey, publicCoeffs and pubKeyShare from the same key share,
+// matching the consensus vote implies the validator's share lies on the consensus
+// polynomial. The recorded votes are pruned here.
+func (k *Keeper) invalidateNonConsensusFinalizations(ctx context.Context, latestRound *types.DKGNetwork) error {
+	consensusKey := globalPubKeyVoteKey(latestRound.Round, latestRound.GlobalPublicKey, latestRound.PublicCoeffs)
+
+	finalizedRegs, err := k.getDKGRegistrationsByStatus(ctx, latestRound.Round, types.DKGRegStatusFinalized)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch finalized DKG registrations")
+	}
+
+	for i := range finalizedRegs {
+		reg := finalizedRegs[i]
+		voteStoreKey := finalizeVoteStoreKey(latestRound.Round, common.HexToAddress(reg.ValidatorAddr))
+
+		submitted, err := k.FinalizeVotes.Get(ctx, voteStoreKey)
+		if err != nil && !errors.Is(err, collections.ErrNotFound) {
+			return errors.Wrap(err, "failed to get finalize vote", "validator", reg.ValidatorAddr)
+		}
+
+		if err := k.FinalizeVotes.Remove(ctx, voteStoreKey); err != nil {
+			return errors.Wrap(err, "failed to prune finalize vote", "validator", reg.ValidatorAddr)
+		}
+
+		if submitted == consensusKey {
+			continue
+		}
+
+		reg.Status = types.DKGRegStatusInvalidated
+		if err := k.setDKGRegistration(ctx, common.HexToAddress(reg.ValidatorAddr), &reg); err != nil {
+			return errors.Wrap(err, "failed to invalidate non-consensus finalization",
+				"validator", reg.ValidatorAddr,
+				"index", reg.Index,
+			)
+		}
+
+		log.Warn(ctx, "Invalidated finalized validator: finalize vote does not match consensus",
+			nil,
+			"round", latestRound.Round,
+			"validator", reg.ValidatorAddr,
+			"index", reg.Index,
+		)
+	}
 
 	return nil
 }

--- a/client/x/dkg/keeper/dkg_finalization_internal_test.go
+++ b/client/x/dkg/keeper/dkg_finalization_internal_test.go
@@ -12,8 +12,16 @@ import (
 
 	dkgtestutil "github.com/piplabs/story/client/x/dkg/testutil"
 	"github.com/piplabs/story/client/x/dkg/types"
+	"github.com/piplabs/story/lib/netconf"
 
 	"go.uber.org/mock/gomock"
+)
+
+// consensusGPK / consensusCoeffs are arbitrary fixed consensus key material used by
+// the finalize-vote tests (only their byte identity matters, not their curve validity).
+var (
+	consensusGPK    = []byte{0xaa, 0xbb, 0xcc}
+	consensusCoeffs = [][]byte{{0x01}, {0x02}}
 )
 
 func TestFinalizeDKGRound_ThresholdChecks(t *testing.T) {
@@ -119,10 +127,14 @@ func TestFinalizeDKGRound_ThresholdChecks(t *testing.T) {
 			params.MinReqFinalizedParticipants = tc.minReqFinalized
 			require.NoError(t, k.SetParams(ctx, params))
 
-			// Set up DKG network (GlobalPublicKey must be non-empty for finalization to proceed)
-			var globalPubKey []byte
+			// Set up DKG network (consensus key material must be non-empty to proceed)
+			var (
+				globalPubKey []byte
+				publicCoeffs [][]byte
+			)
 			if !tc.emptyGlobalKey {
 				globalPubKey = []byte("global-pub-key")
+				publicCoeffs = [][]byte{[]byte("coeff")}
 			}
 			latestRound := &types.DKGNetwork{
 				Round:           testRound,
@@ -131,6 +143,7 @@ func TestFinalizeDKGRound_ThresholdChecks(t *testing.T) {
 				Threshold:       tc.threshold,
 				Stage:           types.DKGStageFinalization,
 				GlobalPublicKey: globalPubKey,
+				PublicCoeffs:    publicCoeffs,
 			}
 			require.NoError(t, k.setDKGNetwork(sdkCtx, latestRound))
 
@@ -183,6 +196,7 @@ func TestFinalizeDKGRound_UpgradeRound(t *testing.T) {
 		Stage:           types.DKGStageFinalization,
 		IsUpgrade:       true, // upgrade resharing round
 		GlobalPublicKey: []byte("global-pub-key"),
+		PublicCoeffs:    [][]byte{[]byte("coeff")},
 	}
 	require.NoError(t, k.setDKGNetwork(sdkCtx, latestRound))
 
@@ -236,6 +250,7 @@ func TestFinalizeDKGRound_DKGSvcEnabled(t *testing.T) {
 		Stage:           types.DKGStageFinalization,
 		IsUpgrade:       false,
 		GlobalPublicKey: []byte("global-pub-key"),
+		PublicCoeffs:    [][]byte{[]byte("coeff")},
 	}
 	require.NoError(t, k.setDKGNetwork(sdkCtx, latestRound))
 
@@ -329,4 +344,248 @@ func TestBeginFinalization_DKGSvcEnabled(t *testing.T) {
 
 	err := k.BeginFinalization(ctx, network)
 	require.NoError(t, err)
+}
+
+// TestInvalidateNonConsensusFinalizations verifies the core sweep: finalized validators
+// whose recorded finalize vote matches the consensus key are kept; those that diverge
+// (or have no recorded vote) are invalidated, and all recorded votes are pruned.
+func TestInvalidateNonConsensusFinalizations(t *testing.T) {
+	const (
+		round = uint32(7)
+		n     = 5
+	)
+
+	validators := make([]common.Address, n)
+	for i := range n {
+		validators[i] = common.BytesToAddress([]byte{byte(i + 1)})
+	}
+
+	// Index divergentIdx voted for a different polynomial; index missingIdx has no vote.
+	const divergentIdx, missingIdx = 2, 3
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx)
+
+	latestRound := &types.DKGNetwork{
+		Round:           round,
+		Total:           n,
+		Threshold:       3,
+		Stage:           types.DKGStageFinalization,
+		GlobalPublicKey: consensusGPK,
+		PublicCoeffs:    consensusCoeffs,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+
+	consensusKey := globalPubKeyVoteKey(round, consensusGPK, consensusCoeffs)
+	divergentKey := globalPubKeyVoteKey(round, consensusGPK, [][]byte{{0x09}}) // different coeffs
+
+	for i := range n {
+		reg := &types.DKGRegistration{
+			Round:         round,
+			ValidatorAddr: validators[i].Hex(),
+			Index:         uint32(i + 1),
+			Status:        types.DKGRegStatusFinalized,
+		}
+		require.NoError(t, k.setDKGRegistration(ctx, validators[i], reg))
+
+		switch i {
+		case missingIdx:
+			// no recorded finalize vote
+		case divergentIdx:
+			require.NoError(t, k.FinalizeVotes.Set(ctx, finalizeVoteStoreKey(round, validators[i]), divergentKey))
+		default:
+			require.NoError(t, k.FinalizeVotes.Set(ctx, finalizeVoteStoreKey(round, validators[i]), consensusKey))
+		}
+	}
+
+	require.NoError(t, k.invalidateNonConsensusFinalizations(ctx, latestRound))
+
+	for i := range n {
+		reg, err := k.getDKGRegistration(ctx, round, validators[i])
+		require.NoError(t, err)
+
+		if i == divergentIdx || i == missingIdx {
+			require.Equal(t, types.DKGRegStatusInvalidated, reg.Status,
+				"participant %d (non-consensus vote) should be invalidated", i+1)
+		} else {
+			require.Equal(t, types.DKGRegStatusFinalized, reg.Status,
+				"participant %d (consensus vote) should remain finalized", i+1)
+		}
+
+		// Recorded votes are pruned.
+		has, err := k.FinalizeVotes.Has(ctx, finalizeVoteStoreKey(round, validators[i]))
+		require.NoError(t, err)
+		require.False(t, has, "finalize vote for participant %d should be pruned", i+1)
+	}
+}
+
+// TestSkipToNextRound_PrunesFinalizeVotes verifies that abandoning a v1.9.0 round that
+// recorded finalize votes (but never reached consensus) prunes those votes, so they do
+// not leak across rounds.
+func TestSkipToNextRound_PrunesFinalizeVotes(t *testing.T) {
+	const round = uint32(14)
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+
+	val := common.BytesToAddress([]byte{0x01})
+	latestRound := &types.DKGNetwork{
+		Round:            round,
+		Total:            1,
+		Threshold:        2, // never reached -> GlobalPublicKey stays empty -> guard skip
+		Stage:            types.DKGStageFinalization,
+		StartBlockHeight: 400, // v1.9.0 active
+		ActiveValSet:     []string{val.Hex()},
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+
+	// A validator finalized (recorded a vote) but consensus did not reach threshold.
+	require.NoError(t, k.setDKGRegistration(ctx, val, &types.DKGRegistration{
+		Round:         round,
+		ValidatorAddr: val.Hex(),
+		Index:         1,
+		Status:        types.DKGRegStatusFinalized,
+	}))
+	require.NoError(t, k.FinalizeVotes.Set(ctx, finalizeVoteStoreKey(round, val), "some-vote-key"))
+
+	// SkipToNextRound -> InitiateDKGRound needs stakingKeeper.GetAllValidators.
+	sk := k.stakingKeeper.(*dkgtestutil.MockStakingKeeper)
+	sk.EXPECT().GetAllValidators(ctx).Return(nil, nil).Times(1)
+
+	// GlobalPublicKey empty -> FinalizeDKGRound takes the guard skip path (no sweep).
+	require.NoError(t, k.FinalizeDKGRound(ctx, latestRound))
+
+	has, err := k.FinalizeVotes.Has(ctx, finalizeVoteStoreKey(round, val))
+	require.NoError(t, err)
+	require.False(t, has, "finalize vote must be pruned when the round is abandoned")
+}
+
+// TestFinalizeDKGRound_NoPublicCoeffs verifies that a round with no consensus public
+// coefficients skips to the next round rather than activating.
+func TestFinalizeDKGRound_NoPublicCoeffs(t *testing.T) {
+	const round = uint32(8)
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx)
+
+	latestRound := &types.DKGNetwork{
+		Round:           round,
+		Total:           1,
+		Threshold:       1,
+		Stage:           types.DKGStageFinalization,
+		GlobalPublicKey: []byte("global-pub-key"),
+		PublicCoeffs:    nil, // consensus polynomial missing
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+
+	// SkipToNextRound -> InitiateDKGRound needs stakingKeeper.GetAllValidators.
+	sk := k.stakingKeeper.(*dkgtestutil.MockStakingKeeper)
+	sk.EXPECT().GetAllValidators(ctx).Return(nil, nil).Times(1)
+
+	require.NoError(t, k.FinalizeDKGRound(ctx, latestRound))
+
+	net, err := k.getLatestDKGNetwork(ctx)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGStageRegistration, net.Stage, "a new round should have been initiated")
+	require.Equal(t, round+1, net.Round)
+}
+
+// TestFinalizeDKGRound_V190Gate verifies that the non-consensus sweep only runs once the
+// v1.9.0 upgrade height is reached, so pre-upgrade blocks replay deterministically.
+func TestFinalizeDKGRound_V190Gate(t *testing.T) {
+	const (
+		round     = uint32(9)
+		n         = 4
+		threshold = 5 // intentionally > n so FinalizeDKGRound always takes the skip path
+	)
+
+	const divergentIdx = 1
+
+	// setup builds a keeper with one divergent finalize vote in a round that started at
+	// roundStartHeight (the gate is on the round's start height, not the current height).
+	setup := func(t *testing.T, roundStartHeight int64) (*Keeper, sdk.Context, []common.Address) {
+		t.Helper()
+
+		k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+		ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+
+		params := types.DefaultParams()
+		params.MinReqFinalizedParticipants = 1
+		require.NoError(t, k.SetParams(ctx, params))
+
+		validators := make([]common.Address, n)
+		activeValSet := make([]string, n)
+		for i := range n {
+			validators[i] = common.BytesToAddress([]byte{byte(i + 1)})
+			activeValSet[i] = validators[i].Hex()
+		}
+
+		latestRound := &types.DKGNetwork{
+			Round:            round,
+			ActiveValSet:     activeValSet,
+			Total:            n,
+			Threshold:        threshold,
+			Stage:            types.DKGStageFinalization,
+			StartBlockHeight: roundStartHeight, // gate is on the round's start height
+			GlobalPublicKey:  consensusGPK,
+			PublicCoeffs:     consensusCoeffs,
+		}
+		require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+
+		consensusKey := globalPubKeyVoteKey(round, consensusGPK, consensusCoeffs)
+		divergentKey := globalPubKeyVoteKey(round, consensusGPK, [][]byte{{0x09}})
+
+		for i := range n {
+			reg := &types.DKGRegistration{
+				Round:         round,
+				ValidatorAddr: validators[i].Hex(),
+				Index:         uint32(i + 1),
+				Status:        types.DKGRegStatusFinalized,
+			}
+			require.NoError(t, k.setDKGRegistration(ctx, validators[i], reg))
+
+			voteKey := consensusKey
+			if i == divergentIdx {
+				voteKey = divergentKey
+			}
+			require.NoError(t, k.FinalizeVotes.Set(ctx, finalizeVoteStoreKey(round, validators[i]), voteKey))
+		}
+
+		// threshold (5) > finalized count, so FinalizeDKGRound skips -> InitiateDKGRound.
+		sk := k.stakingKeeper.(*dkgtestutil.MockStakingKeeper)
+		sk.EXPECT().GetAllValidators(gomock.Any()).Return(nil, nil).Times(1)
+
+		return k, ctx, validators
+	}
+
+	t.Run("gated off: round started below v1.9.0 height, divergent reg stays finalized", func(t *testing.T) {
+		k, ctx, validators := setup(t, 399) // TestChainID V190 height is 400
+
+		latestRound, err := k.getLatestDKGNetwork(ctx)
+		require.NoError(t, err)
+		require.NoError(t, k.FinalizeDKGRound(ctx, latestRound))
+
+		reg, err := k.getDKGRegistration(ctx, round, validators[divergentIdx])
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusFinalized, reg.Status,
+			"below v1.9.0 height the sweep must not run")
+	})
+
+	t.Run("gated on: round started at v1.9.0 height, divergent reg invalidated", func(t *testing.T) {
+		k, ctx, validators := setup(t, 400)
+
+		latestRound, err := k.getLatestDKGNetwork(ctx)
+		require.NoError(t, err)
+		require.NoError(t, k.FinalizeDKGRound(ctx, latestRound))
+
+		divergent, err := k.getDKGRegistration(ctx, round, validators[divergentIdx])
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusInvalidated, divergent.Status,
+			"at v1.9.0 height the divergent vote must be invalidated")
+
+		// A validator that voted for consensus is untouched.
+		good, err := k.getDKGRegistration(ctx, round, validators[0])
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusFinalized, good.Status)
+	})
 }

--- a/client/x/dkg/keeper/dkg_handler.go
+++ b/client/x/dkg/keeper/dkg_handler.go
@@ -153,6 +153,14 @@ func (k *Keeper) Finalized(ctx context.Context, round uint32, msgSender common.A
 		}
 	}
 
+	// Record this validator's finalize vote so FinalizeDKGRound can invalidate validators
+	// whose submission diverges from the consensus polynomial.
+	if k.isV190Round(ctx, latest) {
+		if err := k.FinalizeVotes.Set(ctx, finalizeVoteStoreKey(round, msgSender), globalPubKeyVoteKey(round, globalPubKey, publicCoeffs)); err != nil {
+			return errors.Wrap(err, "failed to record finalize vote")
+		}
+	}
+
 	if err := k.finalizeDKGRegistration(ctx, round, msgSender, pubKeyShare); err != nil {
 		return errors.Wrap(err, "failed to update dkg registration status")
 	}

--- a/client/x/dkg/keeper/dkg_round.go
+++ b/client/x/dkg/keeper/dkg_round.go
@@ -53,6 +53,14 @@ func (k *Keeper) SkipToNextRound(ctx context.Context, currentRound *types.DKGNet
 	// from being broadcast in the new round's vote extensions.
 	k.FlushAllQueues()
 
+	// Prune transient finalize votes recorded for the abandoned round (the success path
+	// prunes them in FinalizeDKGRound).
+	if k.isV190Round(ctx, currentRound) {
+		if err := k.pruneRoundFinalizeVotes(ctx, currentRound.Round); err != nil {
+			return errors.Wrap(err, "failed to prune finalize votes")
+		}
+	}
+
 	// Preserve the upgrade flag so the next round retries with isUpgrade=true
 	// if the failed round was an upgrade resharing round.
 	isUpgrade := currentRound.IsUpgrade

--- a/client/x/dkg/keeper/dkg_votes.go
+++ b/client/x/dkg/keeper/dkg_votes.go
@@ -8,19 +8,30 @@ import (
 
 	"cosmossdk.io/collections"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/piplabs/story/lib/errors"
 )
 
-// AddGlobalPubKeyVote Increase vote for global public key by 1.
-func (k *Keeper) AddGlobalPubKeyVote(ctx context.Context, round uint32, globalPubKey []byte, publicCoeffs [][]byte) (uint32, error) {
-	coeffHash := hex.EncodeToString(hashPublicCoeffs(publicCoeffs))
-
-	key := fmt.Sprintf(
+// globalPubKeyVoteKey identifies a (round, globalPubKey, publicCoeffs) vote bucket.
+// Validators that agree on the same consensus polynomial produce the same key.
+func globalPubKeyVoteKey(round uint32, globalPubKey []byte, publicCoeffs [][]byte) string {
+	return fmt.Sprintf(
 		"%d_%s_%s",
 		round,
 		hex.EncodeToString(globalPubKey),
-		coeffHash,
+		hex.EncodeToString(hashPublicCoeffs(publicCoeffs)),
 	)
+}
+
+// finalizeVoteStoreKey is the FinalizeVotes state key for a validator in a round.
+func finalizeVoteStoreKey(round uint32, validator common.Address) string {
+	return fmt.Sprintf("%d_%s", round, validator.Hex())
+}
+
+// AddGlobalPubKeyVote Increase vote for global public key by 1.
+func (k *Keeper) AddGlobalPubKeyVote(ctx context.Context, round uint32, globalPubKey []byte, publicCoeffs [][]byte) (uint32, error) {
+	key := globalPubKeyVoteKey(round, globalPubKey, publicCoeffs)
 
 	// Read current votes (0 if not found)
 	current, err := k.GlobalPubKeyVotes.Get(ctx, key)

--- a/client/x/dkg/keeper/helpers.go
+++ b/client/x/dkg/keeper/helpers.go
@@ -4,14 +4,29 @@ import (
 	"context"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
 	"github.com/piplabs/story/lib/log"
+	"github.com/piplabs/story/lib/netconf"
 )
 
 const (
 	retryAttempts = 3
 	retryDelay    = 2 * time.Second
 )
+
+// isV190Round reports whether a round is governed by the v1.9.0 DKG validation rules.
+// It checks netconf.IsV190 against the round's start height (not the current height)
+// so a round spanning the upgrade boundary keeps a single rule set, and treats an
+// unregistered chain as not active.
+func (k *Keeper) isV190Round(ctx context.Context, round *types.DKGNetwork) bool {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	active, err := netconf.IsV190(sdkCtx.ChainID(), round.StartBlockHeight)
+
+	return err == nil && active
+}
 
 func retry(ctx context.Context, fn func(ctx context.Context) error) error {
 	for i := range retryAttempts {

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -114,6 +114,8 @@ type Keeper struct {
 
 	CDRPartialSubmitCount collections.Map[string, uint64] // key: validatorAddr; value: valid partial submission count
 	CDRFeePoolBalance     collections.Item[string]        // total coins currently held in cdr-fee-pool
+
+	FinalizeVotes collections.Map[string, string] // key: round_validator; value: finalize vote key (round_gpk_coeffsHash) (v1.9.0+)
 }
 
 // NewKeeper creates a new dkg Keeper instance.
@@ -161,6 +163,7 @@ func NewKeeper(
 		DecryptRequestRegistry:      collections.NewMap(sb, types.DecryptRequestRegistryKey, "decrypt_request_registry", collections.StringKey, codec.CollValue[types.DecryptRequest](cdc)),
 		CDRPartialSubmitCount:       collections.NewMap(sb, types.CDRPartialSubmitCountKey, "cdr_partial_submit_count", collections.StringKey, collections.Uint64Value),
 		CDRFeePoolBalance:           collections.NewItem(sb, types.CDRFeePoolBalanceKey, "cdr_fee_pool_balance", collections.StringValue),
+		FinalizeVotes:               collections.NewMap(sb, types.FinalizeVotesKey, "dkg_finalize_votes", collections.StringKey, collections.StringValue),
 	}
 
 	schema, err := sb.Build()

--- a/client/x/dkg/types/keys.go
+++ b/client/x/dkg/types/keys.go
@@ -33,4 +33,5 @@ var (
 	CDRPartialSubmitCountKey       = collections.NewPrefix(10)
 	CDRFeePoolBalanceKey           = collections.NewPrefix(11)
 	DKGPartialDecryptRoundIndexKey = collections.NewPrefix(12)
+	FinalizeVotesKey               = collections.NewPrefix(13)
 )

--- a/lib/netconf/upgrades.go
+++ b/lib/netconf/upgrades.go
@@ -18,7 +18,9 @@ const (
 	V160   = "v1.6.0"
 
 	Seneca = "seneca"
-	V190   = "v1.9.0"
+
+	// V190 gates the DKG consensus-polynomial validation sweep in FinalizeDKGRound.
+	V190 = "v1.9.0"
 )
 
 var (
@@ -43,14 +45,14 @@ var UpgradeHistories = map[string]UpgradeMap{
 		Terence: 50,
 		V142:    50,
 		Horace:  100,
-		V190:    200,
+		V190:    100,
 	},
 	StoryLocalnetID: {
 		V121:    0,
 		Terence: 0,
 		V142:    0,
 		Horace:  100,
-		V190:    200,
+		V190:    0,
 	},
 	AeneidChainID: {
 		Virgil:   345158,
@@ -141,6 +143,9 @@ func IsSeneca(chainID string, blockNumber int64) (bool, error) {
 	return blockNumber >= senecaBlock, nil
 }
 
+// IsV190 reports whether the v1.9.0 upgrade is active at blockNumber on chainID.
+// Returns an error when V190 is not registered for the chain; DKG callers treat that
+// as "not active" rather than halting (DKG can run on chains not in UpgradeHistories).
 func IsV190(chainID string, blockNumber int64) (bool, error) {
 	v190Block, err := GetUpgradeHeight(chainID, V190)
 	if err != nil {

--- a/lib/netconf/upgrades_test.go
+++ b/lib/netconf/upgrades_test.go
@@ -49,3 +49,65 @@ func TestGetUpgradeHeight(t *testing.T) {
 		})
 	}
 }
+
+func TestIsV190(t *testing.T) {
+	tcs := []struct {
+		name        string
+		chainID     string
+		blockNumber int64
+		expectedErr string
+		expected    bool
+	}{
+		{
+			name:        "before upgrade height",
+			chainID:     netconf.TestChainID,
+			blockNumber: 399,
+			expected:    false,
+		},
+		{
+			name:        "at upgrade height",
+			chainID:     netconf.TestChainID,
+			blockNumber: 400,
+			expected:    true,
+		},
+		{
+			name:        "after upgrade height",
+			chainID:     netconf.TestChainID,
+			blockNumber: 401,
+			expected:    true,
+		},
+		{
+			name:        "localnet active from genesis",
+			chainID:     netconf.StoryLocalnetID,
+			blockNumber: 0,
+			expected:    true,
+		},
+		{
+			name:        "unknown chain ID returns error",
+			chainID:     "unknown-chain-id",
+			blockNumber: 1000,
+			expectedErr: netconf.ErrUnknownChainID.Error(),
+		},
+		{
+			name:        "chain without V190 registered returns error",
+			chainID:     netconf.StoryChainID,
+			blockNumber: 1000,
+			expectedErr: netconf.ErrUnknownUpgrade.Error(),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := netconf.IsV190(tc.chainID, tc.blockNumber)
+
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedErr)
+				require.False(t, ok)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue

A validator whose dealing-phase view diverged from consensus can finalize with a public key share that is not on the consensus polynomial, producing partial decryptions inconsistent with the committee.

## Fix
`FinalizeDKGRound` now verifies each finalized validator's public key share against the consensus public coefficients (`vss.VerifyPublicKeyShare`) and invalidates mismatches before counting the committee; the round is skipped if no consensus coefficients were set. 

issue: #833 
