### PR TITLE
fix(dkg): align register key-length checks with the kernel encoding

### DIFF
--- a/contracts/src/protocol/DKG.sol
+++ b/contracts/src/protocol/DKG.sol
@@ -192,12 +192,12 @@ contract DKG is IDKG, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Pausa
         // arrays would otherwise be ambiguous: (dkgPubKey=X‖Y, commKey=Z) and
         // (dkgPubKey=X, commKey=Y‖Z) hash to the same value. Fixing both lengths makes
         // the packing injective, which the kernel's calculateReportData mirrors.
-        require(enclaveInstanceData.dkgPubKey.length == 64, "DKG: DKG public key must be 64 bytes");
-        require(enclaveInstanceData.enclaveCommKey.length == 65, "DKG: Enclave communication key must be 65 bytes");
+        require(enclaveInstanceData.dkgPubKey.length == 32, "DKG: DKG public key must be 32 bytes");
+        require(enclaveInstanceData.enclaveCommKey.length == 64, "DKG: Enclave communication key must be 64 bytes");
 
         // Compute expectedDataCommitment matching kernel's calculateReportData:
         // keccak256(validatorAddr(20) || round(4) || startBlockHeight(8) || startBlockHash(32) ||
-        //           dkgPubKey(64) || enclaveCommKey(65))
+        //           dkgPubKey(32) || enclaveCommKey(64))
         bytes32 expectedDataCommitment = keccak256(
             abi.encodePacked(
                 enclaveInstanceData.validatorAddr,

--- a/contracts/test/dkg/dkg.t.sol
+++ b/contracts/test/dkg/dkg.t.sol
@@ -356,7 +356,7 @@ contract DKGTest is Test {
         uint256 fee = dkg.fee();
         vm.deal(alice, fee);
         vm.prank(alice);
-        vm.expectRevert("DKG: Enclave communication key must be 65 bytes");
+        vm.expectRevert("DKG: Enclave communication key must be 64 bytes");
         dkg.register{ value: fee }(hex"aa", instanceData, 100, bytes32(uint256(1)), "");
     }
 
@@ -366,27 +366,27 @@ contract DKGTest is Test {
         uint256 fee = dkg.fee();
         vm.deal(alice, fee);
         vm.prank(alice);
-        vm.expectRevert("DKG: DKG public key must be 64 bytes");
+        vm.expectRevert("DKG: DKG public key must be 32 bytes");
         dkg.register{ value: fee }(hex"aa", instanceData, 100, bytes32(uint256(1)), "");
     }
 
     function testDKG_Register_RevertIfWrongDkgPubKeyLength() public {
         IDKG.EnclaveInstanceData memory instanceData = _defaultInstanceData();
-        instanceData.dkgPubKey = new bytes(63); // one short of 64
+        instanceData.dkgPubKey = new bytes(31); // one short of 32
         uint256 fee = dkg.fee();
         vm.deal(alice, fee);
         vm.prank(alice);
-        vm.expectRevert("DKG: DKG public key must be 64 bytes");
+        vm.expectRevert("DKG: DKG public key must be 32 bytes");
         dkg.register{ value: fee }(hex"aa", instanceData, 100, bytes32(uint256(1)), "");
     }
 
     function testDKG_Register_RevertIfWrongCommKeyLength() public {
         IDKG.EnclaveInstanceData memory instanceData = _defaultInstanceData();
-        instanceData.enclaveCommKey = new bytes(64); // one short of 65
+        instanceData.enclaveCommKey = new bytes(63); // one short of 64
         uint256 fee = dkg.fee();
         vm.deal(alice, fee);
         vm.prank(alice);
-        vm.expectRevert("DKG: Enclave communication key must be 65 bytes");
+        vm.expectRevert("DKG: Enclave communication key must be 64 bytes");
         dkg.register{ value: fee }(hex"aa", instanceData, 100, bytes32(uint256(1)), "");
     }
 
@@ -651,8 +651,8 @@ contract DKGTest is Test {
             1,
             alice,
             MOCK_ENCLAVE_TYPE,
-            instanceData.enclaveCommKey, // 65-byte fixture
-            instanceData.dkgPubKey, // 64-byte fixture
+            instanceData.enclaveCommKey, // 64-byte fixture
+            instanceData.dkgPubKey, // 32-byte fixture
             bytes32(uint256(42)), // mock codeCommitment
             100,
             bytes32(uint256(1)),
@@ -846,7 +846,7 @@ contract DKGTest is Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     function _defaultInstanceData() internal view returns (IDKG.EnclaveInstanceData memory) {
-        // register() pins dkgPubKey to 64 bytes and enclaveCommKey to 65 bytes so the
+        // register() pins dkgPubKey to 32 bytes and enclaveCommKey to 64 bytes so the
         // abi.encodePacked report-data preimage stays injective; default fixtures must
         // therefore use real-length keys.
         return
@@ -854,8 +854,8 @@ contract DKGTest is Test {
                 round: 1,
                 validatorAddr: alice,
                 enclaveType: GENESIS_ENCLAVE_TYPE,
-                enclaveCommKey: new bytes(65),
-                dkgPubKey: new bytes(64)
+                enclaveCommKey: new bytes(64),
+                dkgPubKey: new bytes(32)
             });
     }
 


### PR DESCRIPTION
## Problem

`DKG.sol::register` pins `dkgPubKey` to 64 bytes and `enclaveCommKey` to 65 bytes, but the kernel produces — and the consensus client verifies — a **32-byte** ed25519 `dkgPubKey` and a **64-byte** secp256k1 `commKey` (uncompressed, `0x04` prefix stripped). Every `register` therefore reverts on the length check, so DKG cannot bootstrap on any chain running the current contracts.

The strict checks were added in #831 (previously the fields were only required to be non-empty), which is why this surfaced only after the up-to-date contracts were actually deployed.

## Fix

Require `dkgPubKey == 32` and `enclaveCommKey == 64` to match what the kernel emits and the CL verifies. Both fields stay fixed-length, so the `abi.encodePacked` report-data preimage remains injective and `calculateReportData` still mirrors it.

issue: https://github.com/piplabs/story-kernel/issues/73
