### PR TITLE
chore(dkg): log decrypt retries at warn

### DIFF
--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -523,26 +523,31 @@ func (k *Keeper) batchSubmitConsumer(ctx context.Context, session *types.DKGSess
 			return
 		}
 		if err := k.submitPartialDecryptionBatch(ctx, session, batch); err != nil {
-			log.Error(ctx, "Failed to submit partial decryption batch", err,
+			// WARN: retried below unless a request has exhausted its retries.
+			log.Warn(ctx, "Failed to submit partial decryption batch; will retry", err,
 				"session", session.GetSessionKey(),
 				"batch_size", len(batch),
 			)
 			incDecryptBatch(labelBatchError, len(batch))
+			requeued := 0
 			for _, r := range batch {
 				preq := requests[r.idx]
 				preq.RetryCount++
 				if preq.RetryCount > maxReprocessAttempts {
-					log.Warn(ctx, "Dropping decrypt request after max retry attempts", nil,
+					// Exhausted retries: real failure, alert here.
+					log.Error(ctx, "Decrypt request dropped after max retry attempts", err,
 						"session", session.GetSessionKey(),
 						"round", r.req.Round,
 						"retry_count", preq.RetryCount,
 						"max_reprocess_attempts", maxReprocessAttempts,
 					)
+					incDecryptRequest(labelDecryptRetryDropped, 1)
 					continue
 				}
 				session.AddDecryptRequest(preq)
+				requeued++
 			}
-			incDecryptRequest(labelDecryptRequeued, len(batch))
+			incDecryptRequest(labelDecryptRequeued, requeued)
 		} else {
 			log.Info(ctx, "Successfully submitted partial decryption batch",
 				"session", session.GetSessionKey(),
@@ -558,22 +563,27 @@ func (k *Keeper) batchSubmitConsumer(ctx context.Context, session *types.DKGSess
 		r := <-resultCh
 
 		if r.err != nil {
-			log.Error(ctx, "Kernel partial decrypt failed", r.err,
-				"session", session.GetSessionKey(),
-				"round", r.req.Round,
-			)
 			incDecryptRequest(labelDecryptKernelFailed, 1)
 			preq := requests[r.idx]
 			preq.RetryCount++
 			if preq.RetryCount > maxReprocessAttempts {
-				log.Warn(ctx, "Dropping decrypt request after max retry attempts", nil,
+				// Exhausted retries: real failure, alert here.
+				log.Error(ctx, "Decrypt request dropped after max retry attempts", r.err,
 					"session", session.GetSessionKey(),
 					"round", r.req.Round,
 					"retry_count", preq.RetryCount,
 					"max_reprocess_attempts", maxReprocessAttempts,
 				)
+				incDecryptRequest(labelDecryptRetryDropped, 1)
 				continue
 			}
+			// Transient (usually light-client lag); self-heals on retry, so WARN only.
+			log.Warn(ctx, "Kernel partial decrypt failed; will retry", r.err,
+				"session", session.GetSessionKey(),
+				"round", r.req.Round,
+				"retry_count", preq.RetryCount,
+				"max_reprocess_attempts", maxReprocessAttempts,
+			)
 			session.AddDecryptRequest(preq)
 			continue
 		}
@@ -618,9 +628,11 @@ func (k *Keeper) computePartialDecrypt(ctx context.Context, session *types.DKGSe
 
 	if err != nil {
 		result.err = errors.Wrap(err, "generating partial decrypt failed")
-		log.Error(ctx, "Kernel PartialDecryptTDH2 failed", err,
+		// DEBUG only; batchSubmitConsumer owns the retry/drop decision and WARN/ERROR.
+		log.Debug(ctx, "Kernel PartialDecryptTDH2 call failed; retry decision deferred to batch consumer",
 			"session", session.GetSessionKey(),
 			"kernel_duration_ms", kernelDuration.Milliseconds(),
+			"err", err,
 		)
 		return
 	}

--- a/client/x/dkg/keeper/dkg_svc_test.go
+++ b/client/x/dkg/keeper/dkg_svc_test.go
@@ -1160,6 +1160,47 @@ func TestProcessDecryptRequests_PartialKernelFailure(t *testing.T) {
 	require.Equal(t, []byte("ct2"), requeued[0].Ciphertext)
 }
 
+// TestProcessDecryptRequests_DropsAfterMaxRetries: a failure past the retry cap drops
+// the request instead of re-queuing it.
+func TestProcessDecryptRequests_DropsAfterMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cc := []byte("cc-drop")
+	mockKernel := dkgtestutil.NewMockKernelServiceClient(ctrl)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+
+	router := NewKernelRouter(nil, nil)
+	router.RegisterClient(cc, mockKernel)
+
+	k := &Keeper{kernelRouter: router, contractClient: mockContract}
+
+	session := &types.DKGSession{
+		Round:          1,
+		Index:          2,
+		GlobalPubKey:   []byte("global-pub"),
+		CodeCommitment: cc,
+	}
+
+	// Single request already at the retry cap; the next failure must drop it.
+	requests := []types.PendingDecryptRequest{
+		{
+			DecryptRequest: types.DecryptRequest{Ciphertext: []byte("ct"), Label: makeLabel(1), RequesterPubKey: []byte("rpk")},
+			RetryCount:     maxReprocessAttempts,
+		},
+	}
+
+	mockKernel.EXPECT().PartialDecryptTDH2(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("kernel error")).
+		Times(1)
+
+	k.processDecryptRequests(ctx, session, requests)
+
+	require.Empty(t, session.GetDecryptRequests(), "request past the retry cap must be dropped, not re-queued")
+}
+
 // TestProcessDecryptRequests_ConcurrentABCIWrite verifies that new requests added by the
 // ABCI thread via AddDecryptRequest while processDecryptRequests is running are not lost.
 // This is the key race scenario: DrainDecryptRequests atomically clears the queue before

--- a/client/x/dkg/keeper/metrics.go
+++ b/client/x/dkg/keeper/metrics.go
@@ -29,6 +29,7 @@ const (
 const (
 	labelDecryptStaleDropped = "stale_dropped"
 	labelDecryptKernelFailed = "kernel_failed"
+	labelDecryptRetryDropped = "retry_dropped"
 	labelDecryptRequeued     = "requeued"
 	labelDecryptSubmitted    = "submitted"
 )


### PR DESCRIPTION
Transient `PartialDecryptTDH2` failures (usually the kernel's light client lagging the chain tip) were logged at ERROR on every retry, while the actual drop logged only at WARN — so monitoring paged on failures that self-heal on the next tick.

- Per-attempt kernel/batch failures → WARN; per-call log in `computePartialDecrypt` → DEBUG.
- Only requests that exhaust `maxReprocessAttempts` → ERROR + new `retry_dropped` metric.

Alert on the `retry_dropped` metric (or the `Decrypt request dropped after max retry attempts` ERROR) instead of per-attempt noise.

issue: none
