### PR TITLE
fix(dkg): invalidate dealers that submit no deal during the dealing phase

### DIFF
--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -184,6 +184,14 @@ func (k *Keeper) ProcessJustifications(ctx context.Context, latestRound *types.D
 }
 
 func (k *Keeper) ProcessDeals(ctx context.Context, latestRound *types.DKGNetwork, deals []types.Deal) error {
+	// Record which dealers submitted a deal so missing dealers can be invalidated at
+	// BeginFinalization.
+	if k.isV190Round(ctx, latestRound) {
+		if err := k.markDealersDealt(ctx, latestRound, deals); err != nil {
+			return errors.Wrap(err, "failed to mark dealers dealt")
+		}
+	}
+
 	if err := k.emitBeginProcessDeals(ctx, latestRound, deals); err != nil {
 		return errors.Wrap(err, "failed to emit begin process deals event")
 	}
@@ -199,6 +207,72 @@ func (k *Keeper) ProcessDeals(ctx context.Context, latestRound *types.DKGNetwork
 	}
 
 	return nil
+}
+
+// markDealersDealt records the address of each dealer that submitted a deal, so missing
+// dealers can be invalidated at BeginFinalization. deal.Index is the dealer's 0-based kyber
+// index within the DEALER committee: the current round for the initial DKG, but the previous
+// active committee for resharing rounds (they hold the existing shares). The index is resolved
+// to a validator address through that committee's registrations, because the dealer and current
+// index spaces are permuted differently across rounds.
+func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNetwork, deals []types.Deal) error {
+	dealerRound, dealerTotal, err := k.dealerCommitteeRound(ctx, latestRound)
+	if err != nil {
+		return err
+	}
+	if dealerRound == nil {
+		return nil
+	}
+
+	dealerRegs, err := k.getDKGRegistrationsByRound(ctx, *dealerRound)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch dealer registrations", "round", *dealerRound)
+	}
+
+	// Map the dealer committee's 1-based registration index to validator address.
+	addrByIndex := make(map[uint32]string, len(dealerRegs))
+	for i := range dealerRegs {
+		addrByIndex[dealerRegs[i].Index] = dealerRegs[i].ValidatorAddr
+	}
+
+	for _, deal := range deals {
+		// Bound the 0-based kyber index by the dealer committee's total, then convert to
+		// the 1-based registration index.
+		if deal.Index >= dealerTotal {
+			continue
+		}
+
+		addr, ok := addrByIndex[deal.Index+1]
+		if !ok {
+			continue
+		}
+
+		if err := k.DealtDealers.Set(ctx, dealtDealerKey(latestRound.Round, addr)); err != nil {
+			return errors.Wrap(err, "failed to record dealt dealer", "round", latestRound.Round, "dealer", addr)
+		}
+	}
+
+	return nil
+}
+
+// dealerCommitteeRound returns the round and total of the committee expected to deal in
+// latestRound. For resharing rounds this is the previous active committee (which holds the
+// existing shares); otherwise it is the current round. A nil round means there is no dealer
+// committee to attribute deals to (e.g. resharing with no prior active round).
+func (k *Keeper) dealerCommitteeRound(ctx context.Context, latestRound *types.DKGNetwork) (*uint32, uint32, error) {
+	if !latestRound.IsResharing {
+		return &latestRound.Round, latestRound.Total, nil
+	}
+
+	prevActive, err := k.getLatestActiveDKGNetwork(ctx)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "failed to get previous active round")
+	}
+	if prevActive == nil {
+		return nil, 0, nil
+	}
+
+	return &prevActive.Round, prevActive.Total, nil
 }
 
 func (k *Keeper) ProcessResponses(ctx context.Context, latestRound *types.DKGNetwork, responses []types.Response) error {

--- a/client/x/dkg/keeper/dkg_dealt_dealers_hash_internal_test.go
+++ b/client/x/dkg/keeper/dkg_dealt_dealers_hash_internal_test.go
@@ -1,0 +1,74 @@
+package keeper
+
+import (
+	"testing"
+
+	"cosmossdk.io/collections"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piplabs/story/client/x/dkg/types"
+)
+
+// TestDealtDealersCollection_NoHashImpact proves that registering the DealtDealers
+// KeySet on the schema (as NewKeeper does) does not change the committed app hash on
+// its own: the hash only changes once something is actually written to the prefix, and
+// returns to the original once the entry is pruned.
+func TestDealtDealersCollection_NoHashImpact(t *testing.T) {
+	cdc := moduletestutil.MakeTestEncodingConfig().Codec
+
+	// commitHash builds a fresh store, registers the DKGNetworks map and (optionally) the
+	// DealtDealers KeySet, writes a fixed DKGNetwork, optionally writes/prunes a dealt
+	// mark, commits, and returns the resulting multistore commit hash.
+	commitHash := func(t *testing.T, registerDealt, writeDealt, pruneDealt bool) []byte {
+		t.Helper()
+
+		key := storetypes.NewKVStoreKey(types.StoreKey)
+		tkey := storetypes.NewTransientStoreKey("transient_test")
+		testCtx := testutil.DefaultContextWithDB(t, key, tkey)
+		sb := collections.NewSchemaBuilder(runtime.NewKVStoreService(key))
+
+		networks := collections.NewMap(sb, types.DKGNetworkKey, "dkg_networks",
+			collections.StringKey, codec.CollValue[types.DKGNetwork](cdc))
+
+		var dealt collections.KeySet[string]
+		if registerDealt {
+			dealt = collections.NewKeySet(sb, types.DealtDealersKey, "dealt_dealers", collections.StringKey)
+		}
+
+		_, err := sb.Build()
+		require.NoError(t, err)
+
+		ctx := testCtx.Ctx
+
+		// Identical "real" state written in every case.
+		require.NoError(t, networks.Set(ctx, "1", types.DKGNetwork{Round: 1, Total: 3, Threshold: 2}))
+
+		const dealerAddr = "0x0000000000000000000000000000000000000002"
+		if writeDealt {
+			require.NoError(t, dealt.Set(ctx, dealtDealerKey(1, dealerAddr)))
+			if pruneDealt {
+				require.NoError(t, dealt.Remove(ctx, dealtDealerKey(1, dealerAddr)))
+			}
+		}
+
+		return testCtx.CMS.Commit().Hash
+	}
+
+	hWithout := commitHash(t, false, false, false)   // KeySet not registered at all
+	hRegistered := commitHash(t, true, false, false) // registered, never written
+	hWritten := commitHash(t, true, true, false)     // registered and written
+	hPruned := commitHash(t, true, true, true)       // written then pruned
+
+	require.Equal(t, hWithout, hRegistered,
+		"registering the DealtDealers KeySet without writing must not change the app hash")
+	require.NotEqual(t, hWithout, hWritten,
+		"writing a dealt mark must change the app hash (sanity: the test can detect a real change)")
+	require.Equal(t, hWithout, hPruned,
+		"writing then pruning a dealt mark must restore the original app hash")
+}

--- a/client/x/dkg/keeper/dkg_finalization.go
+++ b/client/x/dkg/keeper/dkg_finalization.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (k *Keeper) BeginFinalization(ctx context.Context, latestRound *types.DKGNetwork) error {
+	// Invalidate dealers that never submitted a deal during the dealing phase.
+	if k.isV190Round(ctx, latestRound) {
+		if err := k.invalidateMissingDealers(ctx, latestRound); err != nil {
+			return errors.Wrap(err, "failed to invalidate missing dealers")
+		}
+	}
+
 	if err := k.emitBeginDKGFinalization(ctx, latestRound); err != nil {
 		return errors.Wrap(err, "failed to emit begin DKG finalization event")
 	}
@@ -196,4 +203,99 @@ func (k *Keeper) invalidateNonConsensusFinalizations(ctx context.Context, latest
 	}
 
 	return nil
+}
+
+// invalidateMissingDealers invalidates dealers that never submitted a deal during the
+// dealing phase. The expected dealer set is the committee that should have produced deals:
+// the previous active committee for resharing rounds, the current round otherwise. A missing
+// dealer is penalized only if it also holds a verified registration in the current round; a
+// dealer leaving the committee has no current registration and nothing to invalidate. The
+// dealt set recorded in ProcessDeals is pruned here.
+func (k *Keeper) invalidateMissingDealers(ctx context.Context, latestRound *types.DKGNetwork) error {
+	expectedDealers, err := k.expectedDealers(ctx, latestRound)
+	if err != nil {
+		return err
+	}
+
+	for _, dealer := range expectedDealers {
+		dealerAddr := common.HexToAddress(dealer)
+		key := dealtDealerKey(latestRound.Round, dealer)
+
+		dealt, err := k.DealtDealers.Has(ctx, key)
+		if err != nil {
+			return errors.Wrap(err, "failed to check dealt dealer", "dealer", dealer)
+		}
+
+		if dealt {
+			if err := k.DealtDealers.Remove(ctx, key); err != nil {
+				return errors.Wrap(err, "failed to prune dealt dealer", "dealer", dealer)
+			}
+
+			continue
+		}
+
+		// No deal from this dealer. Only penalize if it is also a verified member of the
+		// current round; a leaving member has no current registration to invalidate.
+		has, err := k.hasDKGRegistration(ctx, latestRound.Round, dealerAddr)
+		if err != nil {
+			return errors.Wrap(err, "failed to check current registration", "dealer", dealer)
+		}
+		if !has {
+			continue
+		}
+
+		reg, err := k.getDKGRegistration(ctx, latestRound.Round, dealerAddr)
+		if err != nil {
+			return errors.Wrap(err, "failed to get current registration", "dealer", dealer)
+		}
+		if reg.Status != types.DKGRegStatusVerified {
+			continue
+		}
+
+		reg.Status = types.DKGRegStatusInvalidated
+		if err := k.setDKGRegistration(ctx, dealerAddr, reg); err != nil {
+			return errors.Wrap(err, "failed to invalidate missing dealer",
+				"validator", dealer,
+				"index", reg.Index,
+			)
+		}
+
+		log.Warn(ctx, "Invalidated dealer: no deal submitted during dealing phase",
+			nil,
+			"round", latestRound.Round,
+			"validator", dealer,
+			"index", reg.Index,
+		)
+	}
+
+	return nil
+}
+
+// expectedDealers returns the validator addresses of the committee that should produce deals
+// in latestRound: the previous active committee for resharing rounds, the current round's
+// registrations otherwise.
+func (k *Keeper) expectedDealers(ctx context.Context, latestRound *types.DKGNetwork) ([]string, error) {
+	if latestRound.IsResharing {
+		prevActive, err := k.getLatestActiveDKGNetwork(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get previous active round")
+		}
+		if prevActive == nil {
+			return nil, nil
+		}
+
+		return prevActive.ActiveValSet, nil
+	}
+
+	regs, err := k.getDKGRegistrationsByRound(ctx, latestRound.Round)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch DKG registrations")
+	}
+
+	dealers := make([]string, len(regs))
+	for i := range regs {
+		dealers[i] = regs[i].ValidatorAddr
+	}
+
+	return dealers, nil
 }

