### PR TITLE
fix(dkg): map deal and justification indices through the dealer committee

### DIFF
--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"context"
+	"sort"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -112,10 +114,22 @@ func (k *Keeper) ProcessJustifications(ctx context.Context, latestRound *types.D
 
 	suite := edwards25519.NewBlakeSHA256Ed25519()
 
-	dealerPubKeys, err := k.buildDealerPubKeyMap(ctx, latestRound, suite)
+	// Snapshot the dealer committee once so j.Index resolves stably even as the loop below
+	// invalidates registrations.
+	dealerRound, err := k.resolveDealerRound(ctx, latestRound)
 	if err != nil {
-		return errors.Wrap(err, "build dealer pub key map")
+		return errors.Wrap(err, "resolve dealer committee round")
 	}
+
+	var committee []types.DKGRegistration
+	if dealerRound != nil {
+		committee, err = k.dealerCommitteeRegs(ctx, *dealerRound)
+		if err != nil {
+			return errors.Wrap(err, "build dealer committee")
+		}
+	}
+
+	dealerPubKeys := dealerPubKeyMap(ctx, committee, suite)
 
 	// Step 1: Signature verification (deterministic, no kernel needed).
 	var signatureVerified []types.Justification
@@ -150,15 +164,28 @@ func (k *Keeper) ProcessJustifications(ctx context.Context, latestRound *types.D
 
 		if !valid {
 			// Deal was genuinely invalid — invalidate the dealer's on-chain registration
-			// so they cannot finalize or receive committee rewards.
+			// so they cannot finalize or receive committee rewards. Resolve the dealer index
+			// against the committee snapshot taken above.
+			if int(j.Index) >= len(committee) {
+				log.Error(ctx, "Justification dealer index out of committee range", nil,
+					"dealer_index", j.Index,
+					"committee_size", len(committee),
+				)
+
+				continue
+			}
+
+			dealerAddr := common.HexToAddress(strings.TrimSpace(committee[j.Index].ValidatorAddr))
+
 			log.Info(ctx, "Justification VSS verification failed, invalidating dealer",
 				"dealer_index", j.Index,
+				"validator_addr", dealerAddr.Hex(),
 				"round", latestRound.Round,
 			)
 
-			if err := k.invalidateDealerRegistration(ctx, latestRound, j.Index); err != nil {
+			if err := k.invalidateDealerByAddr(ctx, latestRound.Round, dealerAddr); err != nil {
 				log.Error(ctx, "Failed to invalidate dealer registration", err,
-					"dealer_index", j.Index,
+					"validator_addr", dealerAddr.Hex(),
 				)
 			}
 
@@ -209,14 +236,11 @@ func (k *Keeper) ProcessDeals(ctx context.Context, latestRound *types.DKGNetwork
 	return nil
 }
 
-// markDealersDealt records the address of each dealer that submitted a deal, so missing
-// dealers can be invalidated at BeginFinalization. deal.Index is the dealer's 0-based kyber
-// index within the DEALER committee: the current round for the initial DKG, but the previous
-// active committee for resharing rounds (they hold the existing shares). The index is resolved
-// to a validator address through that committee's registrations, because the dealer and current
-// index spaces are permuted differently across rounds.
+// markDealersDealt records which dealers submitted a deal so missing dealers can be invalidated
+// at BeginFinalization. deal.Index is the dealer's 0-based position in the dealer committee,
+// resolved to an address via dealerCommitteeAddrs.
 func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNetwork, deals []types.Deal) error {
-	dealerRound, dealerTotal, err := k.dealerCommitteeRound(ctx, latestRound)
+	dealerRound, err := k.resolveDealerRound(ctx, latestRound)
 	if err != nil {
 		return err
 	}
@@ -224,53 +248,33 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 		return nil
 	}
 
-	dealerRegs, err := k.getDKGRegistrationsByRound(ctx, *dealerRound)
+	// committee[i] is the validator at kyber index i; deal.Index indexes directly into it.
+	committee, err := k.dealerCommitteeAddrs(ctx, *dealerRound)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch dealer registrations", "round", *dealerRound)
+		return err
 	}
 
-	// Map the dealer committee's 1-based registration index to validator address.
-	addrByIndex := make(map[uint32]string, len(dealerRegs))
-	for i := range dealerRegs {
-		addrByIndex[dealerRegs[i].Index] = dealerRegs[i].ValidatorAddr
-	}
-
-	// DEBUG: resolve each incoming deal's (0-based, dealer-committee) index to a
-	// validator address so the logs say WHICH validator dealt — the raw kyber
-	// index alone is unreadable. dealerRound/dealerTotal describe the committee
-	// expected to deal (prev active committee for resharing, current otherwise).
 	log.Debug(ctx, "MarkDealersDealt: dealer committee",
 		"round", latestRound.Round,
 		"dealer_round", *dealerRound,
-		"dealer_total", dealerTotal,
+		"committee_size", len(committee),
 		"num_deals", len(deals),
 		"is_resharing", latestRound.IsResharing,
 	)
 
 	recorded := 0
 	for _, deal := range deals {
-		// Bound the 0-based kyber index by the dealer committee's total, then convert to
-		// the 1-based registration index.
-		if deal.Index >= dealerTotal {
+		if deal.Index >= uint32(len(committee)) {
 			log.Debug(ctx, "MarkDealersDealt: deal index out of dealer-committee range; skipping",
 				"round", latestRound.Round,
 				"deal_index", deal.Index,
-				"dealer_total", dealerTotal,
+				"committee_size", len(committee),
 			)
 
 			continue
 		}
 
-		addr, ok := addrByIndex[deal.Index+1]
-		if !ok {
-			log.Debug(ctx, "MarkDealersDealt: no dealer address for index; skipping",
-				"round", latestRound.Round,
-				"deal_index", deal.Index,
-				"reg_index", deal.Index+1,
-			)
-
-			continue
-		}
+		addr := committee[deal.Index]
 
 		log.Debug(ctx, "MarkDealersDealt: dealer submitted deal",
 			"round", latestRound.Round,
@@ -286,31 +290,64 @@ func (k *Keeper) markDealersDealt(ctx context.Context, latestRound *types.DKGNet
 
 	log.Info(ctx, "MarkDealersDealt: recorded dealers that submitted a deal",
 		"round", latestRound.Round,
-		"dealer_total", dealerTotal,
+		"committee_size", len(committee),
 		"recorded", recorded,
 	)
 
 	return nil
 }
 
-// dealerCommitteeRound returns the round and total of the committee expected to deal in
-// latestRound. For resharing rounds this is the previous active committee (which holds the
-// existing shares); otherwise it is the current round. A nil round means there is no dealer
-// committee to attribute deals to (e.g. resharing with no prior active round).
-func (k *Keeper) dealerCommitteeRound(ctx context.Context, latestRound *types.DKGNetwork) (*uint32, uint32, error) {
+// dealerCommitteeRegs returns the dealer round's committee: ALL of the round's registrations
+// (any status) sorted by registration index, matching the kernel's kyber committee where the
+// 0-based position is the kyber deal/justification Index. Invalidated members keep their slot so
+// the survivors' indices do not shift (kyber resharing requires the position to be preserved).
+func (k *Keeper) dealerCommitteeRegs(ctx context.Context, round uint32) ([]types.DKGRegistration, error) {
+	committee, err := k.getDKGRegistrationsByRound(ctx, round)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch dealer registrations", "round", round)
+	}
+
+	sort.SliceStable(committee, func(i, j int) bool {
+		return committee[i].Index < committee[j].Index
+	})
+
+	return committee, nil
+}
+
+// dealerCommitteeAddrs returns dealerCommitteeRegs as validator addresses; committee[i] is the
+// validator at kyber index i.
+func (k *Keeper) dealerCommitteeAddrs(ctx context.Context, round uint32) ([]string, error) {
+	regs, err := k.dealerCommitteeRegs(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs := make([]string, len(regs))
+	for i := range regs {
+		addrs[i] = regs[i].ValidatorAddr
+	}
+
+	return addrs, nil
+}
+
+// resolveDealerRound returns the round of the committee expected to deal in latestRound. For
+// resharing rounds this is the previous active committee (which holds the existing shares);
+// otherwise it is the current round. A nil round means there is no dealer committee to attribute
+// deals to (e.g. resharing with no prior active round).
+func (k *Keeper) resolveDealerRound(ctx context.Context, latestRound *types.DKGNetwork) (*uint32, error) {
 	if !latestRound.IsResharing {
-		return &latestRound.Round, latestRound.Total, nil
+		return &latestRound.Round, nil
 	}
 
 	prevActive, err := k.getLatestActiveDKGNetwork(ctx)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to get previous active round")
+		return nil, errors.Wrap(err, "failed to get previous active round")
 	}
 	if prevActive == nil {
-		return nil, 0, nil
+		return nil, nil
 	}
 
-	return &prevActive.Round, prevActive.Total, nil
+	return &prevActive.Round, nil
 }
 
 func (k *Keeper) ProcessResponses(ctx context.Context, latestRound *types.DKGNetwork, responses []types.Response) error {

--- a/client/x/dkg/keeper/dkg_dealing_test.go
+++ b/client/x/dkg/keeper/dkg_dealing_test.go
@@ -420,12 +420,10 @@ func TestBuildDealerPubKeyMap(t *testing.T) {
 	setupDealerRegistrationWithKey(t, k, ctx, round, dealer1, 0, dtc1.pubBytes)
 	setupDealerRegistrationWithKey(t, k, ctx, round, dealer2, 1, dtc2.pubBytes)
 
-	network := &types.DKGNetwork{
-		Round: round,
-	}
-
-	pubKeys, err := k.buildDealerPubKeyMap(ctx, network, suite)
+	committee, err := k.dealerCommitteeRegs(ctx, round)
 	require.NoError(t, err)
+
+	pubKeys := dealerPubKeyMap(ctx, committee, suite)
 	require.Len(t, pubKeys, 2)
 	require.True(t, pubKeys[0].Equal(dtc1.pub))
 	require.True(t, pubKeys[1].Equal(dtc2.pub))
@@ -473,9 +471,10 @@ func TestJustificationPipeline_SignatureThenDedupThenVSS(t *testing.T) {
 		Threshold: dealingTestThreshold,
 	}
 
-	// Build the dealer public key map once, matching what the handler builds.
-	dealerPubKeys, err := k.buildDealerPubKeyMap(ctx, network, suite)
+	// Build the dealer public key map once, matching what ProcessJustifications builds.
+	committee, err := k.dealerCommitteeRegs(ctx, round)
 	require.NoError(t, err)
+	dealerPubKeys := dealerPubKeyMap(ctx, committee, suite)
 	require.Len(t, dealerPubKeys, 2)
 
 	t.Run("valid signatures pass, invalid signatures are dropped", func(t *testing.T) {
@@ -671,7 +670,7 @@ func TestProcessJustifications_InvalidatesDealer(t *testing.T) {
 	})
 }
 
-// TestBuildDealerPubKeyMap_EmptyDkgPubKey verifies that buildDealerPubKeyMap skips
+// TestBuildDealerPubKeyMap_EmptyDkgPubKey verifies that dealerPubKeyMap skips
 // registrations with empty DkgPubKey (the `len(reg.DkgPubKey) == 0` branch).
 func TestBuildDealerPubKeyMap_EmptyDkgPubKey(t *testing.T) {
 	t.Parallel()
@@ -692,13 +691,13 @@ func TestBuildDealerPubKeyMap_EmptyDkgPubKey(t *testing.T) {
 	}
 	require.NoError(t, k.setDKGRegistration(ctx, emptyKeyDealer, reg))
 
-	network := &types.DKGNetwork{Round: round}
-	pubKeys, err := k.buildDealerPubKeyMap(ctx, network, suite)
+	committee, err := k.dealerCommitteeRegs(ctx, round)
 	require.NoError(t, err)
+	pubKeys := dealerPubKeyMap(ctx, committee, suite)
 	require.Empty(t, pubKeys, "empty DkgPubKey registrations must be skipped")
 }
 
-// TestBuildDealerPubKeyMap_InvalidDkgPubKeyBytes verifies that buildDealerPubKeyMap
+// TestBuildDealerPubKeyMap_InvalidDkgPubKeyBytes verifies that dealerPubKeyMap
 // silently skips (via log.Warn) registrations whose DkgPubKey bytes cannot be
 // unmarshaled as an Edwards25519 point. The map is still returned without error.
 func TestBuildDealerPubKeyMap_InvalidDkgPubKeyBytes(t *testing.T) {
@@ -725,11 +724,12 @@ func TestBuildDealerPubKeyMap_InvalidDkgPubKeyBytes(t *testing.T) {
 	}
 	require.NoError(t, k.setDKGRegistration(ctx, invalidDealer, badReg))
 
-	network := &types.DKGNetwork{Round: round}
-	pubKeys, err := k.buildDealerPubKeyMap(ctx, network, suite)
-	require.NoError(t, err, "invalid DkgPubKey bytes must be skipped without error")
+	committee, err := k.dealerCommitteeRegs(ctx, round)
+	require.NoError(t, err)
+	pubKeys := dealerPubKeyMap(ctx, committee, suite)
 	require.Len(t, pubKeys, 1, "only the valid dealer should appear in the map")
-	require.True(t, pubKeys[1].Equal(dtcValid.pub), "valid dealer's key must be in the map at index 1")
+	// The valid dealer has the lowest registration index, so it sits at committee position 0.
+	require.True(t, pubKeys[0].Equal(dtcValid.pub), "valid dealer's key must be at committee position 0")
 }
 
 // --- Tests merged from begin_dealing_test.go ---
@@ -1290,7 +1290,7 @@ func initTestStateManager(t *testing.T, k *Keeper) {
 
 // TestProcessJustifications_MissingDealerRegistration verifies that ProcessJustifications
 // skips a justification (via verifyJustification returning error) when the dealer
-// has no registration (buildDealerPubKeyMap returns an empty map → sig verify fails).
+// has no registration (dealerPubKeyMap returns an empty map → sig verify fails).
 func TestProcessJustifications_MissingDealerRegistration(t *testing.T) {
 	// No dealer registrations — signature verification will fail for any justification.
 	k, ctx := setupDKGKeeper(t)
@@ -1316,4 +1316,92 @@ func TestProcessJustifications_MissingDealerRegistration(t *testing.T) {
 	// ProcessJustifications should not error — invalid justifications are simply skipped.
 	err := k.ProcessJustifications(ctx, network, []types.Justification{j})
 	require.NoError(t, err, "invalid justification should be skipped, not cause an error")
+}
+
+// TestProcessJustifications_GapCommitteeInvalidatesCorrectDealer: in a non-resharing round an
+// invalidated member is NOT dropped from the committee (it was fixed at dealing start), so a
+// dealer keeps its position = reg.Index-1 even after a peer is invalidated mid-dealing. valD
+// (reg index 3 -> committee position 2) proves an invalid deal and must be the one invalidated.
+func TestProcessJustifications_GapCommitteeInvalidatesCorrectDealer(t *testing.T) {
+	const n = 3
+
+	k, ctx := setupDKGKeeper(t)
+	k.isDKGSvcEnabled = false
+
+	round := uint32(80)
+
+	dtcD := newDealerTestContext(t, n, dealingTestThreshold)
+
+	valA := common.HexToAddress("0x00000000000000000000000000000000000000A1")
+	valBad := common.HexToAddress("0x00000000000000000000000000000000000000B2")
+	valD := common.HexToAddress("0x00000000000000000000000000000000000000D4")
+
+	// Registration indices 1,2,3 with index 2 invalidated mid-dealing. The non-resharing
+	// committee keeps all members -> [valA@0, valBad@1, valD@2], so valD stays at position 2.
+	setupDealerRegistrationWithKey(t, k, ctx, round, valA, 1, []byte("a-key"))
+	require.NoError(t, k.setDKGRegistration(ctx, valBad, &types.DKGRegistration{
+		Round: round, ValidatorAddr: valBad.Hex(), Index: 2,
+		DkgPubKey: []byte("bad-key"), Status: types.DKGRegStatusInvalidated,
+	}))
+	setupDealerRegistrationWithKey(t, k, ctx, round, valD, 3, dtcD.pubBytes)
+
+	network := &types.DKGNetwork{Round: round, Total: 3, Threshold: dealingTestThreshold}
+
+	// valD proves an invalid deal at its committee position (2).
+	j := dtcD.makeInvalidDealJustification(t, 2)
+	require.NoError(t, k.ProcessJustifications(ctx, network, []types.Justification{j}))
+
+	regD, err := k.getDKGRegistration(ctx, round, valD)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGRegStatusInvalidated, regD.Status, "valD (committee position 2) must be invalidated")
+
+	regA, err := k.getDKGRegistration(ctx, round, valA)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGRegStatusVerified, regA.Status, "valA (position 0) must NOT be invalidated")
+}
+
+// TestProcessJustifications_ReshardingResolvesPrevCommittee: in a resharing round the dealers
+// are the previous active committee. A justification index must resolve against that committee,
+// and the resolved dealer's CURRENT-round registration is the one invalidated.
+func TestProcessJustifications_ReshardingResolvesPrevCommittee(t *testing.T) {
+	const n = 3
+
+	k, ctx := setupDKGKeeper(t)
+	k.isDKGSvcEnabled = false
+
+	oldRound := uint32(90)
+	newRound := uint32(92)
+
+	dtcD := newDealerTestContext(t, n, dealingTestThreshold)
+
+	valA := common.HexToAddress("0x00000000000000000000000000000000000000A1")
+	valD := common.HexToAddress("0x00000000000000000000000000000000000000D4")
+
+	// Previous active committee: [valA(idx1)@pos0, valD(idx2)@pos1].
+	old := &types.DKGNetwork{
+		Round: oldRound, Total: 2, Stage: types.DKGStageActive,
+		ActiveValSet: []string{valA.Hex(), valD.Hex()},
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, old))
+	require.NoError(t, k.setLatestActiveRound(ctx, old))
+	setupDealerRegistrationWithKey(t, k, ctx, oldRound, valA, 1, []byte("a-key"))
+	setupDealerRegistrationWithKey(t, k, ctx, oldRound, valD, 2, dtcD.pubBytes)
+
+	// Both continue into the resharing round.
+	newDKG := &types.DKGNetwork{Round: newRound, Total: 2, Threshold: dealingTestThreshold, IsResharing: true}
+	require.NoError(t, k.setDKGNetwork(ctx, newDKG))
+	setupDealerRegistrationWithKey(t, k, ctx, newRound, valA, 1, []byte("a-key"))
+	setupDealerRegistrationWithKey(t, k, ctx, newRound, valD, 2, dtcD.pubBytes)
+
+	// valD proves an invalid deal at its prev-committee position (1).
+	j := dtcD.makeInvalidDealJustification(t, 1)
+	require.NoError(t, k.ProcessJustifications(ctx, newDKG, []types.Justification{j}))
+
+	regD, err := k.getDKGRegistration(ctx, newRound, valD)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGRegStatusInvalidated, regD.Status, "valD's current-round reg must be invalidated")
+
+	regA, err := k.getDKGRegistration(ctx, newRound, valA)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGRegStatusVerified, regA.Status)
 }

--- a/client/x/dkg/keeper/dkg_finalization_internal_test.go
+++ b/client/x/dkg/keeper/dkg_finalization_internal_test.go
@@ -1134,3 +1134,217 @@ func TestInvalidateMissingDealers_NonFinalizedPrevNotExpected(t *testing.T) {
 		require.Equal(t, types.DKGRegStatusVerified, reg.Status, "validator %s must stay verified", addr.Hex())
 	}
 }
+
+// TestInvalidateMissingDealers_ReshardingDealerGhostGap: an INVALIDATED member in the dealer
+// round keeps its committee slot (the committee is not re-compacted), so deal.Index still equals
+// reg.Index-1 for every survivor. The high-index dealer (val4) stays at its slot and must be
+// credited, not invalidated.
+func TestInvalidateMissingDealers_ReshardingDealerGhostGap(t *testing.T) {
+	const (
+		oldRound = uint32(70)
+		newRound = uint32(72)
+	)
+
+	// Old round registrations, by registration index: val1=1(FIN), val2=2(FIN),
+	// valBad=3(INVALIDATED), val4=4(FIN). The dealer committee keeps valBad's slot and sorts by
+	// index -> [val1, val2, valBad, val4], so val4 stays at kyber index 3 (= reg.Index 4 - 1).
+	val1 := common.BytesToAddress([]byte{0x01})
+	val2 := common.BytesToAddress([]byte{0x02})
+	valBad := common.BytesToAddress([]byte{0x08}) // invalidated in the old round; slot preserved
+	val4 := common.BytesToAddress([]byte{0x04})   // high-index dealer; must keep kyber index 3
+
+	oldRegs := []struct {
+		addr   common.Address
+		status types.DKGRegStatus
+	}{
+		{val1, types.DKGRegStatusFinalized},
+		{val2, types.DKGRegStatusFinalized},
+		{valBad, types.DKGRegStatusInvalidated},
+		{val4, types.DKGRegStatusFinalized},
+	}
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+
+	// Previous active round. ActiveValSet is the set of share holders expected to deal.
+	old := &types.DKGNetwork{
+		Round:        oldRound,
+		Total:        3,
+		ActiveValSet: []string{val1.Hex(), val2.Hex(), val4.Hex()},
+		Stage:        types.DKGStageActive,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, old))
+	require.NoError(t, k.setLatestActiveRound(ctx, old))
+	for i, r := range oldRegs {
+		require.NoError(t, k.setDKGRegistration(ctx, r.addr, &types.DKGRegistration{
+			Round:         oldRound,
+			ValidatorAddr: r.addr.Hex(),
+			Index:         uint32(i + 1),
+			Status:        r.status,
+		}))
+	}
+
+	// New resharing round: the three healthy share holders continue.
+	newRegs := []common.Address{val1, val2, val4}
+	newDKG := &types.DKGNetwork{
+		Round: newRound, Total: 3, Threshold: 2,
+		Stage: types.DKGStageFinalization, IsResharing: true, StartBlockHeight: 400,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, newDKG))
+	for i, addr := range newRegs {
+		require.NoError(t, k.setDKGRegistration(ctx, addr, &types.DKGRegistration{
+			Round:         newRound,
+			ValidatorAddr: addr.Hex(),
+			Index:         uint32(i + 1),
+			Status:        types.DKGRegStatusVerified,
+		}))
+	}
+
+	// The healthy dealers deal at their committee positions: val1@0, val2@1, val4@3
+	// (valBad occupies slot 2 and does not deal).
+	require.NoError(t, k.markDealersDealt(ctx, newDKG, []types.Deal{{Index: 0}, {Index: 1}, {Index: 3}}))
+	require.NoError(t, k.invalidateMissingDealers(ctx, newDKG))
+
+	// val4 deals at kyber index 3 (its slot is preserved past the invalidated valBad). It must
+	// stay verified, as must val1/val2.
+	for _, addr := range newRegs {
+		reg, err := k.getDKGRegistration(ctx, newRound, addr)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg.Status, "validator %s must stay verified", addr.Hex())
+	}
+}
+
+// TestInvalidateMissingDealers_ReshardingGhostGapInvalidatesNonDealer: positive direction of
+// the ghost-gap topology — a prev-round holder that continues but submits no deal is still
+// correctly invalidated (the committee mapping must not over-correct).
+func TestInvalidateMissingDealers_ReshardingGhostGapInvalidatesNonDealer(t *testing.T) {
+	const (
+		oldRound = uint32(74)
+		newRound = uint32(76)
+	)
+
+	// Same ghost-gap old round as above: val1=1(FIN), val2=2(FIN), valBad=3(INVALIDATED),
+	// val4=4(FIN). Committee keeps all slots -> [val1, val2, valBad, val4] (kyber 0,1,2,3).
+	val1 := common.BytesToAddress([]byte{0x01})
+	val2 := common.BytesToAddress([]byte{0x02})
+	valBad := common.BytesToAddress([]byte{0x08})
+	val4 := common.BytesToAddress([]byte{0x04})
+
+	oldRegs := []struct {
+		addr   common.Address
+		status types.DKGRegStatus
+	}{
+		{val1, types.DKGRegStatusFinalized},
+		{val2, types.DKGRegStatusFinalized},
+		{valBad, types.DKGRegStatusInvalidated},
+		{val4, types.DKGRegStatusFinalized},
+	}
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+
+	old := &types.DKGNetwork{
+		Round:        oldRound,
+		Total:        3,
+		ActiveValSet: []string{val1.Hex(), val2.Hex(), val4.Hex()},
+		Stage:        types.DKGStageActive,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, old))
+	require.NoError(t, k.setLatestActiveRound(ctx, old))
+	for i, r := range oldRegs {
+		require.NoError(t, k.setDKGRegistration(ctx, r.addr, &types.DKGRegistration{
+			Round:         oldRound,
+			ValidatorAddr: r.addr.Hex(),
+			Index:         uint32(i + 1),
+			Status:        r.status,
+		}))
+	}
+
+	newRegs := []common.Address{val1, val2, val4}
+	newDKG := &types.DKGNetwork{
+		Round: newRound, Total: 3, Threshold: 2,
+		Stage: types.DKGStageFinalization, IsResharing: true, StartBlockHeight: 400,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, newDKG))
+	for i, addr := range newRegs {
+		require.NoError(t, k.setDKGRegistration(ctx, addr, &types.DKGRegistration{
+			Round:         newRound,
+			ValidatorAddr: addr.Hex(),
+			Index:         uint32(i + 1),
+			Status:        types.DKGRegStatusVerified,
+		}))
+	}
+
+	// val1 (kyber 0) and val2 (kyber 1) deal; val4 (kyber 3) submits nothing.
+	require.NoError(t, k.markDealersDealt(ctx, newDKG, []types.Deal{{Index: 0}, {Index: 1}}))
+	require.NoError(t, k.invalidateMissingDealers(ctx, newDKG))
+
+	// val4 was a real prev-round holder that skipped dealing -> invalidated; val1/val2 kept.
+	reg4, err := k.getDKGRegistration(ctx, newRound, val4)
+	require.NoError(t, err)
+	require.Equal(t, types.DKGRegStatusInvalidated, reg4.Status, "non-dealing holder val4 must be invalidated")
+	for _, addr := range []common.Address{val1, val2} {
+		reg, err := k.getDKGRegistration(ctx, newRound, addr)
+		require.NoError(t, err)
+		require.Equal(t, types.DKGRegStatusVerified, reg.Status, "validator %s must stay verified", addr.Hex())
+	}
+}
+
+// TestMarkDealersDealt_InitialDKGMidGap: a non-resharing round does NOT drop an invalidated
+// member from the committee — the kernel fixed it from all registrations at dealing start, so
+// positions equal reg.Index-1 and stay stable even after a mid-round invalidation. D keeps its
+// position (reg.Index 4 -> kyber index 3), not a compacted index 2.
+func TestMarkDealersDealt_InitialDKGMidGap(t *testing.T) {
+	const round = uint32(17)
+
+	// Current round: A=1(VERIFIED), B=2(VERIFIED), BAD=3(INVALIDATED), D=4(VERIFIED).
+	// Committee (not filtered) -> [A, B, BAD, D] (kyber 0,1,2,3); D stays at kyber index 3.
+	valA := common.BytesToAddress([]byte{0x01})
+	valB := common.BytesToAddress([]byte{0x02})
+	valBad := common.BytesToAddress([]byte{0x08})
+	valD := common.BytesToAddress([]byte{0x04})
+
+	regs := []struct {
+		addr   common.Address
+		status types.DKGRegStatus
+	}{
+		{valA, types.DKGRegStatusVerified},
+		{valB, types.DKGRegStatusVerified},
+		{valBad, types.DKGRegStatusInvalidated},
+		{valD, types.DKGRegStatusVerified},
+	}
+
+	k, _, _, baseCtx := setupDKGKeeperWithMocks(t)
+	ctx := sdk.UnwrapSDKContext(baseCtx).WithChainID(netconf.TestChainID)
+
+	// Non-resharing round (dealer committee == current round).
+	latestRound := &types.DKGNetwork{
+		Round: round, Total: 4, Threshold: 2,
+		Stage: types.DKGStageFinalization, StartBlockHeight: 400,
+	}
+	require.NoError(t, k.setDKGNetwork(ctx, latestRound))
+	for i, r := range regs {
+		require.NoError(t, k.setDKGRegistration(ctx, r.addr, &types.DKGRegistration{
+			Round:         round,
+			ValidatorAddr: r.addr.Hex(),
+			Index:         uint32(i + 1),
+			Status:        r.status,
+		}))
+	}
+
+	// A (kyber 0) and D (kyber 3) deal; B (kyber 1) and BAD (kyber 2) do not.
+	require.NoError(t, k.markDealersDealt(ctx, latestRound, []types.Deal{{Index: 0}, {Index: 3}}))
+	require.NoError(t, k.invalidateMissingDealers(ctx, latestRound))
+
+	want := map[common.Address]types.DKGRegStatus{
+		valA:   types.DKGRegStatusVerified,    // dealt
+		valB:   types.DKGRegStatusInvalidated, // verified member, no deal
+		valBad: types.DKGRegStatusInvalidated, // already invalidated, untouched
+		valD:   types.DKGRegStatusVerified,    // dealt at kyber index 3 (reg.Index 4 - 1)
+	}
+	for addr, status := range want {
+		reg, err := k.getDKGRegistration(ctx, round, addr)
+		require.NoError(t, err)
+		require.Equal(t, status, reg.Status, "validator %s", addr.Hex())
+	}
+}

