### PR TITLE
fix(dkg): skip idle sessions in processDecryptQueue to avoid misleading deferral warnings

### DIFF
--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -334,6 +334,12 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 	}
 
 	for _, session := range sessions {
+		// Skip sessions with no queued requests so the precondition checks below
+		// (index / global public key) don't log misleading deferral warnings for idle sessions.
+		if len(session.GetDecryptRequests()) == 0 {
+			continue
+		}
+
 		// Drop queued requests from sessions that are at least 2 rounds behind the
 		// current round — their keys are no longer relevant and the requests would
 		// never be processed successfully.

--- a/client/x/dkg/keeper/dkg_svc_test.go
+++ b/client/x/dkg/keeper/dkg_svc_test.go
@@ -498,6 +498,73 @@ func TestProcessDecryptQueue_SessionReadyButEmpty(t *testing.T) {
 	k.processDecryptQueue(ctx) // should be a no-op after drain
 }
 
+// TestProcessDecryptQueue_IdleSessionSkippedNoMutation verifies that a non-finalized
+// session (Index==0, empty GlobalPubKey) with an EMPTY decrypt queue is skipped at the
+// top of the loop before the precondition checks, so no state mutation occurs. This is
+// the idle-session log-noise fix: the index/GPK deferral warnings must not fire for
+// sessions that have no queued work.
+func TestProcessDecryptQueue_IdleSessionSkippedNoMutation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+	mockContract.EXPECT().BlockNumber(gomock.Any()).Return(uint64(100), nil)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	// Non-finalized idle session: Index unset, GlobalPubKey empty, no requests.
+	original := time.Now().Add(-time.Hour).UTC()
+	session := &types.DKGSession{
+		Round: 1, Index: 0, GlobalPubKey: nil,
+		LastUpdate:      original,
+		DecryptRequests: nil,
+	}
+	require.NoError(t, sm.CreateSession(ctx, session))
+
+	k := &Keeper{stateManager: sm, contractClient: mockContract, kernelRouter: NewKernelRouter(nil, nil)}
+	k.processDecryptQueue(ctx)
+
+	got, err := sm.GetSession(1)
+	require.NoError(t, err)
+	require.Empty(t, got.GetDecryptRequests(), "idle session must stay empty")
+	// LastUpdate is bumped by DrainDecryptRequests/UpdateSession; an unchanged value
+	// proves the session was skipped before any draining or persistence occurred.
+	require.True(t, got.LastUpdate.Equal(original), "idle session must not be mutated when skipped")
+}
+
+// TestProcessDecryptQueue_QueuedRequestReachesPreconditions verifies that a session with
+// a non-empty queue still reaches the precondition checks (here: Index==0 deferral), i.e.
+// the idle-session guard only skips sessions whose queue is empty.
+func TestProcessDecryptQueue_QueuedRequestReachesPreconditions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	mockContract := dkgtestutil.NewMockDKGContractClient(ctrl)
+	mockContract.EXPECT().BlockNumber(gomock.Any()).Return(uint64(100), nil)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	req := types.DecryptRequest{Ciphertext: []byte("encrypted"), Label: make([]byte, 32)}
+	session := &types.DKGSession{
+		Round: 1, Index: 0, GlobalPubKey: nil, // not yet finalized
+		DecryptRequests: []types.PendingDecryptRequest{{DecryptRequest: req}},
+	}
+	require.NoError(t, sm.CreateSession(ctx, session))
+
+	k := &Keeper{stateManager: sm, contractClient: mockContract, kernelRouter: NewKernelRouter(nil, nil)}
+	k.processDecryptQueue(ctx)
+
+	// The guard did not skip this session; it hit the Index==0 deferral and the request
+	// remains queued (deferred, not drained) for the next tick.
+	got, err := sm.GetSession(1)
+	require.NoError(t, err)
+	require.Len(t, got.GetDecryptRequests(), 1, "queued request must be deferred, not dropped")
+}
+
 func TestProcessDecryptQueue_FailedRequestsRetained(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

In `processDecryptQueue`, the per-session precondition checks log a WARN (`Session index not set` / `Missing global public key`, "deferring decrypt requests to next tick") for **every** non-finalized session on **every** tick — before the empty-queue check. Since each round's session has `Index == 0` / empty `GlobalPubKey` until it finalizes, idle sessions with zero queued requests produce high-volume, misleading log noise.

## Fix

Skip sessions with no queued requests at the top of the loop, using the non-mutating `GetDecryptRequests()` accessor, so the precondition warnings only fire for sessions that actually have work. The stale-drop, index, GPK, and drain logic are otherwise unchanged (an empty stale session has nothing to drop; a stale session with queued requests still reaches the drop path).

issue: #845
