### PR TITLE
fix(dkg): store presence-only DKG collections as bool maps so ICS23 can prove their leaves

### DIFF
--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -239,7 +239,7 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 	// validator address so the logs say WHICH validator dealt — the raw kyber
 	// index alone is unreadable. dealerRound/dealerTotal describe the committee
 	// expected to deal (prev active committee for resharing, current otherwise).
-	log.Debug(ctx, "markDealersDealt: dealer committee",
+	log.Debug(ctx, "MarkDealersDealt: dealer committee",
 		"round", latestRound.Round,
 		"dealer_round", *dealerRound,
 		"dealer_total", dealerTotal,
@@ -252,7 +252,7 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 		// Bound the 0-based kyber index by the dealer committee's total, then convert to
 		// the 1-based registration index.
 		if deal.Index >= dealerTotal {
-			log.Debug(ctx, "markDealersDealt: deal index out of dealer-committee range; skipping",
+			log.Debug(ctx, "MarkDealersDealt: deal index out of dealer-committee range; skipping",
 				"round", latestRound.Round,
 				"deal_index", deal.Index,
 				"dealer_total", dealerTotal,
@@ -263,7 +263,7 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 
 		addr, ok := addrByIndex[deal.Index+1]
 		if !ok {
-			log.Debug(ctx, "markDealersDealt: no dealer address for index; skipping",
+			log.Debug(ctx, "MarkDealersDealt: no dealer address for index; skipping",
 				"round", latestRound.Round,
 				"deal_index", deal.Index,
 				"reg_index", deal.Index+1,
@@ -272,7 +272,7 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 			continue
 		}
 
-		log.Debug(ctx, "markDealersDealt: dealer submitted deal",
+		log.Debug(ctx, "MarkDealersDealt: dealer submitted deal",
 			"round", latestRound.Round,
 			"deal_index", deal.Index,
 			"dealer", addr,
@@ -284,7 +284,7 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 		recorded++
 	}
 
-	log.Info(ctx, "markDealersDealt: recorded dealers that submitted a deal",
+	log.Info(ctx, "MarkDealersDealt: recorded dealers that submitted a deal",
 		"round", latestRound.Round,
 		"dealer_total", dealerTotal,
 		"recorded", recorded,

--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -247,7 +247,7 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 			continue
 		}
 
-		if err := k.DealtDealers.Set(ctx, dealtDealerKey(latestRound.Round, addr)); err != nil {
+		if err := k.DealtDealers.Set(ctx, dealtDealerKey(latestRound.Round, addr), true); err != nil {
 			return errors.Wrap(err, "failed to record dealt dealer", "round", latestRound.Round, "dealer", addr)
 		}
 	}

--- a/client/x/dkg/keeper/dkg_dealt_dealers_hash_internal_test.go
+++ b/client/x/dkg/keeper/dkg_dealt_dealers_hash_internal_test.go
@@ -10,21 +10,26 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	"github.com/cosmos/iavl"
+	iavldb "github.com/cosmos/iavl/db"
+	ics23 "github.com/cosmos/ics23/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/piplabs/story/client/x/dkg/types"
 )
 
-// TestDealtDealersCollection_NoHashImpact proves that registering the DealtDealers
-// KeySet on the schema (as NewKeeper does) does not change the committed app hash on
-// its own: the hash only changes once something is actually written to the prefix, and
-// returns to the original once the entry is pruned.
+// TestDealtDealersCollection_NoHashImpact proves that declaring the DealtDealers Map on
+// the schema (as NewKeeper does) does not change the committed app hash on its own: the
+// hash only changes once something is actually written to the prefix, and returns to the
+// original once the entry is pruned. This is what guarantees consensus safety for chains
+// that ran before DealtDealers existed (e.g. v1.7.0 Aeneid).
 func TestDealtDealersCollection_NoHashImpact(t *testing.T) {
 	cdc := moduletestutil.MakeTestEncodingConfig().Codec
 
 	// commitHash builds a fresh store, registers the DKGNetworks map and (optionally) the
-	// DealtDealers KeySet, writes a fixed DKGNetwork, optionally writes/prunes a dealt
-	// mark, commits, and returns the resulting multistore commit hash.
+	// DealtDealers Map, writes a fixed DKGNetwork, optionally writes/prunes a dealt mark,
+	// commits, and returns the resulting multistore commit hash.
 	commitHash := func(t *testing.T, registerDealt, writeDealt, pruneDealt bool) []byte {
 		t.Helper()
 
@@ -36,9 +41,10 @@ func TestDealtDealersCollection_NoHashImpact(t *testing.T) {
 		networks := collections.NewMap(sb, types.DKGNetworkKey, "dkg_networks",
 			collections.StringKey, codec.CollValue[types.DKGNetwork](cdc))
 
-		var dealt collections.KeySet[string]
+		var dealt collections.Map[string, bool]
 		if registerDealt {
-			dealt = collections.NewKeySet(sb, types.DealtDealersKey, "dealt_dealers", collections.StringKey)
+			dealt = collections.NewMap(sb, types.DealtDealersKey, "dealt_dealers",
+				collections.StringKey, collections.BoolValue)
 		}
 
 		_, err := sb.Build()
@@ -51,7 +57,7 @@ func TestDealtDealersCollection_NoHashImpact(t *testing.T) {
 
 		const dealerAddr = "0x0000000000000000000000000000000000000002"
 		if writeDealt {
-			require.NoError(t, dealt.Set(ctx, dealtDealerKey(1, dealerAddr)))
+			require.NoError(t, dealt.Set(ctx, dealtDealerKey(1, dealerAddr), true))
 			if pruneDealt {
 				require.NoError(t, dealt.Remove(ctx, dealtDealerKey(1, dealerAddr)))
 			}
@@ -60,15 +66,144 @@ func TestDealtDealersCollection_NoHashImpact(t *testing.T) {
 		return testCtx.CMS.Commit().Hash
 	}
 
-	hWithout := commitHash(t, false, false, false)   // KeySet not registered at all
-	hRegistered := commitHash(t, true, false, false) // registered, never written
-	hWritten := commitHash(t, true, true, false)     // registered and written
+	hWithout := commitHash(t, false, false, false)   // Map not declared at all
+	hRegistered := commitHash(t, true, false, false) // declared, never written
+	hWritten := commitHash(t, true, true, false)     // declared and written
 	hPruned := commitHash(t, true, true, true)       // written then pruned
 
 	require.Equal(t, hWithout, hRegistered,
-		"registering the DealtDealers KeySet without writing must not change the app hash")
+		"declaring the DealtDealers Map without writing must not change the app hash")
 	require.NotEqual(t, hWithout, hWritten,
 		"writing a dealt mark must change the app hash (sanity: the test can detect a real change)")
 	require.Equal(t, hWithout, hPruned,
 		"writing then pruning a dealt mark must restore the original app hash")
+}
+
+// TestDealtDealersCollection_DeterministicReplay models a v1.9.0 binary (with the new
+// DealtDealers Map declared on the keeper) reprocessing v1.7.0-era history that predates
+// DealtDealers. Replaying the same pre-DealtDealers writes under the new code must yield
+// the same app hash as the original processing, i.e. merely declaring the new collection
+// prefix does not perturb replay of old state.
+func TestDealtDealersCollection_DeterministicReplay(t *testing.T) {
+	cdc := moduletestutil.MakeTestEncodingConfig().Codec
+
+	// commitOldEraState writes a fixed set of pre-DealtDealers dkg-module keys, NEVER
+	// touches DealtDealers, commits, and returns the commit hash. declareDealt controls
+	// whether the new Map is declared on the schema (i.e. old binary vs new binary).
+	commitOldEraState := func(t *testing.T, declareDealt bool) []byte {
+		t.Helper()
+
+		key := storetypes.NewKVStoreKey(types.StoreKey)
+		tkey := storetypes.NewTransientStoreKey("transient_test")
+		testCtx := testutil.DefaultContextWithDB(t, key, tkey)
+		sb := collections.NewSchemaBuilder(runtime.NewKVStoreService(key))
+
+		networks := collections.NewMap(sb, types.DKGNetworkKey, "dkg_networks",
+			collections.StringKey, codec.CollValue[types.DKGNetwork](cdc))
+		votes := collections.NewMap(sb, types.GlobalPubKeyVotesKey, "dkg_global_pub_key_votes",
+			collections.StringKey, collections.Uint32Value)
+
+		// v1.9.0 binary additionally declares the new Map; v1.7.0 binary does not.
+		if declareDealt {
+			collections.NewMap(sb, types.DealtDealersKey, "dealt_dealers",
+				collections.StringKey, collections.BoolValue)
+		}
+
+		_, err := sb.Build()
+		require.NoError(t, err)
+
+		ctx := testCtx.Ctx
+
+		// Pre-DealtDealers state: networks + votes, identical across both binaries.
+		require.NoError(t, networks.Set(ctx, "1", types.DKGNetwork{Round: 1, Total: 3, Threshold: 2}))
+		require.NoError(t, networks.Set(ctx, "2", types.DKGNetwork{Round: 2, Total: 5, Threshold: 3}))
+		require.NoError(t, votes.Set(ctx, "1_abc", 2))
+		require.NoError(t, votes.Set(ctx, "2_def", 4))
+
+		return testCtx.CMS.Commit().Hash
+	}
+
+	h1 := commitOldEraState(t, false) // v1.7.0 binary processing v1.7.0-era state
+	h2 := commitOldEraState(t, true)  // v1.9.0 binary replaying the same state
+
+	require.Equal(t, h1, h2,
+		"a v1.9.0 node declaring DealtDealers must replay pre-DealtDealers history to the same app hash")
+}
+
+// TestDealtDealers_BoolICS23Provable proves that the bool value makes a DealtDealers leaf
+// ICS23-provable. It reproduces the original failure mode at the IAVL layer: an empty-value
+// leaf fails ics23 leaf-op verification ("leaf op needs value"), which broke non-membership
+// proofs whose absent key has a DealtDealers right neighbor. With the bool marker both the
+// membership proof for the leaf and a non-membership proof for an absent key bracketed by
+// bool leaves verify against the tree root.
+func TestDealtDealers_BoolICS23Provable(t *testing.T) {
+	// dealtKey builds the full in-store key for a DealtDealers entry: the collection
+	// prefix (0x0e) followed by the StringKey-encoded logical key. ICS23 proves against
+	// these raw store keys, so the test must match the on-disk layout.
+	dealtKey := func(logical string) []byte {
+		out := append([]byte{}, types.DealtDealersKey.Bytes()...)
+		return append(out, []byte(logical)...)
+	}
+
+	// boolVal is the on-disk value bytes for storing true via collections.BoolValue, which
+	// is a single non-empty byte (0x01) and is what keeps the leaf ICS23-provable.
+	boolVal, err := collections.BoolValue.Encode(true)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x01}, boolVal, "BoolValue must encode true to a single 0x01 byte")
+
+	const (
+		loKey = "1_0x0000000000000000000000000000000000000001"
+		hiKey = "1_0x0000000000000000000000000000000000000009"
+		// absentKey sorts strictly between loKey and hiKey so its right neighbor in a
+		// non-membership proof is the hiKey DealtDealers leaf.
+		absentKey = "1_0x0000000000000000000000000000000000000005"
+	)
+
+	t.Run("bool leaf verifies", func(t *testing.T) {
+		tree := iavl.NewMutableTree(iavldb.NewMemDB(), 0, false, iavl.NewNopLogger())
+
+		_, err := tree.Set(dealtKey(loKey), boolVal)
+		require.NoError(t, err)
+		_, err = tree.Set(dealtKey(hiKey), boolVal)
+		require.NoError(t, err)
+		_, _, err = tree.SaveVersion()
+		require.NoError(t, err)
+
+		imm, err := tree.GetImmutable(tree.Version())
+		require.NoError(t, err)
+		root := imm.Hash()
+
+		// Membership proof for a bool leaf verifies (non-empty value passes LeafOp).
+		memProof, err := imm.GetMembershipProof(dealtKey(hiKey))
+		require.NoError(t, err)
+		require.True(t, ics23.VerifyMembership(ics23.IavlSpec, root, memProof, dealtKey(hiKey), boolVal),
+			"bool-valued DealtDealers leaf must be ICS23-provable")
+
+		// Non-membership proof for an absent key whose right neighbor is a bool leaf
+		// verifies. This is the exact path that failed when leaves had empty values.
+		nonMemProof, err := imm.GetNonMembershipProof(dealtKey(absentKey))
+		require.NoError(t, err)
+		require.True(t, ics23.VerifyNonMembership(ics23.IavlSpec, root, nonMemProof, dealtKey(absentKey)),
+			"non-membership proof bracketed by bool leaves must verify")
+	})
+
+	t.Run("empty-value leaf is not ICS23-provable", func(t *testing.T) {
+		tree := iavl.NewMutableTree(iavldb.NewMemDB(), 0, false, iavl.NewNopLogger())
+
+		// Empty value reproduces the old KeySet encoding.
+		_, err := tree.Set(dealtKey(hiKey), []byte{})
+		require.NoError(t, err)
+		_, _, err = tree.SaveVersion()
+		require.NoError(t, err)
+
+		imm, err := tree.GetImmutable(tree.Version())
+		require.NoError(t, err)
+		root := imm.Hash()
+
+		memProof, err := imm.GetMembershipProof(dealtKey(hiKey))
+		require.NoError(t, err)
+		// ics23 LeafOp.Apply rejects the empty value, so verification fails.
+		require.False(t, ics23.VerifyMembership(ics23.IavlSpec, root, memProof, dealtKey(hiKey), []byte{}),
+			"empty-value leaf must NOT be ICS23-provable (the bug being fixed)")
+	})
 }

--- a/client/x/dkg/keeper/dkg_partial_decryption.go
+++ b/client/x/dkg/keeper/dkg_partial_decryption.go
@@ -113,7 +113,7 @@ func (k *Keeper) setPartialDecryptionSubmission(
 	// from genesis would cause an app hash mismatch between old and new binaries.
 	if k.isPartialDecryptIndexActive(ctx) {
 		indexKey := dkgPartialDecryptRoundIndexKey(round, key)
-		if err := k.DKGPartialDecryptRoundIndex.Set(ctx, indexKey, []byte{}); err != nil {
+		if err := k.DKGPartialDecryptRoundIndex.Set(ctx, indexKey, true); err != nil {
 			return errors.Wrap(err, "set partial decrypt round index")
 		}
 	}
@@ -234,7 +234,7 @@ func (k *Keeper) MigratePartialDecryptRoundIndex(ctx context.Context) error {
 			continue
 		}
 		indexKey := dkgPartialDecryptRoundIndexKey(uint32(roundVal), primaryKey)
-		if err := k.DKGPartialDecryptRoundIndex.Set(ctx, indexKey, []byte{}); err != nil {
+		if err := k.DKGPartialDecryptRoundIndex.Set(ctx, indexKey, true); err != nil {
 			return errors.Wrap(err, "migrate partial decrypt round index: write secondary index entry")
 		}
 		indexed++

--- a/client/x/dkg/keeper/dkg_partial_decryption_test.go
+++ b/client/x/dkg/keeper/dkg_partial_decryption_test.go
@@ -6,8 +6,16 @@ import (
 	"testing"
 
 	"cosmossdk.io/collections"
+	storetypes "cosmossdk.io/store/types"
 
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/iavl"
+	iavldb "github.com/cosmos/iavl/db"
+	ics23 "github.com/cosmos/ics23/go"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
@@ -587,4 +595,144 @@ func TestMigratePartialDecryptRoundIndex_Idempotent(t *testing.T) {
 	allIter.Close()
 	require.NoError(t, err)
 	require.Len(t, indexKeys, 2, "idempotent migration must not duplicate secondary index entries")
+}
+
+// TestPartialDecryptRoundIndexCollection_NoHashImpact proves that declaring the
+// DKGPartialDecryptRoundIndex Map on the schema does not change the committed app hash on
+// its own: the hash only changes once something is actually written to the prefix, and
+// returns to the original once the entry is pruned. The index is unreleased, so this also
+// confirms that nodes which never write the index commit the same hash whether or not the
+// new collection is declared.
+func TestPartialDecryptRoundIndexCollection_NoHashImpact(t *testing.T) {
+	cdc := moduletestutil.MakeTestEncodingConfig().Codec
+
+	// commitHash builds a fresh store, registers the DKGNetworks map and (optionally) the
+	// round-index Map, writes a fixed DKGNetwork, optionally writes/prunes an index entry,
+	// commits, and returns the resulting multistore commit hash.
+	commitHash := func(t *testing.T, registerIndex, writeIndex, pruneIndex bool) []byte {
+		t.Helper()
+
+		key := storetypes.NewKVStoreKey(types.StoreKey)
+		tkey := storetypes.NewTransientStoreKey("transient_test")
+		testCtx := testutil.DefaultContextWithDB(t, key, tkey)
+		sb := collections.NewSchemaBuilder(runtime.NewKVStoreService(key))
+
+		networks := collections.NewMap(sb, types.DKGNetworkKey, "dkg_networks",
+			collections.StringKey, codec.CollValue[types.DKGNetwork](cdc))
+
+		var index collections.Map[string, bool]
+		if registerIndex {
+			index = collections.NewMap(sb, types.DKGPartialDecryptRoundIndexKey, "dkg_partial_decrypt_round_index",
+				collections.StringKey, collections.BoolValue)
+		}
+
+		_, err := sb.Build()
+		require.NoError(t, err)
+
+		ctx := testCtx.Ctx
+
+		// Identical "real" state written in every case.
+		require.NoError(t, networks.Set(ctx, "1", types.DKGNetwork{Round: 1, Total: 3, Threshold: 2}))
+
+		const primaryKey = "reqhash_label_cthash_1_validator"
+		if writeIndex {
+			indexKey := dkgPartialDecryptRoundIndexKey(1, primaryKey)
+			require.NoError(t, index.Set(ctx, indexKey, true))
+			if pruneIndex {
+				require.NoError(t, index.Remove(ctx, indexKey))
+			}
+		}
+
+		return testCtx.CMS.Commit().Hash
+	}
+
+	hWithout := commitHash(t, false, false, false)   // Map not declared at all
+	hRegistered := commitHash(t, true, false, false) // declared, never written
+	hWritten := commitHash(t, true, true, false)     // declared and written
+	hPruned := commitHash(t, true, true, true)       // written then pruned
+
+	require.Equal(t, hWithout, hRegistered,
+		"declaring the round-index Map without writing must not change the app hash")
+	require.NotEqual(t, hWithout, hWritten,
+		"writing an index entry must change the app hash (sanity: the test can detect a real change)")
+	require.Equal(t, hWithout, hPruned,
+		"writing then pruning an index entry must restore the original app hash")
+}
+
+// TestPartialDecryptRoundIndex_BoolICS23Provable proves that the bool value makes a
+// DKGPartialDecryptRoundIndex leaf ICS23-provable. It reproduces the original failure mode
+// at the IAVL layer: an empty-value leaf fails ics23 leaf-op verification ("leaf op needs
+// value"), which broke any non-membership proof whose absent key has a round-index right
+// neighbor. With the bool marker both the membership proof for the leaf and a non-membership
+// proof for an absent key bracketed by bool leaves verify against the tree root.
+func TestPartialDecryptRoundIndex_BoolICS23Provable(t *testing.T) {
+	// indexKey builds the full in-store key for a round-index entry: the collection prefix
+	// (0x0c) followed by the StringKey-encoded logical key. ICS23 proves against these raw
+	// store keys, so the test must match the on-disk layout.
+	indexKey := func(logical string) []byte {
+		out := append([]byte{}, types.DKGPartialDecryptRoundIndexKey.Bytes()...)
+		return append(out, []byte(logical)...)
+	}
+
+	// boolVal is the on-disk value bytes for storing true via collections.BoolValue, a
+	// single non-empty byte (0x01) and what keeps the leaf ICS23-provable.
+	boolVal, err := collections.BoolValue.Encode(true)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x01}, boolVal, "BoolValue must encode true to a single 0x01 byte")
+
+	var (
+		loKey = dkgPartialDecryptRoundIndexKey(1, "reqhash_label_cthash_1_validatorA")
+		hiKey = dkgPartialDecryptRoundIndexKey(1, "reqhash_label_cthash_1_validatorZ")
+		// absentKey sorts strictly between loKey and hiKey so its right neighbor in a
+		// non-membership proof is the hiKey round-index leaf.
+		absentKey = dkgPartialDecryptRoundIndexKey(1, "reqhash_label_cthash_1_validatorM")
+	)
+
+	t.Run("bool leaf verifies", func(t *testing.T) {
+		tree := iavl.NewMutableTree(iavldb.NewMemDB(), 0, false, iavl.NewNopLogger())
+
+		_, err := tree.Set(indexKey(loKey), boolVal)
+		require.NoError(t, err)
+		_, err = tree.Set(indexKey(hiKey), boolVal)
+		require.NoError(t, err)
+		_, _, err = tree.SaveVersion()
+		require.NoError(t, err)
+
+		imm, err := tree.GetImmutable(tree.Version())
+		require.NoError(t, err)
+		root := imm.Hash()
+
+		// Membership proof for a bool leaf verifies (non-empty value passes LeafOp).
+		memProof, err := imm.GetMembershipProof(indexKey(hiKey))
+		require.NoError(t, err)
+		require.True(t, ics23.VerifyMembership(ics23.IavlSpec, root, memProof, indexKey(hiKey), boolVal),
+			"bool-valued round-index leaf must be ICS23-provable")
+
+		// Non-membership proof for an absent key whose right neighbor is a bool leaf
+		// verifies. This is the exact path that failed when leaves had empty values.
+		nonMemProof, err := imm.GetNonMembershipProof(indexKey(absentKey))
+		require.NoError(t, err)
+		require.True(t, ics23.VerifyNonMembership(ics23.IavlSpec, root, nonMemProof, indexKey(absentKey)),
+			"non-membership proof bracketed by bool leaves must verify")
+	})
+
+	t.Run("empty-value leaf is not ICS23-provable", func(t *testing.T) {
+		tree := iavl.NewMutableTree(iavldb.NewMemDB(), 0, false, iavl.NewNopLogger())
+
+		// Empty value reproduces the old []byte{} encoding.
+		_, err := tree.Set(indexKey(hiKey), []byte{})
+		require.NoError(t, err)
+		_, _, err = tree.SaveVersion()
+		require.NoError(t, err)
+
+		imm, err := tree.GetImmutable(tree.Version())
+		require.NoError(t, err)
+		root := imm.Hash()
+
+		memProof, err := imm.GetMembershipProof(indexKey(hiKey))
+		require.NoError(t, err)
+		// ics23 LeafOp.Apply rejects the empty value, so verification fails.
+		require.False(t, ics23.VerifyMembership(ics23.IavlSpec, root, memProof, indexKey(hiKey), []byte{}),
+			"empty-value leaf must NOT be ICS23-provable (the bug being fixed)")
+	})
 }

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -102,7 +102,7 @@ type Keeper struct {
 	KernelUpgradeInfos collections.Map[string, types.KernelUpgradeInfo] // key: upgradeVersion
 
 	DKGPartialDecrypt           collections.Map[string, []byte]               // key: requesterPubKeyHash_label_ciphertextHash_round_validator; value: partial submission
-	DKGPartialDecryptRoundIndex collections.Map[string, []byte]               // secondary index key: {round:010d}_{primary_key}; value: empty (presence only)
+	DKGPartialDecryptRoundIndex collections.Map[string, bool]                 // secondary index key: {round:010d}_{primary_key}; bool value keeps leaves ICS23-provable
 	DecryptRequestRegistry      collections.Map[string, types.DecryptRequest] // key: requesterPubKeyHash_label_round_ciphertextHash; value: decrypt request
 
 	// offChainPartialDecryptStore is an optional off-chain KV store that archives pruned partial
@@ -160,7 +160,7 @@ func NewKeeper(
 		SettlementBalance:           collections.NewItem(sb, types.SettlementBalanceKey, "settlement_balance", collections.StringValue),
 		KernelUpgradeInfos:          collections.NewMap(sb, types.KernelUpgradeInfoKey, "kernel_upgrade_infos", collections.StringKey, codec.CollValue[types.KernelUpgradeInfo](cdc)),
 		DKGPartialDecrypt:           collections.NewMap(sb, types.DKGPartialDecryptKey, "dkg_partial_decrypt_submissions", collections.StringKey, collections.BytesValue),
-		DKGPartialDecryptRoundIndex: collections.NewMap(sb, types.DKGPartialDecryptRoundIndexKey, "dkg_partial_decrypt_round_index", collections.StringKey, collections.BytesValue),
+		DKGPartialDecryptRoundIndex: collections.NewMap(sb, types.DKGPartialDecryptRoundIndexKey, "dkg_partial_decrypt_round_index", collections.StringKey, collections.BoolValue),
 		DecryptRequestRegistry:      collections.NewMap(sb, types.DecryptRequestRegistryKey, "decrypt_request_registry", collections.StringKey, codec.CollValue[types.DecryptRequest](cdc)),
 		CDRPartialSubmitCount:       collections.NewMap(sb, types.CDRPartialSubmitCountKey, "cdr_partial_submit_count", collections.StringKey, collections.Uint64Value),
 		CDRFeePoolBalance:           collections.NewItem(sb, types.CDRFeePoolBalanceKey, "cdr_fee_pool_balance", collections.StringValue),

--- a/client/x/dkg/keeper/keeper.go
+++ b/client/x/dkg/keeper/keeper.go
@@ -116,7 +116,7 @@ type Keeper struct {
 	CDRFeePoolBalance     collections.Item[string]        // total coins currently held in cdr-fee-pool
 
 	FinalizeVotes collections.Map[string, string] // key: round_validator; value: finalize vote key (round_gpk_coeffsHash) (v1.9.0+)
-	DealtDealers  collections.KeySet[string]      // key: round_dealerIndex; marks dealers that submitted a deal (v1.9.0+)
+	DealtDealers  collections.Map[string, bool]   // key: round_dealerIndex; bool value keeps leaves ICS23-provable (v1.9.0+)
 }
 
 // NewKeeper creates a new dkg Keeper instance.
@@ -165,7 +165,7 @@ func NewKeeper(
 		CDRPartialSubmitCount:       collections.NewMap(sb, types.CDRPartialSubmitCountKey, "cdr_partial_submit_count", collections.StringKey, collections.Uint64Value),
 		CDRFeePoolBalance:           collections.NewItem(sb, types.CDRFeePoolBalanceKey, "cdr_fee_pool_balance", collections.StringValue),
 		FinalizeVotes:               collections.NewMap(sb, types.FinalizeVotesKey, "dkg_finalize_votes", collections.StringKey, collections.StringValue),
-		DealtDealers:                collections.NewKeySet(sb, types.DealtDealersKey, "dealt_dealers", collections.StringKey),
+		DealtDealers:                collections.NewMap(sb, types.DealtDealersKey, "dealt_dealers", collections.StringKey, collections.BoolValue),
 	}
 
 	schema, err := sb.Build()

--- a/go.mod
+++ b/go.mod
@@ -84,8 +84,8 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/iavl v1.2.5 // indirect
-	github.com/cosmos/ics23/go v0.11.0 // indirect
+	github.com/cosmos/iavl v1.2.5
+	github.com/cosmos/ics23/go v0.11.0
 	github.com/cosmos/ledger-cosmos-go v0.14.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect


### PR DESCRIPTION
## Problem

`DealtDealers` (a `KeySet`) and `DKGPartialDecryptRoundIndex` (a `Map[string, []byte]` storing `[]byte{}`) write **empty-value** IAVL leaves. ICS23's `LeafOp.Apply` rejects empty values (`leaf op needs value`), so when the kernel verifies an ICS23 **non-existence** proof for a non-registered (e.g. non-TEE) validator's DKG registration whose in-tree right neighbor is one of these leaves, `VerifyNonMembership` returns false. The kernel then cannot build `roundContext`, the affected TEE validator submits no deal during the dealing window and is INVALIDATED.

## Fix

Store both presence-only collections as `Map[string, bool]` and write `true`. `collections.BoolValue` encodes to a single non-empty byte (`0x01`), so the leaves become ICS23-provable. Same prefixes and names are kept.

Both collections are unreleased (introduced for v1.9.0, absent from v1.7.0/Aeneid and all release branches), so **no migration is needed** — declaring an empty collection adds no IAVL leaf and does not change the app hash.

Two commits, one per collection. Tests prove:
- declaring an empty collection has no app-hash impact,
- a v1.9.0 binary replaying v1.7.0-era blocks yields the same commit hash (consensus-safe for existing chains),
- a bool-valued leaf is ICS23-provable (real `VerifyMembership`/`VerifyNonMembership`) while an empty-value leaf fails.

issue: [story-kernel #76](https://github.com/piplabs/story-kernel/issues/76)
