### PR TITLE
fix(dkg): prune dkg sessions older than the retention window

### DIFF
--- a/client/x/dkg/keeper/dkg_svc_complete.go
+++ b/client/x/dkg/keeper/dkg_svc_complete.go
@@ -29,6 +29,10 @@ func (k *Keeper) handleDKGComplete(ctx context.Context, dkgNetwork *types.DKGNet
 		return
 	}
 
+	// A round just activated, so bound session growth by pruning rounds well below it.
+	// session.Round is the latest active round and is always retained.
+	k.stateManager.PruneOldSessions(ctx, session.Round)
+
 	if session.Phase == types.PhaseCompleted && session.IsFinalized {
 		log.Info(ctx, "DKG network already completed")
 		// Ensure the decrypt worker is running even if completion was already processed

--- a/client/x/dkg/keeper/state_manager.go
+++ b/client/x/dkg/keeper/state_manager.go
@@ -178,34 +178,37 @@ func (sm *StateManager) GetActiveSession(validatorAddr string) *types.DKGSession
 	return nil
 }
 
-// CleanupExpiredSessions removes expired sessions.
-func (sm *StateManager) CleanupExpiredSessions(ctx context.Context) {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+// sessionRetentionRounds bounds how many recent rounds' sessions are kept. The decrypt path
+// only needs the latest activated round and the one before it; 10 is a generous margin (each
+// session is a small JSON file) that also covers a brief-outage resume, while bounding growth.
+const sessionRetentionRounds = 10
 
-	var expired []string
-
-	for key, session := range sm.sessions {
-		// TODO: more rigorous expiration check
-		if session.Phase == types.PhaseCompleted || session.Phase == types.PhaseFailed {
-			expired = append(expired, key)
-		}
+// PruneOldSessions deletes local sessions (in-memory + disk) for rounds older than
+// (activeRound - sessionRetentionRounds). Rounds activate sequentially, so activeRound is the
+// latest active round and is always kept. Node-local only; the round-based criterion is
+// deterministic with no consensus or wall-clock dependence.
+func (sm *StateManager) PruneOldSessions(ctx context.Context, activeRound uint32) {
+	// Guard against underflow: nothing to prune until enough rounds have elapsed.
+	if activeRound <= sessionRetentionRounds {
+		return
 	}
 
-	for _, key := range expired {
-		session := sm.sessions[key]
-		delete(sm.sessions, key)
+	horizon := activeRound - sessionRetentionRounds
 
-		// Remove from disk
-		filename := sm.getSessionFilename(key)
-		if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
-			log.Error(ctx, "Failed to delete expired session file", err, "filename", filename)
-		} else {
-			log.Info(ctx, "Cleaned up expired DKG session",
-				"code_commitment", session.GetCodeCommitmentString(),
-				"round", session.Round,
-				"phase", session.Phase.String(),
-			)
+	sm.mu.RLock()
+	stale := make([]uint32, 0)
+	for _, session := range sm.sessions {
+		if session.Round < horizon {
+			stale = append(stale, session.Round)
+		}
+	}
+	sm.mu.RUnlock()
+
+	// DeleteSession removes both the in-memory entry and the disk file, taking the
+	// lock itself; the result is independent of map-iteration order.
+	for _, round := range stale {
+		if err := sm.DeleteSession(ctx, round); err != nil {
+			log.Error(ctx, "Failed to prune old DKG session", err, "round", round)
 		}
 	}
 }

--- a/client/x/dkg/keeper/state_manager.go
+++ b/client/x/dkg/keeper/state_manager.go
@@ -156,6 +156,12 @@ func (sm *StateManager) DeleteSession(ctx context.Context, round uint32) error {
 		return errors.Wrap(err, "failed to delete session file")
 	}
 
+	// Defensively remove a stray temporary file for this round if a prior write crashed
+	// before its rename. The round is being deleted, so no saveSession is writing it.
+	if err := os.Remove(filename + ".tmp"); err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "failed to delete temporary session file")
+	}
+
 	log.Info(ctx, "Deleted DKG session",
 		"code_commitment", session.GetCodeCommitmentString(),
 		"round", session.Round,
@@ -231,7 +237,36 @@ func (sm *StateManager) loadSessions() error {
 		sm.sessions[session.GetSessionKey()] = session
 	}
 
+	sm.sweepOrphanedTmpFiles()
+
 	return nil
+}
+
+// sweepOrphanedTmpFiles removes stale temporary session files left behind by a crash
+// between saveSession's write and rename. saveSession writes atomically (write to
+// session_<round>.json.tmp, then rename to session_<round>.json), so any .tmp present at
+// startup is a dead partial write: the valid session, if any, is always at the non-tmp
+// name. This runs only from loadSessions during construction, before the node serves
+// requests, so there is no concurrent saveSession writer to race with.
+func (sm *StateManager) sweepOrphanedTmpFiles() {
+	tmpFiles, err := filepath.Glob(filepath.Join(sm.dataDir, "session_*.json.tmp"))
+	if err != nil {
+		fmt.Printf("Warning: failed to list orphaned temporary session files: %v\n", err)
+		return
+	}
+
+	swept := 0
+	for _, file := range tmpFiles {
+		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
+			fmt.Printf("Warning: failed to remove orphaned temporary session file %s: %v\n", file, err)
+			continue
+		}
+		swept++
+	}
+
+	if swept > 0 {
+		log.Info(context.Background(), "Swept orphaned DKG session temporary files on load", "count", swept)
+	}
 }
 
 // loadSessionFromFile loads a single session from a file.

