### PR TITLE
chore(scripts): relax verifypr title and body checks

### DIFF
--- a/scripts/verifypr/README.md
+++ b/scripts/verifypr/README.md
@@ -1,6 +1,13 @@
 # verifypr
 
-Simple script that is called by [verifypr](../../.github/workflows/verifypr.yml) github action
-that verifies story PRs against the conventional commit template.
+Simple script that is called by the [verifypr](../../.github/workflows/ci-verifypr.yml) github action
+that verifies story PRs.
 
-See supported types [here](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum)
+It checks two things:
+
+1. The PR **title** follows the [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum)
+   style, e.g. `feat: ...` or `fix(scope): ...`. Casing, punctuation and scope are not restricted beyond
+   what the conventional commit spec requires; the title is capped at 100 characters.
+2. The PR **body footer** contains a single `issue:` line referencing a github issue, e.g. `issue: #1234`,
+   `issue: piplabs/story-geth#1559` or `issue: none`. The footer is the last paragraph of the body (the
+   block after the final blank line), so anything above it (e.g. bullet lists) is free-form.

--- a/scripts/verifypr/verify.go
+++ b/scripts/verifypr/verify.go
@@ -14,12 +14,11 @@ import (
 )
 
 var (
-	optionalLink       = `(fix\w*\s|close\w*\s|resolve\w*\s)?`    // Optional issue linking prefix, see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.
-	descRegex          = regexp.MustCompile(`^[a-z0-9 .&/-]+$`)   // e.g. "add foo-bar"
-	scopeRegex         = regexp.MustCompile(`^[*\w]+(/[*\w]+)?$`) // e.g. "*" or "foo" or "foo/bar"
-	issueRegexFull     = regexp.MustCompile(`^` + optionalLink + `https://github\\.com/piplabs/story/issues/\\d+$`)
+	optionalLink       = `(fix\w*\s|close\w*\s|resolve\w*\s)?` // Optional issue linking prefix, see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.
+	issueRegexFull     = regexp.MustCompile(`^` + optionalLink + `https://github\.com/piplabs/story/issues/\d+$`)
 	issueRegexShort    = regexp.MustCompile(`^` + optionalLink + `#\d+$`)                       // e.g. "#1334"
 	issueRegexCrossRef = regexp.MustCompile(`^` + optionalLink + `piplabs\/[a-zA-Z0-9-]+#\d+$`) // e.g. "piplabs/story-geth#1559"
+	issueLineRegex     = regexp.MustCompile(`(?i)^\s*[-*]?\s*issue:\s*(.+)$`)                   // e.g. "issue: #1334" or "- issue: #1334"
 )
 
 // run runs the verification.