--- a/client/x/dkg/keeper/dkg_finalization_internal_test.go
+++ b/client/x/dkg/keeper/dkg_finalization_internal_test.go
@@ -589,3 +589,412 @@ func TestFinalizeDKGRound_V190Gate(t *testing.T) {
 		require.Equal(t, types.DKGRegStatusFinalized, good.Status)
 	})
 }
+
+// TestMarkDealersDealt verifies that 0-based dealer indices [0, Total-1] are resolved to
+// the dealer's validator address via the committee's registrations, and out-of-range
+// indices are skipped. Non-resharing: the dealer committee is the current round.
+func TestMarkDealersDealt(t *testing.T) {
+	const (
+		round = uint32(12)
+		n     = 3
+	)
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx)
+
+	validators := make([]common.Address, n)
+	latestRound := &types.DKGNetwork{Round: round, Total: n} // valid 0-based indices {0,1,2}
+	require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+	for i := range n {
+		validators[i] = common.BytesToAddress([]byte{byte(i + 1)})
+		require.NoError(t, k.setDKGRegistration(ctx, validators[i], &types.DKGRegistration{
+			Round:         round,
+			ValidatorAddr: validators[i].Hex(),
+			Index:         uint32(i + 1), // 1-based
+			Status:        types.DKGRegStatusVerified,
+		}))
+	}
+
+	deals := []types.Deal{
+		{Index: 0}, {Index: 0}, // dealer 0 (duplicate) -> validators[0]
+		{Index: 2}, // dealer 2 -> validators[2]
+		{Index: 3}, // out of range (>= Total=3) -> skipped
+	}
+	require.NoError(t, k.markDealersDealt(ctx, latestRound, deals))
+
+	for i, want := range map[int]bool{0: true, 1: false, 2: true} {
+		has, err := k.DealtDealers.Has(ctx, dealtDealerKey(round, validators[i].Hex()))
+		require.NoError(t, err)
+		require.Equal(t, want, has, "validator %d", i)
+	}
+}
+
+// TestMarkDealersDealt_AllDealersRecorded is a regression test for the 0-based/1-based
+// off-by-one: when all n dealers deal (0-based indices {0..n-1}), every registration
+// index {1..n} — including the highest, n — must be recorded, so invalidateMissingDealers
+// keeps them all. A test built with 1-based deal indices would hide this.
+func TestMarkDealersDealt_AllDealersRecorded(t *testing.T) {
+	const (
+		round = uint32(15)
+		n     = 4
+	)
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx)
+
+	validators := make([]common.Address, n)
+	latestRound := &types.DKGNetwork{Round: round, Total: n, Threshold: 2, Stage: types.DKGStageFinalization}
+	require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+
+	deals := make([]types.Deal, n)
+	for i := range n {
+		validators[i] = common.BytesToAddress([]byte{byte(i + 1)})
+		require.NoError(t, k.setDKGRegistration(ctx, validators[i], &types.DKGRegistration{
+			Round:         round,
+			ValidatorAddr: validators[i].Hex(),
+			Index:         uint32(i + 1), // 1-based
+			Status:        types.DKGRegStatusVerified,
+		}))
+		deals[i] = types.Deal{Index: uint32(i)} // 0-based dealer index
+	}
+
+	require.NoError(t, k.markDealersDealt(ctx, latestRound, deals))
+
+	// Every dealer (incl. the highest index n) must be recorded.
+	for i := range n {
+		has, err := k.DealtDealers.Has(ctx, dealtDealerKey(round, validators[i].Hex()))
+		require.NoError(t, err)
+		require.True(t, has, "validator %d (highest reg.Index=%d) must be recorded as dealt", i+1, n)
+	}
+
+	require.NoError(t, k.invalidateMissingDealers(ctx, latestRound))
+
+	for i := range n {
+		reg, err := k.getDKGRegistration(ctx, round, validators[i])
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg.Status,
+			"reg.Index %d must remain verified (all dealers dealt)", i+1)
+	}
+}
+
+// TestInvalidateMissingDealers verifies that verified dealers without a recorded deal
+// are invalidated, dealers that dealt are kept and their marks pruned, and already
+// invalidated dealers are left untouched.
+func TestInvalidateMissingDealers(t *testing.T) {
+	const (
+		round = uint32(11)
+		n     = 5
+	)
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx)
+
+	validators := make([]common.Address, n)
+	for i := range n {
+		validators[i] = common.BytesToAddress([]byte{byte(i + 1)})
+	}
+
+	latestRound := &types.DKGNetwork{Round: round, Total: n, Threshold: 3, Stage: types.DKGStageFinalization}
+	require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+
+	// reg index 5 (i=4) is already invalidated and never dealt; others are verified.
+	for i := range n {
+		status := types.DKGRegStatusVerified
+		if i == 4 {
+			status = types.DKGRegStatusInvalidated
+		}
+		reg := &types.DKGRegistration{
+			Round:         round,
+			ValidatorAddr: validators[i].Hex(),
+			Index:         uint32(i + 1),
+			Status:        status,
+		}
+		require.NoError(t, k.setDKGRegistration(ctx, validators[i], reg))
+	}
+
+	// 0-based dealer indices 0 and 2 submitted deals -> reg.Index 1 and 3 dealt; 2,4,5 did not.
+	require.NoError(t, k.markDealersDealt(ctx, latestRound, []types.Deal{{Index: 0}, {Index: 2}}))
+
+	require.NoError(t, k.invalidateMissingDealers(ctx, latestRound))
+
+	wantStatus := map[int]types.DKGRegStatus{
+		0: types.DKGRegStatusVerified,    // dealt
+		1: types.DKGRegStatusInvalidated, // missing deal
+		2: types.DKGRegStatusVerified,    // dealt
+		3: types.DKGRegStatusInvalidated, // missing deal
+		4: types.DKGRegStatusInvalidated, // already invalidated, untouched
+	}
+	for i := range n {
+		reg, err := k.getDKGRegistration(ctx, round, validators[i])
+		require.NoError(t, err)
+		require.Equal(t, wantStatus[i], reg.Status, "reg index %d", i+1)
+	}
+
+	// Marks for dealt dealers are pruned (validators[0] and validators[2]).
+	for _, i := range []int{0, 2} {
+		has, err := k.DealtDealers.Has(ctx, dealtDealerKey(round, validators[i].Hex()))
+		require.NoError(t, err)
+		require.False(t, has, "dealt mark for validator %d should be pruned", i)
+	}
+}
+
+// TestBeginFinalization_MissingDealerGate verifies the missing-dealer sweep only runs
+// for rounds started at/after the v1.9.0 height.
+func TestBeginFinalization_MissingDealerGate(t *testing.T) {
+	const (
+		round = uint32(13)
+		n     = 3
+	)
+
+	// nonDealerIdx (0-based) is verified but never submits a deal.
+	const nonDealerIdx = 1
+
+	setup := func(t *testing.T, roundStartHeight int64) (*Keeper, sdk.Context, []common.Address) {
+		t.Helper()
+
+		k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+		ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+
+		validators := make([]common.Address, n)
+		for i := range n {
+			validators[i] = common.BytesToAddress([]byte{byte(i + 1)})
+		}
+
+		latestRound := &types.DKGNetwork{
+			Round:            round,
+			Total:            n,
+			Threshold:        2,
+			Stage:            types.DKGStageFinalization,
+			StartBlockHeight: roundStartHeight,
+		}
+		require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+
+		for i := range n {
+			reg := &types.DKGRegistration{
+				Round:         round,
+				ValidatorAddr: validators[i].Hex(),
+				Index:         uint32(i + 1),
+				Status:        types.DKGRegStatusVerified,
+			}
+			require.NoError(t, k.setDKGRegistration(ctx, validators[i], reg))
+		}
+
+		// Every dealer except nonDealerIdx submitted a deal (0-based dealer index = i).
+		var deals []types.Deal
+		for i := range n {
+			if i != nonDealerIdx {
+				deals = append(deals, types.Deal{Index: uint32(i)})
+			}
+		}
+		require.NoError(t, k.markDealersDealt(ctx, latestRound, deals))
+
+		return k, ctx, validators
+	}
+
+	t.Run("gated off: round started below v1.9.0 height, missing dealer stays verified", func(t *testing.T) {
+		k, ctx, validators := setup(t, 399)
+
+		latestRound, err := k.getLatestDKGNetwork(ctx)
+		require.NoError(t, err)
+		require.NoError(t, k.BeginFinalization(ctx, latestRound))
+
+		reg, err := k.getDKGRegistration(ctx, round, validators[nonDealerIdx])
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg.Status)
+	})
+
+	t.Run("gated on: round started at v1.9.0 height, missing dealer invalidated", func(t *testing.T) {
+		k, ctx, validators := setup(t, 400)
+
+		latestRound, err := k.getLatestDKGNetwork(ctx)
+		require.NoError(t, err)
+		require.NoError(t, k.BeginFinalization(ctx, latestRound))
+
+		missing, err := k.getDKGRegistration(ctx, round, validators[nonDealerIdx])
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusInvalidated, missing.Status)
+
+		dealt, err := k.getDKGRegistration(ctx, round, validators[0])
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, dealt.Status)
+	})
+}
+
+// TestInvalidateMissingDealers_Resharing covers the resharing index-space defect: in a
+// resharing round the dealers are the PREVIOUS active committee, whose index space is
+// permuted differently from the current round. Deals must be attributed by validator
+// address, never by raw index. Reproduces the devnet 4->3 node-removal scenario.
+func TestInvalidateMissingDealers_Resharing(t *testing.T) {
+	const (
+		oldRound = uint32(40)
+		newRound = uint32(42)
+	)
+
+	// Old committee (the dealers), by old reg.Index: val1=1(kyber0), val3=2(kyber1),
+	// val4=3(kyber2), val2=4(kyber3). val3 is stopped and submits no deal.
+	val1 := common.BytesToAddress([]byte{0x01})
+	val2 := common.BytesToAddress([]byte{0x02})
+	val3 := common.BytesToAddress([]byte{0x03})
+	val4 := common.BytesToAddress([]byte{0x04})
+	oldByIndex := []common.Address{val1, val3, val4, val2} // index i -> kyber i
+
+	// Deals from the dealers that are up (old kyber indices 0,2,3); val3 (kyber 1) is down.
+	dealtDeals := []types.Deal{{Index: 0}, {Index: 2}, {Index: 3}}
+
+	setupOld := func(t *testing.T, k *Keeper, ctx sdk.Context) {
+		t.Helper()
+		old := &types.DKGNetwork{
+			Round:        oldRound,
+			Total:        4,
+			ActiveValSet: []string{val1.Hex(), val3.Hex(), val4.Hex(), val2.Hex()},
+			Stage:        types.DKGStageActive,
+		}
+		require.NoError(t, k.setDKGNetwork(ctx, old))
+		require.NoError(t, k.setLatestActiveRound(ctx, old))
+		for i, addr := range oldByIndex {
+			require.NoError(t, k.setDKGRegistration(ctx, addr, &types.DKGRegistration{
+				Round:         oldRound,
+				ValidatorAddr: addr.Hex(),
+				Index:         uint32(i + 1),
+				Status:        types.DKGRegStatusFinalized,
+			}))
+		}
+	}
+
+	t.Run("leaving dealer not invalidated; healthy members kept despite index permutation", func(t *testing.T) {
+		k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+		ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+		setupOld(t, k, ctx)
+
+		// New committee (val3 left): val2=1, val1=2, val4=3. Note val1 sits at the index
+		// (2) the stopped val3 held in the old committee — the bug invalidated val1 here.
+		newRegs := []common.Address{val2, val1, val4}
+		newDKG := &types.DKGNetwork{
+			Round: newRound, Total: 3, Threshold: 2,
+			Stage: types.DKGStageFinalization, IsResharing: true, StartBlockHeight: 400,
+		}
+		require.NoError(t, k.setDKGNetwork(ctx, newDKG))
+		for i, addr := range newRegs {
+			require.NoError(t, k.setDKGRegistration(ctx, addr, &types.DKGRegistration{
+				Round:         newRound,
+				ValidatorAddr: addr.Hex(),
+				Index:         uint32(i + 1),
+				Status:        types.DKGRegStatusVerified,
+			}))
+		}
+
+		require.NoError(t, k.markDealersDealt(ctx, newDKG, dealtDeals))
+		require.NoError(t, k.invalidateMissingDealers(ctx, newDKG))
+
+		// All three new members dealt (val1/val4/val2) and stay verified; val3 left and
+		// has no new registration to invalidate.
+		for _, addr := range newRegs {
+			reg, err := k.getDKGRegistration(ctx, newRound, addr)
+			require.NoError(t, err)
+			require.Equal(t, types.DKGRegStatusVerified, reg.Status, "validator %s must stay verified", addr.Hex())
+		}
+	})
+
+	t.Run("continuing dealer that skips dealing is invalidated", func(t *testing.T) {
+		k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+		ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+		setupOld(t, k, ctx)
+
+		// val3 does NOT leave: it registers for the new round but still submits no deal.
+		newRegs := []common.Address{val2, val1, val4, val3}
+		newDKG := &types.DKGNetwork{
+			Round: newRound, Total: 4, Threshold: 2,
+			Stage: types.DKGStageFinalization, IsResharing: true, StartBlockHeight: 400,
+		}
+		require.NoError(t, k.setDKGNetwork(ctx, newDKG))
+		for i, addr := range newRegs {
+			require.NoError(t, k.setDKGRegistration(ctx, addr, &types.DKGRegistration{
+				Round:         newRound,
+				ValidatorAddr: addr.Hex(),
+				Index:         uint32(i + 1),
+				Status:        types.DKGRegStatusVerified,
+			}))
+		}
+
+		require.NoError(t, k.markDealersDealt(ctx, newDKG, dealtDeals))
+		require.NoError(t, k.invalidateMissingDealers(ctx, newDKG))
+
+		// val3 was an old-committee dealer that skipped dealing and is still a member -> invalidated.
+		reg3, err := k.getDKGRegistration(ctx, newRound, val3)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusInvalidated, reg3.Status)
+
+		for _, addr := range []common.Address{val1, val2, val4} {
+			reg, err := k.getDKGRegistration(ctx, newRound, addr)
+			require.NoError(t, err)
+			require.Equal(t, types.DKGRegStatusVerified, reg.Status, "validator %s must stay verified", addr.Hex())
+		}
+	})
+}
+
+// TestInvalidateMissingDealers_ReshardingExpansion covers the predicted (in the PR review)
+// node-addition failure: in a 3->4 expansion the joining node holds no old share and
+// correctly submits no deal. The expected dealer set is the OLD committee, so the joiner is
+// never a candidate for invalidation — regardless of which registration index it lands on.
+// A raw-index implementation would invalidate whoever sits at index newTotal (here val4).
+func TestInvalidateMissingDealers_ReshardingExpansion(t *testing.T) {
+	const (
+		oldRound = uint32(50)
+		newRound = uint32(52)
+	)
+
+	// Old committee of 3: val1=1(kyber0), val2=2(kyber1), val3=3(kyber2). All deal.
+	val1 := common.BytesToAddress([]byte{0x01})
+	val2 := common.BytesToAddress([]byte{0x02})
+	val3 := common.BytesToAddress([]byte{0x03})
+	val4 := common.BytesToAddress([]byte{0x04}) // joining node, no old share
+	oldByIndex := []common.Address{val1, val2, val3}
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+
+	old := &types.DKGNetwork{
+		Round:        oldRound,
+		Total:        3,
+		ActiveValSet: []string{val1.Hex(), val2.Hex(), val3.Hex()},
+		Stage:        types.DKGStageActive,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, old))
+	require.NoError(t, k.setLatestActiveRound(ctx, old))
+	for i, addr := range oldByIndex {
+		require.NoError(t, k.setDKGRegistration(ctx, addr, &types.DKGRegistration{
+			Round:         oldRound,
+			ValidatorAddr: addr.Hex(),
+			Index:         uint32(i + 1),
+			Status:        types.DKGRegStatusFinalized,
+		}))
+	}
+
+	// New committee of 4, joiner val4 registered LAST (index 4 == newTotal): the index the
+	// buggy implementation would have killed.
+	newRegs := []common.Address{val1, val2, val3, val4}
+	newDKG := &types.DKGNetwork{
+		Round: newRound, Total: 4, Threshold: 2,
+		Stage: types.DKGStageFinalization, IsResharing: true, StartBlockHeight: 400,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, newDKG))
+	for i, addr := range newRegs {
+		require.NoError(t, k.setDKGRegistration(ctx, addr, &types.DKGRegistration{
+			Round:         newRound,
+			ValidatorAddr: addr.Hex(),
+			Index:         uint32(i + 1),
+			Status:        types.DKGRegStatusVerified,
+		}))
+	}
+
+	// Only the old committee deals (kyber 0,1,2); the joiner submits nothing.
+	require.NoError(t, k.markDealersDealt(ctx, newDKG, []types.Deal{{Index: 0}, {Index: 1}, {Index: 2}}))
+	require.NoError(t, k.invalidateMissingDealers(ctx, newDKG))
+
+	// All four members — including the joiner that dealt nothing — stay verified.
+	for _, addr := range newRegs {
+		reg, err := k.getDKGRegistration(ctx, newRound, addr)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg.Status, "validator %s must stay verified", addr.Hex())
+	}
+}

