### PR TITLE
chore(dkg): add debug logging to the deal-handling path

### DIFF
--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -235,22 +235,60 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 		addrByIndex[dealerRegs[i].Index] = dealerRegs[i].ValidatorAddr
 	}
 
+	// DEBUG: resolve each incoming deal's (0-based, dealer-committee) index to a
+	// validator address so the logs say WHICH validator dealt — the raw kyber
+	// index alone is unreadable. dealerRound/dealerTotal describe the committee
+	// expected to deal (prev active committee for resharing, current otherwise).
+	log.Debug(ctx, "markDealersDealt: dealer committee",
+		"round", latestRound.Round,
+		"dealer_round", *dealerRound,
+		"dealer_total", dealerTotal,
+		"num_deals", len(deals),
+		"is_resharing", latestRound.IsResharing,
+	)
+
+	recorded := 0
 	for _, deal := range deals {
 		// Bound the 0-based kyber index by the dealer committee's total, then convert to
 		// the 1-based registration index.
 		if deal.Index >= dealerTotal {
+			log.Debug(ctx, "markDealersDealt: deal index out of dealer-committee range; skipping",
+				"round", latestRound.Round,
+				"deal_index", deal.Index,
+				"dealer_total", dealerTotal,
+			)
+
 			continue
 		}
 
 		addr, ok := addrByIndex[deal.Index+1]
 		if !ok {
+			log.Debug(ctx, "markDealersDealt: no dealer address for index; skipping",
+				"round", latestRound.Round,
+				"deal_index", deal.Index,
+				"reg_index", deal.Index+1,
+			)
+
 			continue
 		}
+
+		log.Debug(ctx, "markDealersDealt: dealer submitted deal",
+			"round", latestRound.Round,
+			"deal_index", deal.Index,
+			"dealer", addr,
+		)
 
 		if err := k.DealtDealers.Set(ctx, dealtDealerKey(latestRound.Round, addr)); err != nil {
 			return errors.Wrap(err, "failed to record dealt dealer", "round", latestRound.Round, "dealer", addr)
 		}
+		recorded++
 	}
+
+	log.Info(ctx, "markDealersDealt: recorded dealers that submitted a deal",
+		"round", latestRound.Round,
+		"dealer_total", dealerTotal,
+		"recorded", recorded,
+	)
 
 	return nil
 }

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -110,8 +110,14 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 
 	k.EnqueueDeals(resp.GetDeals())
 
+	// DEBUG: session.Index is this validator's 1-based on-chain registration index
+	// (its dealer identity). Logging it next to the enqueued deal count makes clear
+	// which validator produced this batch of deals.
 	log.Info(ctx, "DKG deals are generated successfully",
 		"round", session.Round,
+		"self_index", session.Index,
+		"is_resharing", session.IsResharing,
+		"enqueued_deals", len(resp.GetDeals()),
 	)
 }
 
@@ -247,6 +253,21 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 	// through with an empty `rejected` slice.
 	rejected := resp.GetRejectedDeals()
 	if len(rejected) > 0 {
+		// DEBUG: list the rejected deals' sender (dealer) indices. This handler runs
+		// in an async context without KV access, so the dealer index -> validator
+		// address mapping is NOT resolved here; cross-reference the consensus-path
+		// "markDealersDealt: dealer submitted deal" logs for the same round to turn
+		// these indices into addresses.
+		rejectedIdx := make([]uint32, 0, len(rejected))
+		for _, r := range rejected {
+			rejectedIdx = append(rejectedIdx, r.Index)
+		}
+		log.Warn(ctx, "Kernel rejected deals", nil,
+			"round", dkgNetwork.Round,
+			"self_index", session.Index,
+			"rejected_sender_index", rejectedIdx,
+		)
+
 		rejectedSet := make(map[rejectedKey]struct{}, len(rejected))
 		for _, r := range rejected {
 			rejectedSet[rejectedDealKey(r)] = struct{}{}


### PR DESCRIPTION
## Motivation

While debugging DKG bootstrap failures on devnet, the existing logging in the deal-handling path was too sparse to tell what was happening — from the logs you couldn't tell which validator sent a deal or whose deal was rejected (only raw kyber indices appeared). This adds debug/forensic logging so the deal flow is legible.

**Logging-only — no behavior change.**

## What's added (`client/x/dkg/keeper`)

- `markDealersDealt` — resolves each incoming deal's dealer-committee index to a validator address (the raw kyber index alone was unreadable) and logs a per-round summary of how many dealers were recorded.
- `handleDKGDealing` — logs this node's own session (dealer) index and the number of deals it enqueued.
- `handleDKGProcessDeals` — enumerates the sender indices of deals the kernel rejected.

## Log levels

Per-deal detail at `debug` (off by default in production); per-round summaries and rejections at `info`/`warn`.

## Context

These logs were used to localize piplabs/story-kernel#76 and piplabs/story-kernel#77 (and complement piplabs/story#845). Pairs with the kernel-side debug-logging PR.
