### PR TITLE
feat(staking): re-land staking pause

### DIFF
--- a/contracts/script/upgrades/DeployNewIPTokenStaking_V2_0_0.s.sol
+++ b/contracts/script/upgrades/DeployNewIPTokenStaking_V2_0_0.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { IPTokenStaking } from "../../src/upgrades/IPTokenStaking.sol";
+import { Predeploys } from "../../src/libraries/Predeploys.sol";
+import { Create3 } from "../../src/deploy/Create3.sol";
+
+/**
+ * @title DeployNewIPTokenStakingImpl
+ * @notice Deploys a new implementation of IPTokenStaking contract to be used for upgrading
+ * @dev This script only deploys the implementation contract, it does not perform the upgrade
+ */
+contract DeployNewIPTokenStaking_V2_0_0 is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        Create3 create3 = Create3(Predeploys.Create3);
+
+        // Generate creation code for IPTokenStaking
+        bytes memory creationCode = abi.encodePacked(
+            type(IPTokenStaking).creationCode,
+            abi.encode(1 ether, 256) // Constructor args: defaultMinFee (1 IP), maxDataLength
+        );
+
+        bytes32 salt = keccak256(abi.encodePacked("IPTokenStaking_Implementation_v2_0_0"));
+
+        // Deploy using Create3
+        address newImplementation = create3.deploy(salt, creationCode);
+        if (create3.getDeployed(deployer, salt) != newImplementation) {
+            revert("Deployment failed");
+        }
+
+        vm.stopBroadcast();
+
+        console2.log("New IPTokenStaking implementation deployed at:", newImplementation);
+    }
+}