--- a/client/x/dkg/keeper/dkg_justification.go
+++ b/client/x/dkg/keeper/dkg_justification.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -162,82 +161,74 @@ func verifyJustification(latestRound *types.DKGNetwork, j types.Justification) (
 	return valid, nil
 }
 
-// buildDealerPubKeyMap builds a map from dealer index to their dkgPubKey for the round.
-// This is built once per ProcessJustifications call to avoid O(N) registration scan per justification.
-func (k *Keeper) buildDealerPubKeyMap(ctx context.Context, latestRound *types.DKGNetwork, suite kyber.Group) (map[uint32]kyber.Point, error) {
-	registrations, err := k.getDKGRegistrationsByRound(ctx, latestRound.Round)
-	if err != nil {
-		return nil, errors.Wrap(err, "get registrations")
-	}
-
-	pubKeys := make(map[uint32]kyber.Point, len(registrations))
-	for _, reg := range registrations {
-		if len(reg.DkgPubKey) == 0 {
+// dealerPubKeyMap maps each dealer's 0-based committee position (the kyber justification Index)
+// to its dkgPubKey. committee must be dealerCommitteeRegs for the dealer round.
+func dealerPubKeyMap(ctx context.Context, committee []types.DKGRegistration, suite kyber.Group) map[uint32]kyber.Point {
+	pubKeys := make(map[uint32]kyber.Point, len(committee))
+	for i := range committee {
+		if len(committee[i].DkgPubKey) == 0 {
 			continue
 		}
 
 		pub := suite.Point()
-		if err := pub.UnmarshalBinary(reg.DkgPubKey); err != nil {
+		if err := pub.UnmarshalBinary(committee[i].DkgPubKey); err != nil {
 			log.Warn(ctx, "Failed to unmarshal dealer dkgPubKey, skipping", err,
-				"dealer_index", reg.Index,
+				"dealer_index", i,
 			)
 
 			continue
 		}
 
-		pubKeys[reg.Index] = pub
+		pubKeys[uint32(i)] = pub
 	}
 
-	return pubKeys, nil
+	return pubKeys
 }
 
-// invalidateDealerRegistration marks a dealer's DKG registration as Invalidated.
-// The dealer is identified by their DKG index within the current round.
-// Invalidated dealers cannot finalize. This is idempotent — re-invalidating
-// an already-invalidated dealer is a no-op.
-//
-// Called from ProcessJustifications (FinalizeBlock) when VSS verification proves
-// a dealer's deal was genuinely invalid.
-func (k *Keeper) invalidateDealerRegistration(ctx context.Context, latestRound *types.DKGNetwork, dealerIndex uint32) error {
-	// Find the registration with this index
-	registrations, err := k.getDKGRegistrationsByRound(ctx, latestRound.Round)
+// invalidateDealerByAddr marks dealerAddr's registration in round as Invalidated so it cannot
+// finalize. No-op if it has no registration in the round; idempotent.
+func (k *Keeper) invalidateDealerByAddr(ctx context.Context, round uint32, dealerAddr common.Address) error {
+	has, err := k.hasDKGRegistration(ctx, round, dealerAddr)
 	if err != nil {
-		return errors.Wrap(err, "failed to get DKG registrations")
+		return errors.Wrap(err, "failed to check registration")
+	}
+	if !has {
+		log.Debug(ctx, "Dealer has no registration in round, skipping invalidation",
+			"validator_addr", dealerAddr.Hex(),
+			"round", round,
+		)
+
+		return nil
 	}
 
-	for _, reg := range registrations {
-		if reg.Index == dealerIndex {
-			// Finalized registrations should never appear during invalidation
-			// because justifications are processed during the dealing stage,
-			// before finalization. If this occurs, it indicates a bug.
-			if reg.Status == types.DKGRegStatusFinalized {
-				return fmt.Errorf("dealer index %d is already finalized, cannot invalidate (possible bug)", dealerIndex)
-			}
-
-			if reg.Status == types.DKGRegStatusInvalidated {
-				log.Debug(ctx, "Dealer already invalidated, skipping",
-					"dealer_index", dealerIndex,
-				)
-
-				return nil
-			}
-
-			reg.Status = types.DKGRegStatusInvalidated
-
-			validatorAddr := common.HexToAddress(strings.TrimSpace(reg.ValidatorAddr))
-			if err := k.setDKGRegistration(ctx, validatorAddr, &reg); err != nil {
-				return errors.Wrap(err, "failed to update registration status to invalidated")
-			}
-
-			log.Info(ctx, "Dealer registration invalidated",
-				"dealer_index", dealerIndex,
-				"validator_addr", reg.ValidatorAddr,
-				"round", latestRound.Round,
-			)
-
-			return nil
-		}
+	reg, err := k.getDKGRegistration(ctx, round, dealerAddr)
+	if err != nil {
+		return errors.Wrap(err, "failed to get registration")
 	}
 
-	return fmt.Errorf("no registration found with dealer index %d", dealerIndex)
+	// Finalized registrations should never appear here: justifications are processed during
+	// the dealing stage, before finalization.
+	if reg.Status == types.DKGRegStatusFinalized {
+		return fmt.Errorf("dealer %s is already finalized, cannot invalidate (possible bug)", dealerAddr.Hex())
+	}
+	if reg.Status == types.DKGRegStatusInvalidated {
+		log.Debug(ctx, "Dealer already invalidated, skipping",
+			"validator_addr", dealerAddr.Hex(),
+			"round", round,
+		)
+
+		return nil
+	}
+
+	reg.Status = types.DKGRegStatusInvalidated
+	if err := k.setDKGRegistration(ctx, dealerAddr, reg); err != nil {
+		return errors.Wrap(err, "failed to update registration status to invalidated")
+	}
+
+	log.Info(ctx, "Dealer registration invalidated",
+		"validator_addr", dealerAddr.Hex(),
+		"round", round,
+	)
+
+	return nil
 }

--- a/client/x/dkg/keeper/dkg_justification_test.go
+++ b/client/x/dkg/keeper/dkg_justification_test.go
@@ -136,120 +136,79 @@ func TestVerifyJustificationVSS_WrongIndex(t *testing.T) {
 	require.False(t, ok, "share for index 1 should not verify at index 2")
 }
 
-// TestInvalidateDealerRegistration_Success verifies that a Verified dealer is
-// successfully transitioned to Invalidated status.
-func TestInvalidateDealerRegistration_Success(t *testing.T) {
+// TestInvalidateDealerByAddr_Success verifies a Verified dealer is transitioned to Invalidated.
+func TestInvalidateDealerByAddr_Success(t *testing.T) {
 	k, ctx := setupDKGKeeper(t)
 
 	round := uint32(5)
 	dealerAddr := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
-	dealerIndex := uint32(3)
+	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerAddr, 3, types.DKGRegStatusVerified)
 
-	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerAddr, dealerIndex, types.DKGRegStatusVerified)
-
-	network := &types.DKGNetwork{
-		Round: round,
-	}
-
-	err := k.invalidateDealerRegistration(ctx, network, dealerIndex)
-	require.NoError(t, err)
+	require.NoError(t, k.invalidateDealerByAddr(ctx, round, dealerAddr))
 
 	reg, err := k.getDKGRegistration(ctx, round, dealerAddr)
 	require.NoError(t, err)
 	require.Equal(t, types.DKGRegStatusInvalidated, reg.Status)
 }
 
-// TestInvalidateDealerRegistration_AlreadyFinalized verifies that a dealer that
-// has already finalized is not re-invalidated (the function returns nil without change).
-func TestInvalidateDealerRegistration_AlreadyFinalized(t *testing.T) {
+// TestInvalidateDealerByAddr_AlreadyFinalized verifies a finalized dealer is not invalidated.
+func TestInvalidateDealerByAddr_AlreadyFinalized(t *testing.T) {
 	k, ctx := setupDKGKeeper(t)
 
 	round := uint32(1)
 	dealerAddr := common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
-	dealerIndex := uint32(2)
+	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerAddr, 2, types.DKGRegStatusFinalized)
 
-	// Set up as already Finalized
-	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerAddr, dealerIndex, types.DKGRegStatusFinalized)
-
-	network := &types.DKGNetwork{
-		Round: round,
-	}
-
-	err := k.invalidateDealerRegistration(ctx, network, dealerIndex)
-	require.Error(t, err, "should error when trying to invalidate a finalized dealer")
+	err := k.invalidateDealerByAddr(ctx, round, dealerAddr)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "already finalized")
 	require.Contains(t, err.Error(), "possible bug")
 
-	// Status should remain Finalized
 	reg, err := k.getDKGRegistration(ctx, round, dealerAddr)
 	require.NoError(t, err)
-	require.Equal(t, types.DKGRegStatusFinalized, reg.Status, "status should not change for finalized dealers")
+	require.Equal(t, types.DKGRegStatusFinalized, reg.Status)
 }
 
-// TestInvalidateDealerRegistration_NotFound verifies that an error is returned
-// when no registration with the given dealer index exists.
-func TestInvalidateDealerRegistration_NotFound(t *testing.T) {
+// TestInvalidateDealerByAddr_NoRegistration verifies that invalidating an address with no
+// registration in the round is a no-op (a dealer that left the committee).
+func TestInvalidateDealerByAddr_NoRegistration(t *testing.T) {
 	k, ctx := setupDKGKeeper(t)
 
-	network := &types.DKGNetwork{
-		Round: 1,
-	}
-
-	// No registration has been created; index 99 does not exist
-	err := k.invalidateDealerRegistration(ctx, network, 99)
-	require.Error(t, err, "should return error when dealer index is not found")
-	require.Contains(t, err.Error(), "no registration found with dealer index 99")
+	missing := common.HexToAddress("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+	require.NoError(t, k.invalidateDealerByAddr(ctx, 1, missing))
 }
 
-// TestInvalidateDealerRegistration_MultipleRegistrations verifies that when
-// multiple dealers exist only the correct one gets invalidated.
-func TestInvalidateDealerRegistration_MultipleRegistrations(t *testing.T) {
+// TestInvalidateDealerByAddr_MultipleRegistrations verifies only the addressed dealer is hit.
+func TestInvalidateDealerByAddr_MultipleRegistrations(t *testing.T) {
 	k, ctx := setupDKGKeeper(t)
 
 	round := uint32(3)
-
 	dealerA := common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC")
 	dealerB := common.HexToAddress("0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD")
-	indexA := uint32(1)
-	indexB := uint32(2)
 
-	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerA, indexA, types.DKGRegStatusVerified)
-	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerB, indexB, types.DKGRegStatusVerified)
+	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerA, 1, types.DKGRegStatusVerified)
+	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerB, 2, types.DKGRegStatusVerified)
 
-	network := &types.DKGNetwork{
-		Round: round,
-	}
-
-	// Invalidate only dealer A
-	err := k.invalidateDealerRegistration(ctx, network, indexA)
-	require.NoError(t, err)
+	require.NoError(t, k.invalidateDealerByAddr(ctx, round, dealerA))
 
 	regA, err := k.getDKGRegistration(ctx, round, dealerA)
 	require.NoError(t, err)
-	require.Equal(t, types.DKGRegStatusInvalidated, regA.Status, "dealer A should be invalidated")
+	require.Equal(t, types.DKGRegStatusInvalidated, regA.Status)
 
 	regB, err := k.getDKGRegistration(ctx, round, dealerB)
 	require.NoError(t, err)
-	require.Equal(t, types.DKGRegStatusVerified, regB.Status, "dealer B should remain Verified")
+	require.Equal(t, types.DKGRegStatusVerified, regB.Status)
 }
 
-// TestInvalidateDealerRegistration_AlreadyInvalidated verifies idempotency:
-// re-invalidating an already-invalidated dealer is a no-op.
-func TestInvalidateDealerRegistration_AlreadyInvalidated(t *testing.T) {
+// TestInvalidateDealerByAddr_AlreadyInvalidated verifies idempotency.
+func TestInvalidateDealerByAddr_AlreadyInvalidated(t *testing.T) {
 	k, ctx := setupDKGKeeper(t)
 
 	round := uint32(2)
 	dealerAddr := common.HexToAddress("0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE")
-	dealerIndex := uint32(5)
+	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerAddr, 5, types.DKGRegStatusInvalidated)
 
-	setupDealerRegistrationForInvalidation(t, k, ctx, round, dealerAddr, dealerIndex, types.DKGRegStatusInvalidated)
-
-	network := &types.DKGNetwork{
-		Round: round,
-	}
-
-	err := k.invalidateDealerRegistration(ctx, network, dealerIndex)
-	require.NoError(t, err, "re-invalidating should be a no-op")
+	require.NoError(t, k.invalidateDealerByAddr(ctx, round, dealerAddr))
 
 	reg, err := k.getDKGRegistration(ctx, round, dealerAddr)
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

`markDealersDealt` resolved a deal's 0-based kyber index with `addrByIndex[deal.Index+1]`, and `ProcessJustifications` keyed the dealer pubkey map by `reg.Index` and matched `reg.Index == dealerIndex`. Both assume the kyber index equals `reg.Index-1`, which only holds while the committee is contiguous. Once a member is invalidated they mis-attribute deals and invalidations to the wrong validator: a healthy dealer is wrongly `INVALIDATED`, a justified bad deal hits the wrong registration, and the justification signature is verified against the wrong dealer key.

## Fix

Resolve every index against the dealer round's committee (`dealerCommitteeRegs`): ALL of the round's registrations sorted by registration index, so an invalidated member keeps its slot and survivors' positions are preserved — matching the kernel's kyber committee. `resolveDealerRound` picks the dealer round (previous active for resharing, current otherwise). `markDealersDealt` indexes `committee[deal.Index]`; `ProcessJustifications` snapshots the committee once, builds the dealer pubkey map from it, resolves the dealer address, and invalidates by address so one invalidation never shifts another dealer's index within the block.

## Why preserve indices instead of filtering

A dealer's committee position must equal the index its share was created at: kyber resharing verifies each old dealer against `dpub.Eval(committeePosition)`. Filtering (re-compacting) survivors would shift positions and break that check, so the chain and kernel both keep the full committee. Requires the companion kernel change: https://github.com/piplabs/story-kernel/pull/81

## Tests

- `TestInvalidateMissingDealers_ReshardingDealerGhostGap` / `_ReshardingGhostGapInvalidatesNonDealer` — gap committee, high-index dealer credited / real non-dealer invalidated.
- `TestMarkDealersDealt_InitialDKGMidGap` — non-resharing committee keeps an invalidated member's slot.
- `TestProcessJustifications_GapCommitteeInvalidatesCorrectDealer` / `_ReshardingResolvesPrevCommittee`.
- `x/dkg/keeper` coverage 81.8%.

issue: #851