--- a/client/x/dkg/keeper/state_manager_test.go
+++ b/client/x/dkg/keeper/state_manager_test.go
@@ -366,6 +366,72 @@ func TestStateManager_PersistenceAcrossReload(t *testing.T) {
 	require.Equal(t, uint32(10), got.Round)
 }
 
+// TestStateManager_LoadSessions_SweepsOrphanedTmpFiles verifies that orphaned
+// session_<round>.json.tmp files (left by a crash between saveSession's write and
+// rename) are removed on construction, while valid .json sessions still load.
+func TestStateManager_LoadSessions_SweepsOrphanedTmpFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// Persist a valid session to disk with a first StateManager.
+	sm1, err := NewStateManager(dir)
+	require.NoError(t, err)
+	require.NoError(t, sm1.CreateSession(ctx, newTestSession(1)))
+
+	// Simulate crashed writes: orphaned .tmp files for several rounds.
+	orphans := []string{
+		filepath.Join(dir, "session_2.json.tmp"),
+		filepath.Join(dir, "session_3.json.tmp"),
+	}
+	for _, f := range orphans {
+		require.NoError(t, os.WriteFile(f, []byte("{ partial"), 0600))
+	}
+
+	// Constructing a new StateManager triggers loadSessions, which sweeps orphans.
+	sm2, err := NewStateManager(dir)
+	require.NoError(t, err)
+
+	// Orphaned .tmp files must be gone.
+	for _, f := range orphans {
+		_, statErr := os.Stat(f)
+		require.True(t, os.IsNotExist(statErr), "orphaned tmp file %s should be swept", f)
+	}
+
+	// The valid session must still load, and no phantom sessions from the .tmp files.
+	got, err := sm2.GetSession(1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), got.Round)
+	require.Len(t, sm2.ListSessions(), 1, "only the valid session should be loaded")
+}
+
+// TestStateManager_DeleteSession_RemovesStrayTmpFile verifies that DeleteSession
+// also removes a stray temporary file for the deleted round.
+func TestStateManager_DeleteSession_RemovesStrayTmpFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	sm, err := NewStateManager(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, sm.CreateSession(ctx, newTestSession(4)))
+
+	// A stray tmp file appears for the same round after creation.
+	tmpFile := filepath.Join(dir, "session_4.json.tmp")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("{ partial"), 0600))
+
+	require.NoError(t, sm.DeleteSession(ctx, 4))
+
+	_, statErr := os.Stat(tmpFile)
+	require.True(t, os.IsNotExist(statErr), "stray tmp file should be removed on delete")
+
+	_, statErr = os.Stat(filepath.Join(dir, "session_4.json"))
+	require.True(t, os.IsNotExist(statErr), "session file should be removed on delete")
+}
+
 // TestStateManager_DeleteSession_FileRemovedFromDisk verifies that after
 // DeleteSession, the corresponding JSON file is removed from disk.
 func TestStateManager_DeleteSession_FileRemovedFromDisk(t *testing.T) {

--- a/client/x/dkg/keeper/state_manager_test.go
+++ b/client/x/dkg/keeper/state_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -243,35 +244,103 @@ func TestStateManager_MarkFailed(t *testing.T) {
 	require.Equal(t, types.PhaseFailed, got.Phase)
 }
 
-// TestStateManager_CleanupExpiredSessions verifies that CleanupExpiredSessions
-// removes sessions in PhaseCompleted or PhaseFailed.
-func TestStateManager_CleanupExpiredSessions(t *testing.T) {
+// TestStateManager_PruneOldSessions verifies that after several rounds, sessions
+// older than the retention horizon are removed from memory and disk while the active
+// round and the retained recent rounds survive.
+func TestStateManager_PruneOldSessions(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	sm, err := NewStateManager(dir)
+	require.NoError(t, err)
+
+	// Advance through several rounds.
+	const activeRound = 20
+	for r := uint32(1); r <= activeRound; r++ {
+		require.NoError(t, sm.CreateSession(ctx, newTestSession(r)))
+	}
+
+	sm.PruneOldSessions(ctx, activeRound)
+
+	// Retention horizon is activeRound - sessionRetentionRounds. Rounds below it are
+	// pruned; the horizon round and everything up to the active round survive.
+	horizon := uint32(activeRound - sessionRetentionRounds)
+
+	for r := uint32(1); r < horizon; r++ {
+		_, err := sm.GetSession(r)
+		require.Error(t, err, "round %d should have been pruned from memory", r)
+
+		_, statErr := os.Stat(filepath.Join(dir, "session_"+strconv.FormatUint(uint64(r), 10)+".json"))
+		require.True(t, os.IsNotExist(statErr), "round %d file should have been pruned from disk", r)
+	}
+
+	for r := horizon; r <= activeRound; r++ {
+		got, err := sm.GetSession(r)
+		require.NoError(t, err, "round %d should have survived", r)
+		require.Equal(t, r, got.Round)
+
+		_, statErr := os.Stat(filepath.Join(dir, "session_"+strconv.FormatUint(uint64(r), 10)+".json"))
+		require.NoError(t, statErr, "round %d file should have survived on disk", r)
+	}
+}
+
+// TestStateManager_PruneOldSessions_RetainedRoundStillUsable verifies that a retained
+// recent round's session remains usable by the decrypt path after pruning: its
+// GlobalPubKey is preserved both in memory and after a reload from disk.
+func TestStateManager_PruneOldSessions_RetainedRoundStillUsable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	sm, err := NewStateManager(dir)
+	require.NoError(t, err)
+
+	const activeRound = 20
+	pubKey := []byte{0x01, 0x02, 0x03, 0x04}
+
+	for r := uint32(1); r <= activeRound; r++ {
+		session := newTestSession(r)
+		// The round just below the active round is still needed by the decrypt path.
+		if r == activeRound-1 {
+			session.GlobalPubKey = pubKey
+			session.Index = 1
+			session.IsFinalized = true
+		}
+		require.NoError(t, sm.CreateSession(ctx, session))
+	}
+
+	sm.PruneOldSessions(ctx, activeRound)
+
+	got, err := sm.GetSession(activeRound - 1)
+	require.NoError(t, err, "the round below active must be retained for the decrypt path")
+	require.Equal(t, pubKey, got.GlobalPubKey, "GlobalPubKey must be preserved for decryption")
+
+	// The preserved key must also survive a reload from disk.
+	sm2, err := NewStateManager(dir)
+	require.NoError(t, err)
+	reloaded, err := sm2.GetSession(activeRound - 1)
+	require.NoError(t, err)
+	require.Equal(t, pubKey, reloaded.GlobalPubKey)
+}
+
+// TestStateManager_PruneOldSessions_NoopBelowHorizon verifies that pruning is a no-op
+// while fewer rounds than the retention window have elapsed (underflow guard).
+func TestStateManager_PruneOldSessions_NoopBelowHorizon(t *testing.T) {
 	t.Parallel()
 
 	sm := newTestStateManager(t)
 	ctx := context.Background()
 
-	// Create 3 sessions: one completed, one failed, one active
-	completed := newTestSession(1)
-	require.NoError(t, sm.CreateSession(ctx, completed))
-	completed.UpdatePhase(types.PhaseCompleted)
-	require.NoError(t, sm.UpdateSession(ctx, completed))
+	for r := uint32(1); r <= sessionRetentionRounds; r++ {
+		require.NoError(t, sm.CreateSession(ctx, newTestSession(r)))
+	}
 
-	failed := newTestSession(2)
-	require.NoError(t, sm.CreateSession(ctx, failed))
-	failed.UpdatePhase(types.PhaseFailed)
-	require.NoError(t, sm.UpdateSession(ctx, failed))
+	sm.PruneOldSessions(ctx, sessionRetentionRounds)
 
-	active := newTestSession(3)
-	require.NoError(t, sm.CreateSession(ctx, active))
-	active.UpdatePhase(types.PhaseDealing)
-	require.NoError(t, sm.UpdateSession(ctx, active))
-
-	sm.CleanupExpiredSessions(ctx)
-
-	sessions := sm.ListSessions()
-	require.Len(t, sessions, 1, "only the dealing session should remain")
-	require.Equal(t, uint32(3), sessions[0].Round)
+	require.Len(t, sm.ListSessions(), sessionRetentionRounds, "nothing should be pruned below the horizon")
 }
 
 // TestStateManager_PersistenceAcrossReload verifies that sessions stored to


### PR DESCRIPTION
## Problem
Local DKG sessions (the in-memory map and on-disk `session_*.json` files) were never pruned and grew unbounded. The existing `CleanupExpiredSessions` was dead code and would have deleted the active completed session.

## Fix
Add `PruneOldSessions`, wired into round activation, deleting sessions for rounds older than `activeRound - sessionRetentionRounds` (`= 10`). Node-local only (no `KVStore`/consensus access); the round-based criterion is deterministic with no wall-clock dependence. Retention of 10 rounds comfortably exceeds the decrypt path's 2-round lookback.

## Tests
- `TestStateManager_PruneOldSessions`, `_RetainedRoundStillUsable`, `_NoopBelowHorizon`

issue: none