@@ -38,10 +37,7 @@ func run() error {
 	log.Printf("PR Title: %s\n", pr.Title)
 	log.Printf("## PR Body:\n%s\n####\n", pr.Body)
 
-	// Convert PR title and body to conventional commit message.
-	commitMsg := fmt.Sprintf("%s\n\n%s", pr.Title, pr.Body)
-
-	return verify(commitMsg)
+	return verify(pr.Title, pr.Body)
 }
 
 type PR struct {
@@ -72,86 +68,79 @@ func prFromEnv() (PR, error) {
 	return pr, nil
 }
 
-// verify returns an error if the commit message doesn't correspond to the story conventional commit template.
-func verify(commitMsg string) error {
-	// Fix line endings, since conventional commit parser doesn't support CRLF.
-	commitMsg = strings.ReplaceAll(commitMsg, "\r\n", "\n")
+// verify returns an error if the PR title isn't a valid conventional commit
+// or if the PR body doesn't reference a github issue.
+func verify(title, body string) error {
+	if err := verifyTitle(title); err != nil {
+		return err
+	}
 
-	// Parse conventional commit message.
+	return verifyIssue(body)
+}
+
+// verifyTitle ensures the PR title follows the conventional commit style
+// (e.g. "feat: ...", "fix(scope): ..."). Casing, punctuation and scope
+// are intentionally not restricted beyond what the conventional commit spec requires.
+func verifyTitle(title string) error {
+	// Fix line endings, since conventional commit parser doesn't support CRLF.
+	title = strings.ReplaceAll(title, "\r\n", "\n")
+
+	const maxLen = 100
+	if len(title) > maxLen {
+		return errors.New("title too long")
+	}
+
 	m := parser.NewMachine()
 	m.WithTypes(cc.TypesConventional)
 
-	msg, err := m.Parse([]byte(commitMsg))
+	msg, err := m.Parse([]byte(title))
 	if err != nil {
-		return fmt.Errorf("parse conventional commit message: %w", err)
+		return fmt.Errorf("title is not a conventional commit: %v", err)
 	}
 
 	commit, ok := msg.(*cc.ConventionalCommit)
 	if !ok {
-		return errors.New("message is not a conventional commit")
+		return errors.New("title is not a conventional commit")
 	}
 
-	// Verify conventional commit message is valid.
 	if !commit.Ok() {
-		return errors.New("conventional commit not ok")
-	}
-
-	// Verify title is valid.
-	if err := verifyDescription(commit.Description); err != nil {
-		return err
-	}
-
-	// Verify body is non-empty.
-	if commit.Body == nil || *commit.Body == "" {
-		return errors.New("body empty")
-	}
-
-	// Verify footer is valid.
-	if err := verifyFooter(commit); err != nil {
-		return err
-	}
-
-	// Verify scope is valid.
-	if err := verifyScope(commit); err != nil {
-		return err
+		return errors.New("title is not a valid conventional commit")
 	}
 
 	return nil
 }
 
-func verifyDescription(description string) error {
-	const maxLen = 80
-	if len(description) > maxLen {
-		return errors.New("description too long")
+// verifyIssue ensures the PR body footer contains a single `issue:` line referencing a
+// github issue. The footer is the last paragraph of the body (the block after the final
+// blank line), so the body above it may contain anything (e.g. bullet lists).
+func verifyIssue(body string) error {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+
+	// Footer = last paragraph, i.e. the block after the final blank line.
+	footer := strings.TrimSpace(body)
+	if idx := strings.LastIndex(footer, "\n\n"); idx >= 0 {
+		footer = strings.TrimSpace(footer[idx+len("\n\n"):])
 	}
 
-	if !descRegex.MatchString(description) {
-		return errors.New("description doesn't match regex")
+	var issues []string
+	for _, line := range strings.Split(footer, "\n") {
+		if matches := issueLineRegex.FindStringSubmatch(line); matches != nil {
+			issues = append(issues, strings.TrimSpace(matches[1]))
+		}
 	}
 
-	return nil
-}
-
-func verifyFooter(commit *cc.ConventionalCommit) error {
-	const issueFooter = "issue"
-
-	if len(commit.Footers) == 0 {
-		return errors.New("missing `issue` section. Please add a github issue for this PR")
+	if len(issues) == 0 {
+		return errors.New("missing `issue` section in footer. Please add an `issue:` line at the end of the PR body")
 	}
 
-	if len(commit.Footers[issueFooter]) == 0 {
-		return errors.New("missing `issue` section. Please add a github issue for this PR")
-	}
-
-	if len(commit.Footers[issueFooter]) != 1 {
+	if len(issues) != 1 {
 		return errors.New("invalid number of issue sections, only one allowed")
 	}
 
-	issue := strings.TrimSpace(commit.Footers[issueFooter][0])
+	// The issue value is never empty: issueLineRegex only captures non-empty content.
+	issue := issues[0]
 	//nolint:nestif // nested ifs readability
-	if issue == "" {
-		return errors.New("issue section empty")
-	} else if issue == "none" {
+	if issue == "none" {
 		// None is fine
 	} else if issueRegexFull.MatchString(issue) {
 		// Full issue URL
@@ -161,24 +150,6 @@ func verifyFooter(commit *cc.ConventionalCommit) error {
 		// Cross-repo (same org) issue URL
 	} else {
 		return errors.New("invalid issue section")
-	}
-
-	return nil
-}
-
-func verifyScope(commit *cc.ConventionalCommit) error {
-	if commit.Scope == nil {
-		return errors.New("scope not set")
-	}
-
-	scope := *commit.Scope
-
-	if scope == "" {
-		return errors.New("scope empty")
-	}
-
-	if !scopeRegex.MatchString(scope) {
-		return errors.New("scope doesn't match regex")
 	}
 
 	return nil

--- a/scripts/verifypr/verify_test.go
+++ b/scripts/verifypr/verify_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestVerify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		title   string
+		body    string
+		wantErr bool
+	}{
+		{
+			name:  "conventional title with caps, punctuation and long description",
+			title: "feat: Add Foo Bar! (with CAPS) & symbols, a fairly long description that goes past eighty chars",
+			body:  "Some description.\n\nissue: #1234",
+		},
+		{
+			name:  "no scope is allowed",
+			title: "fix: do the thing",
+			body:  "issue: #1",
+		},
+		{
+			name:  "scope is allowed",
+			title: "fix(dkg): do the thing",
+			body:  "issue: #1",
+		},
+		{
+			name:    "non-conventional title rejected",
+			title:   "Random title without a type",
+			body:    "issue: #1",
+			wantErr: true,
+		},
+		{
+			name:    "title over 100 chars rejected",
+			title:   "feat: " + strings.Repeat("a", 100),
+			body:    "issue: #1",
+			wantErr: true,
+		},
+		{
+			name:  "issue as bullet point is allowed",
+			title: "chore: cleanup",
+			body:  "- some change\n- issue: #1234",
+		},
+		{
+			name:  "issue in footer after bullet body",
+			title: "chore: cleanup",
+			body:  "- did a thing\n- fixed a bug\n\nissue: #1234",
+		},
+		{
+			name:  "issue in footer after markdown body",
+			title: "chore: cleanup",
+			body:  "## Description\n\n- foo\n- bar\n\nissue: #1234",
+		},
+		{
+			name:    "issue not in footer (content below) rejected",
+			title:   "chore: cleanup",
+			body:    "issue: #1234\n\n- a follow up note",
+			wantErr: true,
+		},
+		{
+			// Only the last paragraph (footer) is inspected; an `issue:` line
+			// elsewhere in the body is ignored, so the footer's single line wins.
+			name:  "issue line outside footer is ignored",
+			title: "chore: cleanup",
+			body:  "issue: #1 referenced in prose\n\nissue: #2",
+		},
+		{
+			name:  "issue with linking prefix is allowed",
+			title: "chore: cleanup",
+			body:  "issue: fixes #1234",
+		},
+		{
+			name:  "cross-repo issue is allowed",
+			title: "chore: cleanup",
+			body:  "issue: piplabs/story-geth#1559",
+		},
+		{
+			name:  "full issue url is allowed",
+			title: "chore: cleanup",
+			body:  "issue: https://github.com/piplabs/story/issues/1234",
+		},
+		{
+			name:  "issue none is allowed",
+			title: "chore: cleanup",
+			body:  "issue: none",
+		},
+		{
+			name:    "missing issue rejected",
+			title:   "chore: cleanup",
+			body:    "just a body without an issue line",
+			wantErr: true,
+		},
+		{
+			name:    "two issue lines rejected",
+			title:   "chore: cleanup",
+			body:    "issue: #1\nissue: #2",
+			wantErr: true,
+		},
+		{
+			name:    "invalid issue value rejected",
+			title:   "chore: cleanup",
+			body:    "issue: not-an-issue",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verify(tt.title, tt.body)
+			if tt.wantErr && err == nil {
+				t.Fatalf("verify(%q, %q) = nil, want error", tt.title, tt.body)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("verify(%q, %q) = %v, want nil", tt.title, tt.body, err)
+			}
+		})
+	}
+}
+
+func TestPrFromEnv(t *testing.T) {
+	// Note: cannot use t.Parallel with t.Setenv.
+	tests := []struct {
+		name    string
+		set     bool
+		val     string
+		want    PR
+		wantErr bool
+	}{
+		{
+			name:    "env not set",
+			set:     false,
+			wantErr: true,
+		},
+		{
+			name:    "env blank",
+			set:     true,
+			val:     "   ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			set:     true,
+			val:     "{not json}",
+			wantErr: true,
+		},
+		{
+			name:    "missing required field",
+			set:     true,
+			val:     `{"title":"feat: x","body":"issue: #1"}`,
+			wantErr: true,
+		},
+		{
+			name: "valid pr",
+			set:  true,
+			val:  `{"title":"feat: x","body":"issue: #1","node_id":"abc"}`,
+			want: PR{Title: "feat: x", Body: "issue: #1", ID: "abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("GITHUB_PR", tt.val)
+			} else {
+				os.Unsetenv("GITHUB_PR")
+			}
+
+			got, err := prFromEnv()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("prFromEnv() = %+v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("prFromEnv() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Fatalf("prFromEnv() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	// Note: cannot use t.Parallel with t.Setenv.
+	tests := []struct {
+		name    string
+		val     string
+		wantErr bool
+	}{
+		{
+			name: "valid pr passes",
+			val:  `{"title":"feat: x","body":"issue: #1","node_id":"abc"}`,
+		},
+		{
+			name: "dependabot pr skipped",
+			val:  `{"title":"chore(deps): bump x","body":"made by dependabot","node_id":"abc"}`,
+		},
+		{
+			name:    "env error propagates",
+			val:     "",
+			wantErr: true,
+		},
+		{
+			name:    "verification failure propagates",
+			val:     `{"title":"not conventional","body":"issue: #1","node_id":"abc"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.val == "" {
+				os.Unsetenv("GITHUB_PR")
+			} else {
+				t.Setenv("GITHUB_PR", tt.val)
+			}
+
+			err := run()
+			if tt.wantErr && err == nil {
+				t.Fatalf("run() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("run() = %v, want nil", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Relaxes the overly strict `scripts/verifypr` PR checks so they validate intent rather than exact formatting.

## Changes

- **Title** — now only needs to follow [conventional commit](https://www.conventionalcommits.org/) style. Removed the lowercase-only/punctuation regex and the mandatory `scope`; uppercase, special characters and missing scope are all allowed. A **100-character** cap remains.
- **Body** — the `issue:` line must sit in the **footer** (the last paragraph of the body). Detection no longer relies on the conventional-commit footer parser, so free-form content above it (e.g. bullet lists, markdown headings) no longer breaks the check. A single valid `issue:` reference is still required.

## Why

The previous check rejected common, reasonable PRs: capitalized titles, titles with `&`/`!`, and bodies where the `issue:` line followed a bullet list — the conventional-commit parser raised `illegal character in trailer` whenever content surrounded the footer.

## Tests

Added `verify_test.go` covering title rules, footer placement, the past failure cases, and env/`run` paths. Coverage **57% → 88.5%** (remaining uncovered: `main`'s `os.Exit` and unreachable defensive guards in `verifyTitle`).

issue: none