--- a/client/x/dkg/keeper/helpers.go
+++ b/client/x/dkg/keeper/helpers.go
@@ -2,9 +2,12 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/piplabs/story/client/x/dkg/types"
 	"github.com/piplabs/story/lib/errors"
@@ -26,6 +29,13 @@ func (k *Keeper) isV190Round(ctx context.Context, round *types.DKGNetwork) bool 
 	active, err := netconf.IsV190(sdkCtx.ChainID(), round.StartBlockHeight)
 
 	return err == nil && active
+}
+
+// dealtDealerKey is the DealtDealers state key for a dealer in a round, keyed by the
+// dealer's validator address. Addresses (not indices) are used because in resharing
+// rounds the dealer committee's index space differs from the current round's.
+func dealtDealerKey(round uint32, dealerAddr string) string {
+	return fmt.Sprintf("%d_%s", round, common.HexToAddress(dealerAddr).Hex())
 }
 
 func retry(ctx context.Context, fn func(ctx context.Context) error) error {

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -116,6 +116,7 @@ type Keeper struct {
 	CDRFeePoolBalance     collections.Item[string]        // total coins currently held in cdr-fee-pool
 
 	FinalizeVotes collections.Map[string, string] // key: round_validator; value: finalize vote key (round_gpk_coeffsHash) (v1.9.0+)
+	DealtDealers  collections.KeySet[string]      // key: round_dealerIndex; marks dealers that submitted a deal (v1.9.0+)
 }
 
 // NewKeeper creates a new dkg Keeper instance.
@@ -164,6 +165,7 @@ func NewKeeper(
 		CDRPartialSubmitCount:       collections.NewMap(sb, types.CDRPartialSubmitCountKey, "cdr_partial_submit_count", collections.StringKey, collections.Uint64Value),
 		CDRFeePoolBalance:           collections.NewItem(sb, types.CDRFeePoolBalanceKey, "cdr_fee_pool_balance", collections.StringValue),
 		FinalizeVotes:               collections.NewMap(sb, types.FinalizeVotesKey, "dkg_finalize_votes", collections.StringKey, collections.StringValue),
+		DealtDealers:                collections.NewKeySet(sb, types.DealtDealersKey, "dealt_dealers", collections.StringKey),
 	}
 
 	schema, err := sb.Build()

--- a/client/x/dkg/types/keys.go
+++ b/client/x/dkg/types/keys.go
@@ -34,4 +34,5 @@ var (
 	CDRFeePoolBalanceKey           = collections.NewPrefix(11)
 	DKGPartialDecryptRoundIndexKey = collections.NewPrefix(12)
 	FinalizeVotesKey               = collections.NewPrefix(13)
+	DealtDealersKey                = collections.NewPrefix(14)
 )


### PR DESCRIPTION
## Issue

A dealer that produces no deal at all is not caught by the VSS complaint path, yet its share is absent from the consensus polynomial.

## Fix
Dealers that submit a deal are recorded while processing vote extensions (`ProcessDeals`); verified dealers with no recorded deal are invalidated at `BeginFinalization`, and the dealt set is pruned once consumed. 

issue: #833 