--- a/contracts/src/upgrades/IPTokenStaking.sol
+++ b/contracts/src/upgrades/IPTokenStaking.sol
@@ -1,0 +1,548 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IIPTokenStaking } from "../interfaces/IIPTokenStaking.sol";
+import { Secp256k1Verifier } from "../protocol/Secp256k1Verifier.sol";
+
+/**
+ * @title IPTokenStaking
+ * @notice The deposit contract for IP token staked validators.
+ * @dev This contract is a sort of "bridge" to request validator related actions on the consensus chain.
+ * The response will happen on the consensus chain.
+ * Since most of the validator related actions are executed on the consensus chain, the methods in this contract
+ * must be considered requests and not final actions, a successful transaction here does not guarantee the success
+ * of the transaction on the consensus chain.
+ * NOTE: All $IP tokens staked to this contract will be burned (transferred to the zero address).
+ * The flow is as follows:
+ * 1. User calls a method in this contract, which will emit an event if checks pass.
+ * 2. Modules on the consensus chain are listening for these events and execute the corresponding logic
+ * (e.g. staking, create validator, etc.), minting tokens in CL if needed.
+ * 3. If the action fails in CL, for example staking on a validator that doesn't exist, the deposited $IP tokens will
+ * not be refunded to the user. Remember that the EL transaction of step 2 would not have reverted. So please be
+ * cautious when making transactions with this contract.
+ */
+contract IPTokenStaking is
+    IIPTokenStaking,
+    ReentrancyGuardUpgradeable,
+    Secp256k1Verifier,
+    PausableUpgradeable,
+    AccessControlUpgradeable
+{
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /// @notice Maximum length of the validator moniker, in bytes.
+    uint256 public constant MAX_MONIKER_LENGTH = 70;
+
+    /// @notice Stake amount increments. Consensus Layer requires staking in increments of 1 gwei.
+    uint256 public constant STAKE_ROUNDING = 1 gwei;
+
+    /// @notice The address that can pause the contract.
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    /// @notice Default minimum fee charged for adding to CL storage
+    uint256 public immutable DEFAULT_MIN_FEE;
+
+    /// @notice The maximum size of the data field in the event logs.
+    uint256 public immutable MAX_DATA_LENGTH;
+
+    /// @notice Global minimum commission rate for validators
+    uint256 public minCommissionRate;
+
+    /// @notice Minimum amount required to stake.
+    uint256 public minStakeAmount;
+
+    /// @notice Minimum amount required to unstake.
+    uint256 public minUnstakeAmount;
+
+    /// @notice Counter to generate delegationIds for delegations with period.
+    /// @dev Starts in 1, since 0 is reserved for flexible delegations.
+    uint256 private _delegationIdCounter;
+
+    /// @notice The fee paid to update a validator (unjail, commission update, etc.)
+    uint256 public fee;
+
+    modifier chargesFee() {
+        require(msg.value == fee, "IPTokenStaking: Invalid fee amount");
+        payable(address(0x0)).transfer(msg.value);
+        _;
+    }
+
+    constructor(uint256 defaultMinFee, uint256 maxDataLength) {
+        require(defaultMinFee >= 1 gwei, "IPTokenStaking: Invalid default min fee");
+        DEFAULT_MIN_FEE = defaultMinFee;
+        MAX_DATA_LENGTH = maxDataLength;
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the contract.
+    /// @dev Only callable once at proxy deployment.
+    /// @param args The initializer arguments.
+    function initialize(IIPTokenStaking.InitializerArgs calldata args) public initializer {
+        __ReentrancyGuard_init();
+        // __Ownable_init(args.owner); deprecated
+        _setMinStakeAmount(args.minStakeAmount);
+        _setMinUnstakeAmount(args.minUnstakeAmount);
+        _setMinCommissionRate(args.minCommissionRate);
+        _setFee(args.fee);
+    }
+
+    /// @notice Initializes the V2 contract.
+    /// @dev Only callable once at proxy deployment.
+    /// @param pauser1 The address of the first pauser.
+    /// @param pauser2 The address of the second pauser.
+    function initializeV2(address pauser1, address pauser2) external reinitializer(2) {
+        require(pauser1 != address(0), "IPTokenStaking: Invalid pauser1");
+        require(pauser2 != address(0), "IPTokenStaking: Invalid pauser2");
+        __AccessControl_init();
+        __Pausable_init();
+        // 0x6c7FA8DF1B8Dc29a7481Bb65ad590D2D16787a82 is the timelock address
+        _grantRole(DEFAULT_ADMIN_ROLE, 0x6c7FA8DF1B8Dc29a7481Bb65ad590D2D16787a82);
+        _grantRole(PAUSER_ROLE, pauser1);
+        _grantRole(PAUSER_ROLE, pauser2);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                             Pause & Unpause                            //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Pauses the contract.
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /// @notice Unpauses the contract.
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                       Admin Setters/Getters                            //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Sets the minimum amount required to stake.
+    /// @param newMinStakeAmount The minimum amount required to stake.
+    function setMinStakeAmount(uint256 newMinStakeAmount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setMinStakeAmount(newMinStakeAmount);
+    }
+
+    /// @dev Sets the minimum amount required to withdraw.
+    /// @param newMinUnstakeAmount The minimum amount required to stake.
+    function setMinUnstakeAmount(uint256 newMinUnstakeAmount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setMinUnstakeAmount(newMinUnstakeAmount);
+    }
+
+    /// @notice Sets the fee charged for adding to CL storage.
+    /// @param newFee The new fee
+    function setFee(uint256 newFee) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setFee(newFee);
+    }
+
+    /// @notice Sets the global minimum commission rate for validators.
+    /// @param newValue The new minimum commission rate.
+    function setMinCommissionRate(uint256 newValue) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setMinCommissionRate(newValue);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                            Internal setters                            //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Sets the fee charged for adding to CL storage.
+    function _setFee(uint256 newFee) private {
+        require(newFee >= DEFAULT_MIN_FEE, "IPTokenStaking: Invalid min fee");
+        fee = newFee;
+        emit FeeSet(newFee);
+    }
+
+    /// @dev Sets the minimum amount required to stake.
+    /// @param newMinStakeAmount The minimum amount required to stake.
+    function _setMinStakeAmount(uint256 newMinStakeAmount) private {
+        minStakeAmount = newMinStakeAmount - (newMinStakeAmount % STAKE_ROUNDING);
+        require(minStakeAmount > 0, "IPTokenStaking: Zero min stake amount");
+        emit MinStakeAmountSet(minStakeAmount);
+    }
+
+    /// @dev Sets the minimum amount required to withdraw.
+    /// @param newMinUnstakeAmount The minimum amount required to stake.
+    function _setMinUnstakeAmount(uint256 newMinUnstakeAmount) private {
+        minUnstakeAmount = newMinUnstakeAmount - (newMinUnstakeAmount % STAKE_ROUNDING);
+        require(minUnstakeAmount > 0, "IPTokenStaking: Zero min unstake amount");
+        emit MinUnstakeAmountSet(minUnstakeAmount);
+    }
+
+    /// @dev Sets the minimum global commission rate for validators.
+    /// @param newValue The new minimum commission rate.
+    function _setMinCommissionRate(uint256 newValue) private {
+        require(newValue > 0, "IPTokenStaking: Zero min commission rate");
+        minCommissionRate = newValue;
+        emit MinCommissionRateChanged(newValue);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                            Operator functions                          //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Sets an operator for a delegator.
+    /// Calling this method will override any existing operator.
+    /// @param operator The operator address to add.
+    function setOperator(address operator) external payable whenNotPaused chargesFee {
+        // Use unsetOperator to remove an operator, not setting to zero address
+        require(operator != address(0), "IPTokenStaking: zero input address");
+        emit SetOperator(msg.sender, operator);
+    }
+
+    /// @notice Removes current operator for a delegator.
+    function unsetOperator() external payable whenNotPaused chargesFee {
+        emit UnsetOperator(msg.sender);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                     Staking Configuration functions                    //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Set/Update the withdrawal address that receives the withdrawals.
+    /// @param newWithdrawalAddress EVM address to receive the  withdrawals.
+    function setWithdrawalAddress(address newWithdrawalAddress) external payable whenNotPaused chargesFee {
+        require(newWithdrawalAddress != address(0), "IPTokenStaking: zero input address");
+        emit SetWithdrawalAddress({
+            delegator: msg.sender,
+            executionAddress: bytes32(uint256(uint160(newWithdrawalAddress))) // left-padded bytes32 of the address
+        });
+    }
+
+    /// @notice Set/Update the withdrawal address that receives the stake and reward withdrawals.
+    /// @dev To prevent spam, only delegators with stake can call this function with cool-down time.
+    /// @param newRewardsAddress EVM address to receive the stake and reward withdrawals.
+    function setRewardsAddress(address newRewardsAddress) external payable whenNotPaused chargesFee {
+        require(newRewardsAddress != address(0), "IPTokenStaking: zero input address");
+        emit SetRewardAddress({
+            delegator: msg.sender,
+            executionAddress: bytes32(uint256(uint160(newRewardsAddress))) // left-padded bytes32 of the address
+        });
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                          Validator Creation                            //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Entry point for creating a new validator with self delegation.
+    /// @dev The caller must provide the compressed public key that matches the expected EVM address.
+    /// Use this method to make sure the caller is the owner of the validator.
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param moniker The moniker of the validator.
+    /// @param commissionRate The commission rate of the validator.
+    /// @param maxCommissionRate The maximum commission rate of the validator.
+    /// @param maxCommissionChangeRate The maximum commission change rate of the validator.
+    /// @param supportsUnlocked Whether the validator supports unlocked staking.
+    /// @param data Additional data for the validator.
+    function createValidator(
+        bytes calldata validatorCmpPubkey,
+        string calldata moniker,
+        uint32 commissionRate,
+        uint32 maxCommissionRate,
+        uint32 maxCommissionChangeRate,
+        bool supportsUnlocked,
+        bytes calldata data
+    ) external payable whenNotPaused verifyCmpPubkeyWithExpectedAddress(validatorCmpPubkey, msg.sender) nonReentrant {
+        _createValidator(
+            validatorCmpPubkey,
+            moniker,
+            commissionRate,
+            maxCommissionRate,
+            maxCommissionChangeRate,
+            supportsUnlocked,
+            data
+        );
+    }
+
+    /// @dev Validator is the delegator when creating a new validator (self-delegation).
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param moniker The moniker of the validator.
+    /// @param commissionRate The commission rate of the validator.
+    /// @param maxCommissionRate The maximum commission rate of the validator.
+    /// @param maxCommissionChangeRate The maximum commission change rate of the validator.
+    /// @param supportsUnlocked Whether the validator supports unlocked staking.
+    /// @param data Additional data for the validator.
+    function _createValidator(
+        bytes calldata validatorCmpPubkey,
+        string memory moniker,
+        uint32 commissionRate,
+        uint32 maxCommissionRate,
+        uint32 maxCommissionChangeRate,
+        bool supportsUnlocked,
+        bytes calldata data
+    ) internal {
+        (uint256 stakeAmount, uint256 remainder) = roundedStakeAmount(msg.value);
+        require(stakeAmount >= minStakeAmount, "IPTokenStaking: Stake amount under min");
+        require(commissionRate >= minCommissionRate, "IPTokenStaking: Commission rate under min");
+        require(commissionRate <= maxCommissionRate, "IPTokenStaking: Commission rate over max");
+        require(bytes(moniker).length <= MAX_MONIKER_LENGTH, "IPTokenStaking: Moniker length over max");
+        require(data.length <= MAX_DATA_LENGTH, "IPTokenStaking: Data length over max");
+
+        payable(address(0)).transfer(stakeAmount);
+        emit CreateValidator(
+            validatorCmpPubkey,
+            moniker,
+            stakeAmount,
+            commissionRate,
+            maxCommissionRate,
+            maxCommissionChangeRate,
+            supportsUnlocked ? 1 : 0,
+            msg.sender,
+            data
+        );
+        if (remainder > 0) {
+            _refundRemainder(remainder);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                           Validator Config                             //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Update the commission rate of a validator.
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param commissionRate The new commission rate of the validator.
+    function updateValidatorCommission(
+        bytes calldata validatorCmpPubkey,
+        uint32 commissionRate
+    ) external payable whenNotPaused chargesFee verifyCmpPubkeyWithExpectedAddress(validatorCmpPubkey, msg.sender) {
+        require(commissionRate >= minCommissionRate, "IPTokenStaking: Commission rate under min");
+        emit UpdateValidatorCommission(validatorCmpPubkey, commissionRate);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                             Token Staking                              //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Entry point to stake (delegate) to the given validator. The consensus client (CL) is notified of
+    /// the deposit and manages the stake accounting and validator onboarding. Payer must be the delegator.
+    /// @dev Staking burns tokens in Execution Layer (EL). Unstaking (withdrawal) will trigger minting through
+    /// withdrawal queue.
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param stakingPeriod The staking period.
+    /// @param data Additional data for the stake.
+    /// @return delegationId The delegation ID, always 0 for flexible staking.
+    function stake(
+        bytes calldata validatorCmpPubkey,
+        IIPTokenStaking.StakingPeriod stakingPeriod,
+        bytes calldata data
+    ) external payable nonReentrant whenNotPaused returns (uint256 delegationId) {
+        return _stake(msg.sender, validatorCmpPubkey, stakingPeriod, data);
+    }
+
+    /// @notice Entry point for staking IP token to stake to the given validator. The consensus chain is notified of
+    /// the stake and manages the stake accounting and validator onboarding. Payer can stake on behalf of another user,
+    /// who will be the beneficiary of the stake.
+    /// @dev Staking burns tokens in Execution Layer (EL). Unstaking (withdrawal) will trigger minting through
+    /// withdrawal queue.
+    /// @param delegator The delegator's address
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param stakingPeriod The staking period.
+    /// @param data Additional data for the stake.
+    /// @return delegationId The delegation ID, always 0 for flexible staking.
+    function stakeOnBehalf(
+        address delegator,
+        bytes calldata validatorCmpPubkey,
+        IIPTokenStaking.StakingPeriod stakingPeriod,
+        bytes calldata data
+    ) external payable nonReentrant whenNotPaused returns (uint256 delegationId) {
+        return _stake(delegator, validatorCmpPubkey, stakingPeriod, data);
+    }
+
+    /// @dev Creates a validator (x/staking.MsgCreateValidator) if it does not exist. Then delegates the stake to the
+    /// validator (x/staking.MsgDelegate).
+    /// @param delegator The delegator's address
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param stakingPeriod The staking period.
+    /// @param data Additional data for the stake.
+    /// @return delegationId The delegation ID, always 0 for flexible staking.
+    function _stake(
+        address delegator,
+        bytes calldata validatorCmpPubkey,
+        IIPTokenStaking.StakingPeriod stakingPeriod,
+        bytes calldata data
+    ) internal verifyCmpPubkey(validatorCmpPubkey) returns (uint256) {
+        require(delegator != address(0), "IPTokenStaking: invalid delegator");
+        require(data.length <= MAX_DATA_LENGTH, "IPTokenStaking: Data length over max");
+        // This can't be tested from Foundry (Solidity), but can be triggered from js/rpc
+        require(stakingPeriod <= IIPTokenStaking.StakingPeriod.LONG, "IPTokenStaking: Invalid staking period");
+        (uint256 stakeAmount, uint256 remainder) = roundedStakeAmount(msg.value);
+        require(stakeAmount >= minStakeAmount, "IPTokenStaking: Stake amount under min");
+
+        uint256 delegationId = 0;
+        if (stakingPeriod != IIPTokenStaking.StakingPeriod.FLEXIBLE) {
+            delegationId = ++_delegationIdCounter;
+        }
+        emit Deposit(delegator, validatorCmpPubkey, stakeAmount, uint8(stakingPeriod), delegationId, msg.sender, data);
+        // We burn staked tokens
+        payable(address(0)).transfer(stakeAmount);
+
+        if (remainder > 0) {
+            _refundRemainder(remainder);
+        }
+
+        return delegationId;
+    }
+
+    /// @notice Entry point for redelegating the stake to another validator.
+    /// @dev For non flexible staking, your staking period will continue as is.
+    /// @dev For locked tokens, this will fail in CL if the validator doesn't support unlocked staking.
+    /// @param validatorSrcCmpPubkey 33 bytes compressed secp256k1 public key of source validator.
+    /// @param validatorDstCmpPubkey 33 bytes compressed secp256k1 public key of destination validator.
+    /// @param delegationId The delegation ID, 0 for flexible staking.
+    /// @param amount The amount of stake to redelegate.
+    function redelegate(
+        bytes calldata validatorSrcCmpPubkey,
+        bytes calldata validatorDstCmpPubkey,
+        uint256 delegationId,
+        uint256 amount
+    ) external payable whenNotPaused chargesFee {
+        _redelegate(msg.sender, validatorSrcCmpPubkey, validatorDstCmpPubkey, delegationId, amount);
+    }
+
+    /// @notice Entry point for redelegating the stake to another validator on behalf of the delegator.
+    /// @dev For non flexible staking, your staking period will continue as is.
+    /// @dev For locked tokens, this will fail in CL if the validator doesn't support unlocked staking.
+    /// @dev Caller must be the operator for the delegator, set via `setOperator`. The operator check is done in CL, so
+    /// this method will succeed even if the caller is not the operator (but will fail in CL).
+    /// @param delegator The delegator's address
+    /// @param validatorSrcCmpPubkey 33 bytes compressed secp256k1 public key of source validator.
+    /// @param validatorDstCmpPubkey 33 bytes compressed secp256k1 public key of destination validator.
+    /// @param delegationId The delegation ID, 0 for flexible staking.
+    /// @param amount The amount of stake to redelegate.
+    function redelegateOnBehalf(
+        address delegator,
+        bytes calldata validatorSrcCmpPubkey,
+        bytes calldata validatorDstCmpPubkey,
+        uint256 delegationId,
+        uint256 amount
+    ) external payable whenNotPaused chargesFee {
+        _redelegate(delegator, validatorSrcCmpPubkey, validatorDstCmpPubkey, delegationId, amount);
+    }
+
+    function _redelegate(
+        address delegator,
+        bytes calldata validatorSrcCmpPubkey,
+        bytes calldata validatorDstCmpPubkey,
+        uint256 delegationId,
+        uint256 amount
+    ) private verifyCmpPubkey(validatorSrcCmpPubkey) verifyCmpPubkey(validatorDstCmpPubkey) {
+        require(delegator != address(0), "IPTokenStaking: Invalid delegator");
+        require(
+            keccak256(validatorSrcCmpPubkey) != keccak256(validatorDstCmpPubkey),
+            "IPTokenStaking: Redelegating to same validator"
+        );
+        require(delegationId <= _delegationIdCounter, "IPTokenStaking: Invalid delegation id");
+        (uint256 stakeAmount, ) = roundedStakeAmount(amount);
+        require(stakeAmount >= minStakeAmount, "IPTokenStaking: Stake amount under min");
+
+        emit Redelegate(delegator, validatorSrcCmpPubkey, validatorDstCmpPubkey, delegationId, msg.sender, stakeAmount);
+    }
+
+    /// @notice Returns the rounded stake amount and the remainder.
+    /// @param rawAmount The raw stake amount.
+    /// @return amount The rounded stake amount.
+    /// @return remainder The remainder of the stake amount.
+    function roundedStakeAmount(uint256 rawAmount) public pure returns (uint256 amount, uint256 remainder) {
+        remainder = rawAmount % STAKE_ROUNDING;
+        amount = rawAmount - remainder;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                             Unstake                                    //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Entry point for unstaking the previously staked token.
+    /// @dev Unstake (withdrawal) will trigger native minting, so token in this contract is considered as burned.
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param delegationId The delegation ID, 0 for flexible staking.
+    /// @param amount Token amount to unstake.
+    /// @param data Additional data for the unstake.
+    function unstake(
+        bytes calldata validatorCmpPubkey,
+        uint256 delegationId,
+        uint256 amount,
+        bytes calldata data
+    ) external payable whenNotPaused chargesFee {
+        _unstake(msg.sender, validatorCmpPubkey, delegationId, amount, data);
+    }
+
+    /// @notice Entry point for unstaking the previously staked token on behalf of the delegator.
+    /// NOTE: If the amount is not divisible by STAKE_ROUNDING, it will be rounded down.
+    /// @dev Caller must be the operator for the delegator, set via `setOperator`. The operator check is done in CL, so
+    /// this method will succeed even if the caller is not the operator (but will fail in CL)
+    /// @param delegator The delegator's address
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param delegationId The delegation ID, 0 for flexible staking.
+    /// @param amount Token amount to unstake. This amount will be rounded to STAKE_ROUNDING.
+    /// @param data Additional data for the unstake.
+    function unstakeOnBehalf(
+        address delegator,
+        bytes calldata validatorCmpPubkey,
+        uint256 delegationId,
+        uint256 amount,
+        bytes calldata data
+    ) external payable whenNotPaused chargesFee {
+        _unstake(delegator, validatorCmpPubkey, delegationId, amount, data);
+    }
+
+    function _unstake(
+        address delegator,
+        bytes calldata validatorCmpPubkey,
+        uint256 delegationId,
+        uint256 amount,
+        bytes calldata data
+    ) private verifyCmpPubkey(validatorCmpPubkey) {
+        require(delegationId <= _delegationIdCounter, "IPTokenStaking: Invalid delegation id");
+        (uint256 unstakeAmount, ) = roundedStakeAmount(amount);
+        require(unstakeAmount >= minUnstakeAmount, "IPTokenStaking: Unstake amount under min");
+        require(data.length <= MAX_DATA_LENGTH, "IPTokenStaking: Data length over max");
+
+        emit Withdraw(delegator, validatorCmpPubkey, unstakeAmount, delegationId, msg.sender, data);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                             Unjail                                    //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Requests to unjail the validator. Caller must pay a fee to prevent spamming.
+    /// Fee must be exact amount.
+    /// @param data Additional data for the unjail.
+    function unjail(
+        bytes calldata validatorCmpPubkey,
+        bytes calldata data
+    ) external payable whenNotPaused chargesFee verifyCmpPubkeyWithExpectedAddress(validatorCmpPubkey, msg.sender) {
+        require(data.length <= MAX_DATA_LENGTH, "IPTokenStaking: Data length over max");
+        emit Unjail(msg.sender, validatorCmpPubkey, data);
+    }
+
+    /// @notice Requests to unjail the validator on behalf of the delegator.
+    /// @dev Must be an approved operator for the delegator.
+    /// @param validatorCmpPubkey 33 bytes compressed secp256k1 public key of validator.
+    /// @param data Additional data for the unjail.
+    function unjailOnBehalf(
+        bytes calldata validatorCmpPubkey,
+        bytes calldata data
+    ) external payable whenNotPaused chargesFee verifyCmpPubkey(validatorCmpPubkey) {
+        require(data.length <= MAX_DATA_LENGTH, "IPTokenStaking: Data length over max");
+        emit Unjail(msg.sender, validatorCmpPubkey, data);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+    //                             Helpers                                    //
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Refunds the remainder of the stake amount to the msg sender.
+    /// WARNING: Methods using this function should have nonReentrant modifier
+    /// to prevent potential reentrancy attacks.
+    /// @param remainder The remainder of the stake amount.
+    function _refundRemainder(uint256 remainder) private {
+        (bool success, ) = msg.sender.call{ value: remainder }("");
+        require(success, "IPTokenStaking: Failed to refund remainder");
+    }
+}

--- a/contracts/test/upgrades/IPTokenStaking.t.sol
+++ b/contracts/test/upgrades/IPTokenStaking.t.sol
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity 0.8.23;
+
+import { Test } from "../utils/Test.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { IPTokenStaking } from "../../src/upgrades/IPTokenStaking.sol";
+import { IIPTokenStaking } from "../../src/interfaces/IIPTokenStaking.sol";
+import { EIP1967Helper } from "../../script/utils/EIP1967Helper.sol";
+
+import { console2 } from "forge-std/console2.sol";
+
+/**
+ * @title IPTokenStakingTest
+ * @dev A test for the IPTokenStaking contract
+ */
+contract IPTokenStakingTest is Test {
+    IPTokenStaking ipTokenStakingProxy;
+    address safeGovernanceMultisig;
+    address securityCouncilMultisig;
+    address oldOwner;
+
+    uint256 public monikerLengthBefore;
+    uint256 public stakeRoundingBefore;
+    bytes32 public pauserRoleBefore;
+    uint256 public defaultMinFeeBefore;
+    uint256 public maxDataLengthBefore;
+    uint256 public minCommissionRateBefore;
+    uint256 public minStakeAmountBefore;
+    uint256 public minUnstakeAmountBefore;
+    uint256 public feeBefore;
+
+    function setUp() public override {
+        // Fork the desired network where UMA contracts are deployed
+        uint256 forkId = vm.createFork("https://mainnet.storyrpc.io/");
+        vm.selectFork(forkId);
+
+        // Mainnet related addresses
+        ipTokenStakingProxy = IPTokenStaking(0xCCcCcC0000000000000000000000000000000001);
+        safeGovernanceMultisig = 0xF07cA4b61022F0399C1511E7E668A57567f2138B;
+        securityCouncilMultisig = 0x25D2605b2C768082A14E79713114389d0eC297D8;
+        timelock = TimelockController(payable(0x6c7FA8DF1B8Dc29a7481Bb65ad590D2D16787a82));
+
+        oldOwner = OwnableUpgradeable(address(ipTokenStakingProxy)).owner();
+        monikerLengthBefore = ipTokenStakingProxy.MAX_MONIKER_LENGTH();
+        stakeRoundingBefore = ipTokenStakingProxy.STAKE_ROUNDING();
+        defaultMinFeeBefore = ipTokenStakingProxy.DEFAULT_MIN_FEE();
+        maxDataLengthBefore = ipTokenStakingProxy.MAX_DATA_LENGTH();
+        minCommissionRateBefore = ipTokenStakingProxy.minCommissionRate();
+        minStakeAmountBefore = ipTokenStakingProxy.minStakeAmount();
+        minUnstakeAmountBefore = ipTokenStakingProxy.minUnstakeAmount();
+        feeBefore = ipTokenStakingProxy.fee();
+
+        // deploy new implementation
+        IPTokenStaking newImpl = new IPTokenStaking(1000000000000000000, 256);
+
+        // upgrade the proxy to the new implementation
+        ProxyAdmin proxyAdmin = ProxyAdmin(EIP1967Helper.getAdmin(address(ipTokenStakingProxy)));
+        console2.log("proxyAdmin", address(proxyAdmin));
+        vm.startPrank(safeGovernanceMultisig);
+        timelock.schedule(
+            address(proxyAdmin),
+            0,
+            abi.encodeWithSelector(
+                ProxyAdmin.upgradeAndCall.selector,
+                ITransparentUpgradeableProxy(address(ipTokenStakingProxy)),
+                newImpl,
+                abi.encodeWithSelector(
+                    IPTokenStaking.initializeV2.selector,
+                    safeGovernanceMultisig,
+                    securityCouncilMultisig
+                )
+            ),
+            bytes32(0),
+            bytes32(0),
+            timelock.getMinDelay()
+        );
+
+        vm.warp(block.timestamp + timelock.getMinDelay() + 1);
+
+        timelock.execute(
+            address(proxyAdmin),
+            0,
+            abi.encodeWithSelector(
+                ProxyAdmin.upgradeAndCall.selector,
+                ITransparentUpgradeableProxy(address(ipTokenStakingProxy)),
+                newImpl,
+                abi.encodeWithSelector(
+                    IPTokenStaking.initializeV2.selector,
+                    safeGovernanceMultisig,
+                    securityCouncilMultisig
+                )
+            ),
+            bytes32(0),
+            bytes32(0)
+        );
+        vm.stopPrank();
+    }
+
+    function testNewRoles() public {
+        assertEq(
+            AccessControlUpgradeable(address(ipTokenStakingProxy)).hasRole(
+                AccessControlUpgradeable(address(ipTokenStakingProxy)).DEFAULT_ADMIN_ROLE(),
+                address(timelock)
+            ),
+            true
+        );
+        assertEq(
+            AccessControlUpgradeable(address(ipTokenStakingProxy)).hasRole(
+                ipTokenStakingProxy.PAUSER_ROLE(),
+                address(safeGovernanceMultisig)
+            ),
+            true
+        );
+        assertEq(
+            AccessControlUpgradeable(address(ipTokenStakingProxy)).hasRole(
+                ipTokenStakingProxy.PAUSER_ROLE(),
+                address(securityCouncilMultisig)
+            ),
+            true
+        );
+    }
+
+    function testInitializeRevertWhenCalledTwice() public {
+        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+        ipTokenStakingProxy.initialize(
+            IIPTokenStaking.InitializerArgs({
+                minStakeAmount: 1,
+                minUnstakeAmount: 1,
+                minCommissionRate: 1,
+                fee: 1,
+                owner: address(1)
+            })
+        );
+    }
+
+    function testInitializeV2RevertWhenCalledTwice() public {
+        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+        ipTokenStakingProxy.initializeV2(address(1), address(1));
+    }
+
+    function testPauseUnpauseSafeGovernanceMultisig() public {
+        assertEq(ipTokenStakingProxy.paused(), false);
+        vm.startPrank(safeGovernanceMultisig);
+        ipTokenStakingProxy.pause();
+        assertEq(ipTokenStakingProxy.paused(), true);
+        ipTokenStakingProxy.unpause();
+        assertEq(ipTokenStakingProxy.paused(), false);
+    }
+
+    function testPauseUnpauseSecurityCouncilMultisig() public {
+        assertEq(ipTokenStakingProxy.paused(), false);
+        vm.startPrank(securityCouncilMultisig);
+        ipTokenStakingProxy.pause();
+        assertEq(ipTokenStakingProxy.paused(), true);
+        ipTokenStakingProxy.unpause();
+        assertEq(ipTokenStakingProxy.paused(), false);
+    }
+
+    function testSetMinStakeAmountRevertWhenNotAdmin() public {
+        vm.startPrank(address(1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                address(1),
+                ipTokenStakingProxy.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        ipTokenStakingProxy.setMinStakeAmount(1 ether);
+    }
+
+    function testSetMinStakeAmount() public {
+        vm.startPrank(address(timelock));
+        ipTokenStakingProxy.setMinStakeAmount(1 ether);
+        assertEq(ipTokenStakingProxy.minStakeAmount(), 1 ether);
+    }
+
+    function testSetMinUnstakeAmountRevertWhenNotAdmin() public {
+        vm.startPrank(address(1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                address(1),
+                ipTokenStakingProxy.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        ipTokenStakingProxy.setMinUnstakeAmount(1 ether);
+    }
+
+    function testSetMinUnstakeAmount() public {
+        vm.startPrank(address(timelock));
+        ipTokenStakingProxy.setMinUnstakeAmount(1 ether);
+        assertEq(ipTokenStakingProxy.minUnstakeAmount(), 1 ether);
+    }
+
+    function testSetFeeRevertWhenNotAdmin() public {
+        vm.startPrank(address(1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                address(1),
+                ipTokenStakingProxy.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        ipTokenStakingProxy.setFee(1);
+    }
+
+    function testSetFee() public {
+        vm.startPrank(address(timelock));
+        ipTokenStakingProxy.setFee(1000000000000000001);
+        assertEq(ipTokenStakingProxy.fee(), 1000000000000000001);
+    }
+
+    function testSetMinCommissionRateRevertWhenNotAdmin() public {
+        vm.startPrank(address(1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                address(1),
+                ipTokenStakingProxy.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        ipTokenStakingProxy.setMinCommissionRate(1);
+    }
+
+    function testSetMinCommissionRate() public {
+        vm.startPrank(address(timelock));
+        ipTokenStakingProxy.setMinCommissionRate(1);
+        assertEq(ipTokenStakingProxy.minCommissionRate(), 1);
+    }
+
+    function testStakeRevertWhenPaused() public {
+        vm.deal(safeGovernanceMultisig, 1 ether);
+        vm.startPrank(safeGovernanceMultisig);
+        ipTokenStakingProxy.pause();
+        assertEq(ipTokenStakingProxy.paused(), true);
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
+        ipTokenStakingProxy.stake{ value: 1 ether }(bytes(""), IIPTokenStaking.StakingPeriod.FLEXIBLE, bytes(""));
+    }
+
+    function testStakeOnBehalfRevertWhenPaused() public {
+        vm.deal(safeGovernanceMultisig, 1 ether);
+        vm.startPrank(safeGovernanceMultisig);
+        ipTokenStakingProxy.pause();
+        assertEq(ipTokenStakingProxy.paused(), true);
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
+        ipTokenStakingProxy.stakeOnBehalf{ value: 1 ether }(
+            address(1),
+            bytes(""),
+            IIPTokenStaking.StakingPeriod.FLEXIBLE,
+            bytes("")
+        );
+    }
+
+    function testStorage() public {
+        assertEq(ipTokenStakingProxy.MAX_MONIKER_LENGTH(), monikerLengthBefore);
+        assertEq(ipTokenStakingProxy.STAKE_ROUNDING(), stakeRoundingBefore);
+        assertEq(ipTokenStakingProxy.DEFAULT_MIN_FEE(), defaultMinFeeBefore);
+        assertEq(ipTokenStakingProxy.MAX_DATA_LENGTH(), maxDataLengthBefore);
+        assertEq(ipTokenStakingProxy.minCommissionRate(), minCommissionRateBefore);
+        assertEq(ipTokenStakingProxy.minStakeAmount(), minStakeAmountBefore);
+        assertEq(ipTokenStakingProxy.minUnstakeAmount(), minUnstakeAmountBefore);
+        assertEq(ipTokenStakingProxy.fee(), feeBefore);
+    }
+}

--- a/contracts/test/upgrades/IPTokenStaking.t.sol
+++ b/contracts/test/upgrades/IPTokenStaking.t.sol
@@ -258,6 +258,174 @@ contract IPTokenStakingTest is Test {
         );
     }
 
+    // -------------------------------------------------------------------------
+    // whenNotPaused coverage — every gated entry point must revert while paused.
+    // Before this, only stake / stakeOnBehalf were covered. whenNotPaused is the
+    // first modifier on each, so it reverts before any param validation; dummy
+    // args + zero value are sufficient.
+    // -------------------------------------------------------------------------
+
+    function _pauseAsGov() internal {
+        vm.prank(safeGovernanceMultisig);
+        ipTokenStakingProxy.pause();
+        assertEq(ipTokenStakingProxy.paused(), true);
+    }
+
+    function _expectEnforcedPause() internal {
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
+    }
+
+    function testSetOperatorRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.setOperator(address(1));
+    }
+
+    function testUnsetOperatorRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.unsetOperator();
+    }
+
+    function testSetWithdrawalAddressRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.setWithdrawalAddress(address(1));
+    }
+
+    function testSetRewardsAddressRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.setRewardsAddress(address(1));
+    }
+
+    function testCreateValidatorRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.createValidator(bytes(""), "", 0, 0, 0, false, bytes(""));
+    }
+
+    function testUpdateValidatorCommissionRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.updateValidatorCommission(bytes(""), 0);
+    }
+
+    function testRedelegateRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.redelegate(bytes(""), bytes(""), 0, 0);
+    }
+
+    function testRedelegateOnBehalfRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.redelegateOnBehalf(address(1), bytes(""), bytes(""), 0, 0);
+    }
+
+    function testUnstakeRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.unstake(bytes(""), 0, 0, bytes(""));
+    }
+
+    function testUnstakeOnBehalfRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.unstakeOnBehalf(address(1), bytes(""), 0, 0, bytes(""));
+    }
+
+    function testUnjailRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.unjail(bytes(""), bytes(""));
+    }
+
+    function testUnjailOnBehalfRevertWhenPaused() public {
+        _pauseAsGov();
+        _expectEnforcedPause();
+        ipTokenStakingProxy.unjailOnBehalf(bytes(""), bytes(""));
+    }
+
+    // -------------------------------------------------------------------------
+    // pause / unpause access control — only PAUSER_ROLE holders.
+    // -------------------------------------------------------------------------
+
+    function testPauseRevertWhenNotPauser() public {
+        vm.startPrank(address(1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                address(1),
+                ipTokenStakingProxy.PAUSER_ROLE()
+            )
+        );
+        ipTokenStakingProxy.pause();
+    }
+
+    function testUnpauseRevertWhenNotPauser() public {
+        _pauseAsGov();
+        vm.startPrank(address(1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                address(1),
+                ipTokenStakingProxy.PAUSER_ROLE()
+            )
+        );
+        ipTokenStakingProxy.unpause();
+    }
+
+    // -------------------------------------------------------------------------
+    // pause state machine edges.
+    // -------------------------------------------------------------------------
+
+    function testPauseRevertWhenAlreadyPaused() public {
+        _pauseAsGov();
+        vm.prank(securityCouncilMultisig);
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
+        ipTokenStakingProxy.pause();
+    }
+
+    function testUnpauseRevertWhenNotPaused() public {
+        vm.prank(safeGovernanceMultisig);
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.ExpectedPause.selector));
+        ipTokenStakingProxy.unpause();
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin config setters are intentionally NOT gated by pause: they stay
+    // callable by DEFAULT_ADMIN_ROLE (timelock) while the contract is paused.
+    // -------------------------------------------------------------------------
+
+    function testAdminSettersWorkWhilePaused() public {
+        _pauseAsGov();
+        vm.startPrank(address(timelock));
+        ipTokenStakingProxy.setMinStakeAmount(2 ether);
+        ipTokenStakingProxy.setFee(1000000000000000002);
+        vm.stopPrank();
+        assertEq(ipTokenStakingProxy.minStakeAmount(), 2 ether);
+        assertEq(ipTokenStakingProxy.fee(), 1000000000000000002);
+    }
+
+    // -------------------------------------------------------------------------
+    // Gated entry points work again after unpause (resume). setWithdrawalAddress
+    // is fee-charged but has no pubkey validation, so a correct call succeeds.
+    // -------------------------------------------------------------------------
+
+    function testGatedFunctionWorksAfterUnpause() public {
+        vm.startPrank(safeGovernanceMultisig);
+        ipTokenStakingProxy.pause();
+        ipTokenStakingProxy.unpause();
+        vm.stopPrank();
+        assertEq(ipTokenStakingProxy.paused(), false);
+
+        uint256 currentFee = ipTokenStakingProxy.fee();
+        vm.deal(address(2), currentFee);
+        vm.prank(address(2));
+        ipTokenStakingProxy.setWithdrawalAddress{ value: currentFee }(address(3));
+    }
+
     function testStorage() public {
         assertEq(ipTokenStakingProxy.MAX_MONIKER_LENGTH(), monikerLengthBefore);
         assertEq(ipTokenStakingProxy.STAKE_ROUNDING(), stakeRoundingBefore);


### PR DESCRIPTION
## Summary

Re-lands the IPTokenStaking V2 pausing feature onto `main` and adds full test coverage.

History: #606 added pausing to `main`; #632 then reverted it ("to later commit them to a different branch" — it now lives on `dev/pause-staking`). This PR:
1. Reverts #632, restoring the three pausing files (`src/upgrades/IPTokenStaking.sol`, `script/upgrades/DeployNewIPTokenStaking_V2_0_0.s.sol`, `test/upgrades/IPTokenStaking.t.sol`).
2. Extends the pause tests beyond `stake`/`stakeOnBehalf`:
   - `whenNotPaused` revert for the remaining 12 gated entry points (setOperator, unsetOperator, setWithdrawalAddress, setRewardsAddress, createValidator, updateValidatorCommission, redelegate(+OnBehalf), unstake(+OnBehalf), unjail(+OnBehalf))
   - pause/unpause access control (non-PAUSER reverts)
   - state-machine edges (pause-when-paused, unpause-when-not-paused)
   - admin setters remain callable while paused (DEFAULT_ADMIN_ROLE)
   - gated entry point resumes after unpause

## Note

#632 intentionally parked pausing on `dev/pause-staking`. This PR proposes bringing it back to `main` — please confirm that is the intended direction before merging.

## Test

`forge test --match-path test/upgrades/IPTokenStaking.t.sol` — 34 passed, 0 failed (mainnet fork).

issue: none