### PR TITLE
fix(dkg): make dkg session field access uniformly mutex safe

### DIFF
--- a/client/x/dkg/keeper/dkg_dealing.go
+++ b/client/x/dkg/keeper/dkg_dealing.go
@@ -425,7 +425,7 @@ func (k *Keeper) ensureSessionIndex(ctx context.Context, round uint32) error {
 		return err
 	}
 
-	if session.Index != 0 {
+	if session.GetIndex() != 0 {
 		return nil
 	}
 
@@ -434,11 +434,13 @@ func (k *Keeper) ensureSessionIndex(ctx context.Context, round uint32) error {
 		return errors.Wrap(err, "registration lookup failed")
 	}
 
-	session.Index = reg.Index
+	// Set the index through the mutex-guarded setter: the decrypt worker reads it via GetIndex
+	// on its own goroutine, so a raw write here could race that read.
+	session.SetIndex(reg.Index)
 
 	log.Info(ctx, "Session index set from on-chain registration",
 		"round", round,
-		"index", session.Index,
+		"index", session.GetIndex(),
 	)
 
 	return k.stateManager.UpdateSession(ctx, session)

--- a/client/x/dkg/keeper/dkg_svc.go
+++ b/client/x/dkg/keeper/dkg_svc.go
@@ -131,16 +131,20 @@ func (k *Keeper) ResumeDKGService(ctx context.Context, dkgNetwork *types.DKGNetw
 		return
 	}
 
+	// Read the phase through the getter: async DKG goroutines mutate it concurrently
+	// with this ABCI-thread read.
+	phase := session.GetPhase()
+
 	// If the session is completed and the DKG round is active, ensure the decrypt
 	// worker is running. This covers node restarts and the case where the worker
 	// was never started due to context cancellation.
-	if session.Phase == types.PhaseCompleted && dkgNetwork.Stage == types.DKGStageActive {
+	if phase == types.PhaseCompleted && dkgNetwork.Stage == types.DKGStageActive {
 		k.StartDecryptWorker()
 
 		return
 	}
 
-	if session.Phase == types.PhaseFailed {
+	if phase == types.PhaseFailed {
 		k.resumeFailedSession(ctx, session, dkgNetwork)
 
 		return
@@ -155,13 +159,13 @@ func (k *Keeper) ResumeDKGService(ctx context.Context, dkgNetwork *types.DKGNetw
 	//   Dealing      → PhaseDealing     (deals generated, processing responses via VE)
 	//   Finalization → PhaseFinalized   (finalization done, waiting for active)
 	//   Active       → PhaseCompleted
-	if isSessionStuckForStage(session.Phase, dkgNetwork.Stage) {
+	if isSessionStuckForStage(phase, dkgNetwork.Stage) {
 		if tryAcquireDKGSvc(dkgNetwork.Round) {
 			releaseDKGSvc(dkgNetwork.Round)
 
 			log.Info(ctx, "Recovering stuck DKG session: no active goroutine for intermediate phase",
 				"round", dkgNetwork.Round,
-				"phase", session.Phase.String(),
+				"phase", phase.String(),
 				"stage", dkgNetwork.Stage.String(),
 			)
 
@@ -190,6 +194,15 @@ func isSessionStuckForStage(phase types.DKGPhase, stage types.DKGStage) bool {
 		return phase != types.PhaseCompleted
 	default:
 		return false
+	}
+}
+
+// recoverAsyncDKG swallows a panic in an async DKG-service goroutine so it degrades
+// to a logged failure instead of crashing the validator. Use as a deferred call.
+func recoverAsyncDKG(ctx context.Context, name string) {
+	if r := recover(); r != nil {
+		log.Error(ctx, "Recovered from panic in async DKG service goroutine",
+			errors.New("async dkg goroutine panic", "goroutine", name, "value", r))
 	}
 }
 
@@ -226,6 +239,7 @@ func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSess
 
 		go func() {
 			defer cancel()
+			defer recoverAsyncDKG(asyncCtx, "handleDKGRegistration")
 
 			k.handleDKGRegistration(asyncCtx, dkgNetwork, oldCC, alreadyRegistered)
 		}()
@@ -257,6 +271,7 @@ func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSess
 
 		go func() {
 			defer cancel()
+			defer recoverAsyncDKG(asyncCtx, "handleDKGDealing")
 
 			k.handleDKGDealing(asyncCtx, dkgNetwork, deal)
 		}()
@@ -273,6 +288,7 @@ func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSess
 
 		go func() {
 			defer cancel()
+			defer recoverAsyncDKG(asyncCtx, "handleDKGFinalization")
 
 			k.handleDKGFinalization(asyncCtx, dkgNetwork)
 		}()
@@ -292,6 +308,7 @@ func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSess
 
 			go func() {
 				defer cancel()
+				defer recoverAsyncDKG(asyncCtx, "handleDKGComplete")
 
 				k.handleDKGComplete(asyncCtx, dkgNetwork)
 			}()
@@ -318,6 +335,7 @@ func (k *Keeper) resumeFailedSession(ctx context.Context, session *types.DKGSess
 
 		go func() {
 			defer cancel()
+			defer recoverAsyncDKG(asyncCtx, "recoverActiveSessionKeyMaterial")
 
 			k.recoverActiveSessionKeyMaterial(asyncCtx, dkgNetwork)
 		}()
@@ -384,8 +402,8 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 	// Anchor drain on the latest IsFinalized round (issue piplabs/story#826).
 	var latestActivated uint32
 	for _, s := range sessions {
-		if s.IsFinalized && s.Round > latestActivated {
-			latestActivated = s.Round
+		if r := s.GetRound(); s.GetIsFinalized() && r > latestActivated {
+			latestActivated = r
 		}
 	}
 
@@ -399,7 +417,7 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 		// Drop queued requests from sessions that are at least 2 rounds behind the
 		// current round — their keys are no longer relevant and the requests would
 		// never be processed successfully.
-		if latestActivated >= 2 && session.Round <= latestActivated-2 {
+		if latestActivated >= 2 && session.GetRound() <= latestActivated-2 {
 			dropped := session.DrainDecryptRequests()
 			if len(dropped) > 0 {
 				log.Warn(ctx, "Dropping decrypt requests from stale session", nil,
@@ -419,8 +437,9 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 		}
 
 		// Check session-level preconditions before draining so that requests are
-		// not removed from the queue only to be re-added immediately.
-		if session.Index == 0 {
+		// not removed from the queue only to be re-added immediately. Read through
+		// getters: the recovery path writes Index/GlobalPubKey concurrently.
+		if session.GetIndex() == 0 {
 			log.Warn(ctx, "Session index not set, deferring decrypt requests to next tick", nil,
 				"session", session.GetSessionKey(),
 			)
@@ -428,7 +447,7 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 			continue
 		}
 
-		if len(session.GlobalPubKey) == 0 {
+		if len(session.GetGlobalPubKey()) == 0 {
 			log.Warn(ctx, "Missing global public key for session, deferring decrypt requests to next tick", nil,
 				"session", session.GetSessionKey(),
 			)
@@ -446,10 +465,11 @@ func (k *Keeper) processDecryptQueue(ctx context.Context) {
 		// Skip sessions whose kernel binary is no longer connected.
 		// This happens when old events are replayed during chain catch-up
 		// after a kernel binary change — the sealed keys are unreachable.
-		if _, err := k.getClientWithReconnect(session.CodeCommitment); err != nil {
+		codeCommitment := session.GetCodeCommitment()
+		if _, err := k.getClientWithReconnect(codeCommitment); err != nil {
 			log.Warn(ctx, "Dropping decrypt requests for session with unavailable kernel", nil,
 				"session", session.GetSessionKey(),
-				"code_commitment", hex.EncodeToString(session.CodeCommitment),
+				"code_commitment", hex.EncodeToString(codeCommitment),
 				"dropped_requests", len(requests),
 			)
 
@@ -670,7 +690,8 @@ func (k *Keeper) computePartialDecrypt(ctx context.Context, session *types.DKGSe
 		}
 	}()
 
-	client, err := k.getClientWithReconnect(session.CodeCommitment)
+	codeCommitment := session.GetCodeCommitment()
+	client, err := k.getClientWithReconnect(codeCommitment)
 	if err != nil {
 		result.err = errors.Wrap(err, "no kernel client for session")
 		return
@@ -683,11 +704,11 @@ func (k *Keeper) computePartialDecrypt(ctx context.Context, session *types.DKGSe
 
 	kernelStart := time.Now()
 	resp, err := client.PartialDecryptTDH2(callCtx, &types.PartialDecryptTDH2Request{
-		CodeCommitment:  session.CodeCommitment,
-		Round:           session.Round,
+		CodeCommitment:  codeCommitment,
+		Round:           session.GetRound(),
 		Ciphertext:      req.Ciphertext,
 		Label:           req.Label,
-		GlobalPubKey:    session.GlobalPubKey,
+		GlobalPubKey:    session.GetGlobalPubKey(),
 		RequesterPubKey: req.RequesterPubKey,
 	})
 	kernelDuration := time.Since(kernelStart)
@@ -725,8 +746,8 @@ func (k *Keeper) submitPartialDecryption(ctx context.Context, session *types.DKG
 
 	if _, err := k.contractClient.SubmitEncryptedPartialDecryption(
 		ctx,
-		session.Round,
-		session.Index,
+		session.GetRound(),
+		session.GetIndex(),
 		resp.EncryptedPartialDecryption,
 		resp.EphemeralPubKey,
 		resp.PubShare,
@@ -746,6 +767,8 @@ func (k *Keeper) submitPartialDecryption(ctx context.Context, session *types.DKG
 func (k *Keeper) submitPartialDecryptionBatch(ctx context.Context, session *types.DKGSession, results []decryptComputeResult) error {
 	batchReqs := make([]bindings.ICDRPartialDecryptionRequest, 0, len(results))
 
+	round := session.GetRound()
+	pid := session.GetIndex()
 	for _, r := range results {
 		uuid, err := labelToUUID(r.req.Label)
 		if err != nil {
@@ -753,8 +776,8 @@ func (k *Keeper) submitPartialDecryptionBatch(ctx context.Context, session *type
 		}
 
 		batchReqs = append(batchReqs, bindings.ICDRPartialDecryptionRequest{
-			Round:            session.Round,
-			Pid:              session.Index,
+			Round:            round,
+			Pid:              pid,
 			EncryptedPartial: r.resp.EncryptedPartialDecryption,
 			EphemeralPubKey:  r.resp.EphemeralPubKey,
 			PubShare:         r.resp.PubShare,

--- a/client/x/dkg/keeper/dkg_svc_complete.go
+++ b/client/x/dkg/keeper/dkg_svc_complete.go
@@ -31,10 +31,10 @@ func (k *Keeper) handleDKGComplete(ctx context.Context, dkgNetwork *types.DKGNet
 	}
 
 	// A round just activated, so bound session growth by pruning rounds well below it.
-	// session.Round is the latest active round and is always retained.
-	k.stateManager.PruneOldSessions(ctx, session.Round)
+	// The session round is the latest active round and is always retained.
+	k.stateManager.PruneOldSessions(ctx, session.GetRound())
 
-	if session.Phase == types.PhaseCompleted && session.IsFinalized {
+	if session.GetPhase() == types.PhaseCompleted && session.GetIsFinalized() {
 		log.Info(ctx, "DKG network already completed")
 		// Ensure the decrypt worker is running even if completion was already processed
 		// (e.g., after node restart or if the worker exited due to a transient error).
@@ -43,7 +43,7 @@ func (k *Keeper) handleDKGComplete(ctx context.Context, dkgNetwork *types.DKGNet
 		return
 	}
 
-	if session.Phase != types.PhaseFinalized {
+	if session.GetPhase() != types.PhaseFinalized {
 		log.Error(ctx, "Session is not finalized yet", nil)
 		k.stateManager.MarkFailed(ctx, session)
 
@@ -61,7 +61,7 @@ func (k *Keeper) handleDKGComplete(ctx context.Context, dkgNetwork *types.DKGNet
 // recovery path can complete without releasing it. Marks the session failed on error.
 func (k *Keeper) completeSessionLocked(ctx context.Context, session *types.DKGSession) error {
 	session.UpdatePhase(types.PhaseCompleted)
-	session.IsFinalized = true // ready to start DKG threshold encryption/decryption
+	session.SetFinalized() // ready to start DKG threshold encryption/decryption
 
 	if err := k.stateManager.UpdateSession(ctx, session); err != nil {
 		log.Error(ctx, "Failed to update completed session", err)
@@ -71,7 +71,7 @@ func (k *Keeper) completeSessionLocked(ctx context.Context, session *types.DKGSe
 	}
 
 	log.Info(ctx, "DKG process completed successfully",
-		"round", session.Round,
+		"round", session.GetRound(),
 		"validator_evm_address", k.validatorEVMAddr,
 	)
 

--- a/client/x/dkg/keeper/dkg_svc_dealing.go
+++ b/client/x/dkg/keeper/dkg_svc_dealing.go
@@ -49,19 +49,22 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 		return
 	}
 
-	if session.Phase != types.PhaseInitialized {
+	if session.GetPhase() != types.PhaseInitialized {
 		log.Warn(ctx, "Session not in initialized phase, skipping generate deals", nil,
-			"current_phase", session.Phase.String())
+			"current_phase", session.GetPhase().String())
 		k.stateManager.MarkFailed(ctx, session)
 
 		return
 	}
 
+	round := session.GetRound()
+	isResharing := session.GetIsResharing()
+
 	// For upgrade resharing, the dealer uses the old binary's kernel client
 	// because the old key shares are sealed by the old binary.
-	dealerCC := session.CodeCommitment
-	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 {
-		dealerCC = session.OldCodeCommitment
+	dealerCC := session.GetCodeCommitment()
+	if oldCC := session.GetOldCodeCommitment(); dkgNetwork.IsUpgrade && len(oldCC) > 0 {
+		dealerCC = oldCC
 	}
 
 	var resp *types.GenerateDealsResponse
@@ -69,14 +72,14 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 	start := time.Now()
 	retryErr := retry(ctx, func(ctx context.Context) error {
 		log.Info(ctx, "GenerateDeals call to kernel client",
-			"round", session.Round,
+			"round", round,
 			"is_upgrade", dkgNetwork.IsUpgrade,
 		)
 
 		req := &types.GenerateDealsRequest{
 			CodeCommitment: dealerCC,
-			Round:          session.Round,
-			IsResharing:    session.IsResharing,
+			Round:          round,
+			IsResharing:    isResharing,
 		}
 		client, cErr := k.getClientWithReconnect(dealerCC)
 		if cErr != nil {
@@ -99,7 +102,7 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 		return
 	}
 
-	session.Phase = types.PhaseDealing
+	session.UpdatePhase(types.PhaseDealing)
 
 	if err := k.stateManager.UpdateSession(ctx, session); err != nil {
 		log.Error(ctx, "Failed to update session after generating deals", err)
@@ -110,13 +113,13 @@ func (k *Keeper) handleDKGDealing(ctx context.Context, dkgNetwork *types.DKGNetw
 
 	k.EnqueueDeals(resp.GetDeals())
 
-	// DEBUG: session.Index is this validator's 1-based on-chain registration index
+	// DEBUG: self_index is this validator's 1-based on-chain registration index
 	// (its dealer identity). Logging it next to the enqueued deal count makes clear
 	// which validator produced this batch of deals.
 	log.Info(ctx, "DKG deals are generated successfully",
-		"round", session.Round,
-		"self_index", session.Index,
-		"is_resharing", session.IsResharing,
+		"round", round,
+		"self_index", session.GetIndex(),
+		"is_resharing", isResharing,
 		"enqueued_deals", len(resp.GetDeals()),
 	)
 }
@@ -153,20 +156,25 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 	// Initialized to Dealing after GenerateDeals completes (which can take ~30s).
 	// If we reject deals during Initialized phase, they are permanently lost because
 	// vote extensions deliver each deal exactly once.
-	if session.Phase != types.PhaseDealing && session.Phase != types.PhaseInitialized {
+	if phase := session.GetPhase(); phase != types.PhaseDealing && phase != types.PhaseInitialized {
 		log.Warn(ctx, "Session not in dealing or initialized phase, skipping process deals", nil,
-			"current_phase", session.Phase.String(),
+			"current_phase", phase.String(),
 		)
 
 		return
 	}
 
+	round := session.GetRound()
+	isResharing := session.GetIsResharing()
+	codeCommitment := session.GetCodeCommitment()
+	selfIndex := session.GetIndex()
+
 	// Filter deals addressed to this validator before entering retry loop.
-	// RecipientIndex is 0-based (Kyber), session.Index is 1-based (on-chain).
+	// RecipientIndex is 0-based (Kyber), selfIndex is 1-based (on-chain).
 	// Guard against unset index (0) to avoid uint32 underflow.
 	filtered := make([]pendingDeal, 0, len(pending))
 	for _, pd := range pending {
-		if session.Index > 0 && pd.deal.RecipientIndex == session.Index-1 {
+		if selfIndex > 0 && pd.deal.RecipientIndex == selfIndex-1 {
 			filtered = append(filtered, pd)
 		}
 	}
@@ -191,19 +199,19 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 	start := time.Now()
 	retryErr := retry(ctx, func(ctx context.Context) error {
 		log.Info(ctx, "ProcessDeals call to kernel client",
-			"round", session.Round,
+			"round", round,
 			"total_deals", len(pending),
 			"filtered_deals", len(filtered),
 		)
 
 		req := &types.ProcessDealsRequest{
-			CodeCommitment: session.CodeCommitment,
-			Round:          session.Round,
+			CodeCommitment: codeCommitment,
+			Round:          round,
 			Deals:          rawDeals,
-			IsResharing:    session.IsResharing,
+			IsResharing:    isResharing,
 		}
 
-		client, cErr := k.getClientWithReconnect(session.CodeCommitment)
+		client, cErr := k.getClientWithReconnect(codeCommitment)
 		if cErr != nil {
 			return errors.Wrap(cErr, "no kernel client for session")
 		}
@@ -264,7 +272,7 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 		}
 		log.Warn(ctx, "Kernel rejected deals", nil,
 			"round", dkgNetwork.Round,
-			"self_index", session.Index,
+			"self_index", selfIndex,
 			"rejected_sender_index", rejectedIdx,
 		)
 
@@ -297,7 +305,7 @@ func (k *Keeper) handleDKGProcessDeals(ctx context.Context, dkgNetwork *types.DK
 	k.EnqueueResponses(resp.GetResponses())
 
 	log.Info(ctx, "Process deals complete",
-		"round", session.Round,
+		"round", round,
 		"submitted_deals", len(rawDeals),
 		"responses_generated", len(resp.GetResponses()),
 		"rejected_deals", len(resp.GetRejectedDeals()),
@@ -397,27 +405,33 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 	}
 
 	// Accept responses in both Initialized and Dealing phases (same reasoning as deals).
-	if session.Phase != types.PhaseDealing && session.Phase != types.PhaseInitialized {
+	if phase := session.GetPhase(); phase != types.PhaseDealing && phase != types.PhaseInitialized {
 		log.Warn(ctx, "Session not in dealing or initialized phase, skipping process responses", nil,
-			"current_phase", session.Phase.String(),
+			"current_phase", phase.String(),
 		)
 
 		return
 	}
 
+	round := session.GetRound()
+	isResharing := session.GetIsResharing()
+	codeCommitment := session.GetCodeCommitment()
+	oldCodeCommitment := session.GetOldCodeCommitment()
+	selfIndex := session.GetIndex()
+
 	// During upgrade resharing, validators in both old and new sets must send
 	// ProcessResponses to BOTH binaries: the old binary (dealer role) and the new binary
 	// (recipient role). Each binary maintains its own DKG state that needs updating.
-	ccsToProcess := [][]byte{session.CodeCommitment}
-	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 && !bytes.Equal(session.CodeCommitment, session.OldCodeCommitment) {
-		ccsToProcess = append(ccsToProcess, session.OldCodeCommitment)
+	ccsToProcess := [][]byte{codeCommitment}
+	if dkgNetwork.IsUpgrade && len(oldCodeCommitment) > 0 && !bytes.Equal(codeCommitment, oldCodeCommitment) {
+		ccsToProcess = append(ccsToProcess, oldCodeCommitment)
 	}
 
-	// Filter self-responses: VssResponse.Index is 0-based (Kyber), session.Index is 1-based.
-	// If session.Index is 0 (unset), include all responses (no self-filtering).
+	// Filter self-responses: VssResponse.Index is 0-based (Kyber), selfIndex is 1-based.
+	// If selfIndex is 0 (unset), include all responses (no self-filtering).
 	filtered := make([]pendingResponse, 0, len(pending))
 	for _, pr := range pending {
-		if session.Index == 0 || pr.response.VssResponse.Index != session.Index-1 {
+		if selfIndex == 0 || pr.response.VssResponse.Index != selfIndex-1 {
 			filtered = append(filtered, pr)
 		}
 	}
@@ -446,16 +460,16 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 		start := time.Now()
 		retryErr := retry(ctx, func(ctx context.Context) error {
 			log.Info(ctx, "ProcessResponses call to kernel client",
-				"round", session.Round,
+				"round", round,
 				"num_responses", len(rawResponses),
 				"code_commitment", hex.EncodeToString(cc),
 			)
 
 			req := &types.ProcessResponsesRequest{
 				CodeCommitment: cc,
-				Round:          session.Round,
+				Round:          round,
 				Responses:      rawResponses,
-				IsResharing:    session.IsResharing,
+				IsResharing:    isResharing,
 			}
 
 			client, cErr := k.getClientWithReconnect(cc)
@@ -496,7 +510,7 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 
 			log.Info(ctx, "Enqueued justifications for broadcast",
 				"code_commitment", hex.EncodeToString(cc),
-				"round", session.Round,
+				"round", round,
 				"num_justifications", len(processResp.GetJustifications()),
 			)
 		}
@@ -535,7 +549,7 @@ func (k *Keeper) handleDKGProcessResponses(ctx context.Context, dkgNetwork *type
 	}
 
 	log.Info(ctx, "Process responses complete",
-		"round", session.Round,
+		"round", round,
 		"submitted_responses", len(rawResponses),
 		"justifications_received", totalJustifications,
 		"rejected_responses", len(rejected),
@@ -559,9 +573,14 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 		return
 	}
 
-	ccsToProcess := [][]byte{session.CodeCommitment}
-	if dkgNetwork.IsUpgrade && len(session.OldCodeCommitment) > 0 && !bytes.Equal(session.CodeCommitment, session.OldCodeCommitment) {
-		ccsToProcess = append(ccsToProcess, session.OldCodeCommitment)
+	round := session.GetRound()
+	isResharing := session.GetIsResharing()
+	codeCommitment := session.GetCodeCommitment()
+	oldCodeCommitment := session.GetOldCodeCommitment()
+
+	ccsToProcess := [][]byte{codeCommitment}
+	if dkgNetwork.IsUpgrade && len(oldCodeCommitment) > 0 && !bytes.Equal(codeCommitment, oldCodeCommitment) {
+		ccsToProcess = append(ccsToProcess, oldCodeCommitment)
 	}
 
 	// Extract raw justifications from pending items for the kernel call.
@@ -581,9 +600,9 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 		retryErr := retry(ctx, func(ctx context.Context) error {
 			req := &types.ProcessJustificationRequest{
 				CodeCommitment: cc,
-				Round:          session.Round,
+				Round:          round,
 				Justifications: rawJustifications,
-				IsResharing:    session.IsResharing,
+				IsResharing:    isResharing,
 			}
 
 			client, cErr := k.getClientWithReconnect(cc)
@@ -649,7 +668,7 @@ func (k *Keeper) handleDKGProcessJustifications(ctx context.Context, dkgNetwork 
 	}
 
 	log.Info(ctx, "Process justifications complete",
-		"round", session.Round,
+		"round", round,
 		"submitted_justifications", len(rawJustifications),
 		"rejected_justifications", len(rejected),
 	)

--- a/client/x/dkg/keeper/dkg_svc_finalization.go
+++ b/client/x/dkg/keeper/dkg_svc_finalization.go
@@ -46,9 +46,9 @@ func (k *Keeper) handleDKGFinalization(ctx context.Context, dkgNetwork *types.DK
 		return
 	}
 
-	if session.Phase != types.PhaseDealing {
+	if session.GetPhase() != types.PhaseDealing {
 		log.Warn(ctx, "Session not in dealing phase, skipping finalize DKG", nil,
-			"current_phase", session.Phase.String())
+			"current_phase", session.GetPhase().String())
 		k.stateManager.MarkFailed(ctx, session)
 
 		return
@@ -78,13 +78,13 @@ func (k *Keeper) handleDKGFinalization(ctx context.Context, dkgNetwork *types.DK
 	}
 
 	log.Info(ctx, "DKG finalization phase complete",
-		"round", session.Round,
+		"round", session.GetRound(),
 	)
 }
 
 func (k *Keeper) callTEEFinalizeDKG(ctx context.Context, session *types.DKGSession) error {
 	log.Info(ctx, "Finalize call to kernel client",
-		"round", session.Round,
+		"round", session.GetRound(),
 	)
 
 	if len(session.GetGlobalPubKey()) > 0 && len(session.GetSigFinalizeNetwork()) > 0 {
@@ -97,15 +97,16 @@ func (k *Keeper) callTEEFinalizeDKG(ctx context.Context, session *types.DKGSessi
 		resp *types.FinalizeDKGResponse
 		err  error
 	)
+	codeCommitment := session.GetCodeCommitment()
 	start := time.Now()
 	retryErr := retry(ctx, func(ctx context.Context) error {
 		req := &types.FinalizeDKGRequest{
-			CodeCommitment: session.CodeCommitment,
-			Round:          session.Round,
-			IsResharing:    session.IsResharing,
+			CodeCommitment: codeCommitment,
+			Round:          session.GetRound(),
+			IsResharing:    session.GetIsResharing(),
 		}
 
-		client, cErr := k.getClientWithReconnect(session.CodeCommitment)
+		client, cErr := k.getClientWithReconnect(codeCommitment)
 		if cErr != nil {
 			return errors.Wrap(cErr, "no kernel client for session")
 		}
@@ -141,21 +142,26 @@ func (k *Keeper) callTEEFinalizeDKG(ctx context.Context, session *types.DKGSessi
 }
 
 func (k *Keeper) callContractFinalizeDKG(ctx context.Context, session *types.DKGSession) error {
+	// Read the key-material fields through mutex-guarded getters: SetKeyMaterial writes them
+	// under Lock (here or on the active-round recovery path), so a raw read could race that write.
+	globalPubKey := session.GetGlobalPubKey()
+	sigFinalizeNetwork := session.GetSigFinalizeNetwork()
+
 	log.Info(ctx, "Finalize contract call",
-		"round", session.Round,
-		"global_pub_key", hex.EncodeToString(session.GlobalPubKey),
-		"signature_len", len(session.SigFinalizeNetwork),
+		"round", session.GetRound(),
+		"global_pub_key", hex.EncodeToString(globalPubKey),
+		"signature_len", len(sigFinalizeNetwork),
 	)
 
 	if _, err := k.contractClient.Finalize(
 		ctx,
-		session.Round,
-		session.EnclaveType,
-		session.ParticipantsRoot,
-		session.GlobalPubKey,
-		session.PublicCoeffs,
-		session.PubKeyShare,
-		session.SigFinalizeNetwork,
+		session.GetRound(),
+		session.GetEnclaveType(),
+		session.GetParticipantsRoot(),
+		globalPubKey,
+		session.GetPublicCoeffs(),
+		session.GetPubKeyShare(),
+		sigFinalizeNetwork,
 	); err != nil {
 		return err
 	}

--- a/client/x/dkg/keeper/dkg_svc_registration.go
+++ b/client/x/dkg/keeper/dkg_svc_registration.go
@@ -48,17 +48,17 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 	// participate in later stages (especially dealing, and finalization).
 	// Therefore, a session must exist regardless of key generation eligibility.
 	session := types.NewDKGSession(dkgNetwork.Round, dkgNetwork.ActiveValSet, dkgNetwork.IsResharing, k.enclaveType)
-	session.IsUpgrade = dkgNetwork.IsUpgrade
+	session.SetIsUpgrade(dkgNetwork.IsUpgrade)
 
 	// For upgrade rounds, store the old binary's code commitment so that dealers
 	// can route TEE calls to the correct (old) binary for deal generation.
 	if dkgNetwork.IsUpgrade && len(oldCC) > 0 {
-		session.OldCodeCommitment = oldCC
+		session.SetOldCodeCommitment(oldCC)
 
 		// For old-only members (not in current round set), set CodeCommitment
 		// to old CC so they have a valid routing target for processing deals/responses.
 		if !isInCurRoundSet {
-			session.CodeCommitment = oldCC
+			session.SetCodeCommitmentIfEmpty(oldCC)
 		}
 	}
 
@@ -69,9 +69,9 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 		return
 	}
 
-	if session.Phase != types.PhaseInitializing {
+	if session.GetPhase() != types.PhaseInitializing {
 		log.Warn(ctx, "Session not in initializing phase, skipping initialization", nil,
-			"current_phase", session.Phase.String())
+			"current_phase", session.GetPhase().String())
 		k.stateManager.MarkFailed(ctx, session)
 
 		return
@@ -93,7 +93,7 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 
 	if alreadyRegistered {
 		log.Info(ctx, "Validator already registered on-chain; skipping contract call",
-			"round", session.Round,
+			"round", session.GetRound(),
 		)
 	} else if err := k.callContractRegister(ctx, session); err != nil {
 		log.Error(ctx, "Failed to call register method", err)
@@ -112,18 +112,18 @@ func (k *Keeper) handleDKGRegistration(ctx context.Context, dkgNetwork *types.DK
 	}
 
 	log.Info(ctx, "DKG initialization complete",
-		"round", session.Round,
+		"round", session.GetRound(),
 	)
 }
 
 func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.DKGSession, isUpgrade bool, oldCC []byte) error {
 	log.Info(ctx, "GenerateAndSealKey call to kernel client",
-		"round", session.Round,
+		"round", session.GetRound(),
 		"validator", k.validatorEVMAddr,
 		"is_upgrade", isUpgrade,
 	)
 
-	if len(session.DKGPubKey) > 0 && len(session.CommPubKey) > 0 && len(session.EnclaveReport) > 0 {
+	if session.HasSetupData() {
 		log.Info(ctx, "Already generated and sealed the key, skipping call GenerateAndSealKey request")
 
 		return nil
@@ -134,7 +134,7 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 	// - Upgrade rounds: use old binary's CC to find the NEW binary (by exclusion).
 	var targetCC []byte
 	if isUpgrade {
-		targetCC = session.OldCodeCommitment
+		targetCC = session.GetOldCodeCommitment()
 	} else {
 		targetCC = oldCC
 	}
@@ -145,10 +145,8 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 	}
 
 	// Set the code commitment on the session from the resolved kernel client
-	// so the GenerateAndSealKey request includes it.
-	if len(session.CodeCommitment) == 0 {
-		session.CodeCommitment = clientCC
-	}
+	// so the GenerateAndSealKey request includes it. Atomic check-and-set.
+	session.SetCodeCommitmentIfEmpty(clientCC)
 
 	var (
 		resp *types.GenerateAndSealKeyResponse
@@ -158,8 +156,8 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 	retryErr := retry(ctx, func(ctx context.Context) error {
 		req := &types.GenerateAndSealKeyRequest{
 			Address:        k.validatorEVMAddr,
-			CodeCommitment: session.CodeCommitment,
-			Round:          session.Round,
+			CodeCommitment: session.GetCodeCommitment(),
+			Round:          session.GetRound(),
 		}
 
 		resp, err = client.GenerateAndSealKey(ctx, req)
@@ -175,15 +173,18 @@ func (k *Keeper) callTEEGenerateAndSealKey(ctx context.Context, session *types.D
 		return errors.Wrap(retryErr, "kernel client GenerateAndSealKey request failed")
 	}
 
-	// Persist the code commitment from the TEE response for future routing
-	// (used by dealing, finalization, and threshold decryption)
-	session.CodeCommitment = resp.GetCodeCommitment()
-	session.DKGPubKey = resp.GetDkgPubKey()
-	session.CommPubKey = resp.GetCommPubKey()
-	session.EnclaveReport = resp.GetEnclaveReport()
-	session.StartBlockHeight = resp.GetStartBlockHeight()
+	// Persist the setup fields from the TEE response for future routing
+	// (used by dealing, finalization, and threshold decryption). Stored atomically
+	// under a single lock so a concurrent reader never observes a torn slice header.
+	session.SetSetupResult(
+		resp.GetCodeCommitment(),
+		resp.GetDkgPubKey(),
+		resp.GetCommPubKey(),
+		resp.GetEnclaveReport(),
+		resp.GetStartBlockHash(),
+		resp.GetStartBlockHeight(),
+	)
 
-	session.StartBlockHash = resp.GetStartBlockHash()
 	if err := k.stateManager.UpdateSession(ctx, session); err != nil {
 		return errors.Wrap(err, "failed to update session after calling GenerateAndSealKey on the kernel client")
 	}
@@ -286,24 +287,31 @@ func (k *Keeper) getOldCodeCommitment(ctx context.Context) ([]byte, error) {
 }
 
 func (k *Keeper) callContractRegister(ctx context.Context, session *types.DKGSession) error {
+	round := session.GetRound()
+	startBlockHeight := session.GetStartBlockHeight()
+	startBlockHash := session.GetStartBlockHash()
+	dkgPubKey := session.GetDKGPubKey()
+	commPubKey := session.GetCommPubKey()
+	enclaveReport := session.GetEnclaveReport()
+
 	log.Info(ctx, "Register contract call",
-		"round", session.Round,
-		"start_block_height", session.StartBlockHeight,
-		"start_block_hash", hex.EncodeToString(session.StartBlockHash),
-		"dkg_pub_key", hex.EncodeToString(session.DKGPubKey),
-		"comm_pub_key", hex.EncodeToString(session.CommPubKey),
-		"raw_quote_len", len(session.EnclaveReport),
+		"round", round,
+		"start_block_height", startBlockHeight,
+		"start_block_hash", hex.EncodeToString(startBlockHash),
+		"dkg_pub_key", hex.EncodeToString(dkgPubKey),
+		"comm_pub_key", hex.EncodeToString(commPubKey),
+		"raw_quote_len", len(enclaveReport),
 	)
 
 	if _, err := k.contractClient.Register(
 		ctx,
-		session.Round,
-		session.EnclaveType,
-		uint64(session.StartBlockHeight),
-		session.StartBlockHash,
-		session.DKGPubKey,
-		session.CommPubKey,
-		session.EnclaveReport,
+		round,
+		session.GetEnclaveType(),
+		uint64(startBlockHeight),
+		startBlockHash,
+		dkgPubKey,
+		commPubKey,
+		enclaveReport,
 	); err != nil {
 		return err
 	}

--- a/client/x/dkg/keeper/dkg_svc_test.go
+++ b/client/x/dkg/keeper/dkg_svc_test.go
@@ -332,6 +332,94 @@ func TestDkgAsyncContext(t *testing.T) {
 	require.WithinDuration(t, deadline, deadline, dkgAsyncTimeout)
 }
 
+// --- resumeFailedSession async panic recovery ---
+
+// TestResumeFailedSession_AsyncPanicRecovered forces a panic inside one of the async
+// goroutines spawned by resumeFailedSession (the finalization path) and verifies the
+// deferred recoverAsyncDKG guard swallows it so the validator process does NOT crash.
+//
+// The panic is injected via a mock kernel whose FinalizeDKG panics. It propagates
+// through callTEEFinalizeDKG -> handleDKGFinalization up to the goroutine's
+// `defer recoverAsyncDKG(...)`, which is the FIRST deferred function (LIFO), so it runs
+// before `defer cancel()`. We therefore synchronize on the async context being cancelled:
+// cancel() only runs after the goroutine unwinds through recoverAsyncDKG, and the process
+// only stays alive to observe it because recoverAsyncDKG recovered the panic.
+//
+// This is a genuine guard: removing `defer recoverAsyncDKG(...)` from the finalization
+// goroutine lets the panic escape the goroutine, which crashes the test binary and fails
+// the package.
+func TestResumeFailedSession_AsyncPanicRecovered(t *testing.T) {
+	// Not parallel: shares the package-level dkgSvcRound atomic.
+	resetDKGSvcRound()
+	defer resetDKGSvcRound()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	cc := []byte("panic-finalize-cc")
+	mockKernel := dkgtestutil.NewMockKernelServiceClient(ctrl)
+
+	router := NewKernelRouter(nil, nil)
+	router.RegisterClient(cc, mockKernel)
+
+	sm, err := NewStateManager(t.TempDir())
+	require.NoError(t, err)
+
+	k := &Keeper{
+		stateManager:     sm,
+		kernelRouter:     router,
+		validatorEVMAddr: testValidatorAddr,
+	}
+
+	const round = uint32(77)
+	session := &types.DKGSession{
+		Round:          round,
+		Phase:          types.PhaseFailed,
+		CodeCommitment: cc,
+	}
+	require.NoError(t, sm.CreateSession(ctx, session))
+
+	// capturedCtx receives the async context that the spawned goroutine passes down to the
+	// kernel call, letting the test observe its cancellation once the goroutine unwinds.
+	capturedCtx := make(chan context.Context, 1)
+
+	// The mock records that the panic point was reached (by handing back the async context)
+	// and then panics inside the goroutine.
+	mockKernel.EXPECT().FinalizeDKG(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(asyncCtx context.Context, _ *types.FinalizeDKGRequest, _ ...grpc.CallOption) (*types.FinalizeDKGResponse, error) {
+			capturedCtx <- asyncCtx
+			panic("injected finalize panic")
+		}).Times(1)
+
+	dkgNetwork := &types.DKGNetwork{
+		Round:        round,
+		Stage:        types.DKGStageFinalization,
+		ActiveValSet: []string{testValidatorAddr},
+	}
+
+	// Dispatches to the finalization branch, which spawns the recover-wrapped goroutine.
+	k.resumeFailedSession(ctx, session, dkgNetwork)
+
+	// (a) The wrapped goroutine reached the injected panic.
+	var asyncCtx context.Context
+	select {
+	case asyncCtx = <-capturedCtx:
+	case <-time.After(5 * time.Second):
+		t.Fatal("finalization goroutine never reached the panic point")
+	}
+
+	// (b) The goroutine unwound through its deferred chain and returned without crashing the
+	// process. `defer cancel()` runs only after `defer recoverAsyncDKG(...)` recovered the
+	// panic (LIFO order), so a cancelled async context proves the recover branch executed and
+	// the process survived. Without the recover guard, the panic would crash the test binary.
+	select {
+	case <-asyncCtx.Done():
+		require.ErrorIs(t, asyncCtx.Err(), context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("async context was not cancelled; recoverAsyncDKG did not complete")
+	}
+}
+
 // --- Tests merged from dkg_svc_decrypt_test.go ---
 
 // --- processDecryptRequests / computePartialDecrypt / submitPartialDecryption ---

--- a/client/x/dkg/keeper/state_manager.go
+++ b/client/x/dkg/keeper/state_manager.go
@@ -54,7 +54,7 @@ func (sm *StateManager) CreateSession(ctx context.Context, session *types.DKGSes
 	sessionKey := session.GetSessionKey()
 
 	if _, exists := sm.sessions[sessionKey]; exists {
-		log.Info(ctx, "Session already exists with the code commitment and round, skip creating a new session", "code_commitment", session.GetCodeCommitmentString(), "round", session.Round)
+		log.Info(ctx, "Session already exists with the code commitment and round, skip creating a new session", "code_commitment", session.GetCodeCommitmentString(), "round", session.GetRound())
 
 		return nil
 	} else {
@@ -66,8 +66,8 @@ func (sm *StateManager) CreateSession(ctx context.Context, session *types.DKGSes
 
 		log.Info(ctx, "Created DKG session",
 			"code_commitment", session.GetCodeCommitmentString(),
-			"round", session.Round,
-			"phase", session.Phase.String(),
+			"round", session.GetRound(),
+			"phase", session.GetPhase().String(),
 		)
 
 		return nil
@@ -108,8 +108,8 @@ func (sm *StateManager) UpdateSession(ctx context.Context, session *types.DKGSes
 
 	log.Debug(ctx, "Updated DKG session",
 		"code_commitment", session.GetCodeCommitmentString(),
-		"round", session.Round,
-		"phase", session.Phase.String(),
+		"round", session.GetRound(),
+		"phase", session.GetPhase().String(),
 	)
 
 	return nil
@@ -164,7 +164,7 @@ func (sm *StateManager) DeleteSession(ctx context.Context, round uint32) error {
 
 	log.Info(ctx, "Deleted DKG session",
 		"code_commitment", session.GetCodeCommitmentString(),
-		"round", session.Round,
+		"round", session.GetRound(),
 	)
 
 	return nil
@@ -176,7 +176,7 @@ func (sm *StateManager) GetActiveSession(validatorAddr string) *types.DKGSession
 	defer sm.mu.RUnlock()
 
 	for _, session := range sm.sessions {
-		if session.Phase == types.PhaseCompleted {
+		if session.GetPhase() == types.PhaseCompleted {
 			return session
 		}
 	}
@@ -204,8 +204,8 @@ func (sm *StateManager) PruneOldSessions(ctx context.Context, activeRound uint32
 	sm.mu.RLock()
 	stale := make([]uint32, 0)
 	for _, session := range sm.sessions {
-		if session.Round < horizon {
-			stale = append(stale, session.Round)
+		if r := session.GetRound(); r < horizon {
+			stale = append(stale, r)
 		}
 	}
 	sm.mu.RUnlock()
@@ -287,7 +287,12 @@ func (*StateManager) loadSessionFromFile(filename string) (*types.DKGSession, er
 // saveSession saves a session to disk atomically by writing to a temporary file
 // and renaming it, preventing corruption from partial writes during crashes.
 func (sm *StateManager) saveSession(session *types.DKGSession) error {
-	data, err := json.MarshalIndent(session, "", "  ")
+	// Marshal a locked deep-copy snapshot rather than the live pointer. Marshaling the live
+	// pointer reflects over every field without holding session.mu, which races any concurrent
+	// mutex-guarded mutation (UpdatePhase/SetKeyMaterial/IncrementRecoveryAttempts) and can read
+	// a torn slice header. StateManager.mu only serializes UpdateSession calls; it does not
+	// synchronize with session.mu, so the snapshot is what closes the marshal-vs-mutation race.
+	data, err := json.MarshalIndent(session.Snapshot(), "", "  ")
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal session data")
 	}

--- a/client/x/dkg/keeper/state_manager_test.go
+++ b/client/x/dkg/keeper/state_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -455,4 +456,57 @@ func TestStateManager_DeleteSession_FileRemovedFromDisk(t *testing.T) {
 
 	_, err = os.Stat(pattern)
 	require.True(t, os.IsNotExist(err), "session file should be removed after delete")
+}
+
+// TestStateManager_UpdateSession_ConcurrentMarshalAndMutation drives concurrent
+// UpdateSession (which marshals the session to disk) against mutex-guarded mutations of the
+// same session. Before saveSession marshaled a locked Snapshot, the marshal reflected over
+// the live struct without holding session.mu and raced these mutations, so this test fails
+// under -race on the pre-fix code. Run with: go test ./client/x/dkg/... -race.
+func TestStateManager_UpdateSession_ConcurrentMarshalAndMutation(t *testing.T) {
+	t.Parallel()
+
+	sm := newTestStateManager(t)
+	ctx := context.Background()
+
+	session := newTestSession(42)
+	require.NoError(t, sm.CreateSession(ctx, session))
+
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer 1: repeatedly persist the session; saveSession marshals a locked Snapshot.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = sm.UpdateSession(ctx, session)
+		}
+	}()
+
+	// Writer 2: mutate the same session through its mutex-guarded methods.
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			session.UpdatePhase(types.PhaseDealing)
+			session.SetIndex(uint32(i + 1))
+			session.SetKeyMaterial(
+				[]byte("proot"),
+				[]byte("gpk"),
+				[]byte("sig"),
+				[]byte("share"),
+				[][]byte{[]byte("c0"), []byte("c1")},
+			)
+			session.IncrementRecoveryAttempts()
+			session.SetFinalized()
+		}
+	}()
+
+	wg.Wait()
+
+	// Sanity: the session is still persisted and readable after the concurrent churn.
+	got, err := sm.GetSession(42)
+	require.NoError(t, err)
+	require.Equal(t, uint32(42), got.Round)
 }

--- a/client/x/dkg/types/dkg.go
+++ b/client/x/dkg/types/dkg.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -266,4 +267,264 @@ func (s *DKGSession) DrainDecryptRequests() []PendingDecryptRequest {
 	s.LastUpdate = time.Now()
 
 	return reqs
+}
+
+// GetPhase returns the current session phase under RLock.
+func (s *DKGSession) GetPhase() DKGPhase {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Phase
+}
+
+// GetIndex returns this validator's 1-based on-chain registration index under RLock.
+func (s *DKGSession) GetIndex() uint32 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Index
+}
+
+// SetIndex stores this validator's 1-based on-chain registration index under Lock.
+func (s *DKGSession) SetIndex(index uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Index = index
+	s.LastUpdate = time.Now()
+}
+
+// GetIsFinalized reports whether the session key material is ready for
+// threshold encryption/decryption. Read under RLock.
+func (s *DKGSession) GetIsFinalized() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.IsFinalized
+}
+
+// SetFinalized marks the session ready for threshold encryption/decryption under Lock.
+func (s *DKGSession) SetFinalized() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.IsFinalized = true
+	s.LastUpdate = time.Now()
+}
+
+// GetParticipantsRoot returns a copy of the participants root under RLock.
+func (s *DKGSession) GetParticipantsRoot() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.ParticipantsRoot)
+}
+
+// GetPubKeyShare returns a copy of this validator's key share under RLock.
+func (s *DKGSession) GetPubKeyShare() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.PubKeyShare)
+}
+
+// GetPublicCoeffs returns a deep copy of the public coefficients under RLock.
+func (s *DKGSession) GetPublicCoeffs() [][]byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return cloneByteSlices(s.PublicCoeffs)
+}
+
+// GetRound returns the session round. Immutable after construction, but read under RLock
+// for uniform mutex-based access.
+func (s *DKGSession) GetRound() uint32 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Round
+}
+
+// GetIsResharing reports whether this is a resharing round. Immutable after construction,
+// read under RLock for uniformity.
+func (s *DKGSession) GetIsResharing() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.IsResharing
+}
+
+// GetEnclaveType returns the enclave type. The array is returned by value (copy).
+func (s *DKGSession) GetEnclaveType() [32]byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.EnclaveType
+}
+
+// GetCodeCommitment returns a copy of the code commitment under RLock.
+func (s *DKGSession) GetCodeCommitment() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.CodeCommitment)
+}
+
+// GetOldCodeCommitment returns a copy of the previous round's code commitment under RLock.
+func (s *DKGSession) GetOldCodeCommitment() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.OldCodeCommitment)
+}
+
+// GetDKGPubKey returns a copy of the DKG public key under RLock.
+func (s *DKGSession) GetDKGPubKey() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.DKGPubKey)
+}
+
+// GetCommPubKey returns a copy of the communication public key under RLock.
+func (s *DKGSession) GetCommPubKey() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.CommPubKey)
+}
+
+// GetEnclaveReport returns a copy of the enclave report under RLock.
+func (s *DKGSession) GetEnclaveReport() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.EnclaveReport)
+}
+
+// GetStartBlockHeight returns the setup start block height under RLock.
+func (s *DKGSession) GetStartBlockHeight() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.StartBlockHeight
+}
+
+// GetStartBlockHash returns a copy of the setup start block hash under RLock.
+func (s *DKGSession) GetStartBlockHash() []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return bytes.Clone(s.StartBlockHash)
+}
+
+// HasSetupData reports whether the key-generation setup fields have been populated.
+func (s *DKGSession) HasSetupData() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.DKGPubKey) > 0 && len(s.CommPubKey) > 0 && len(s.EnclaveReport) > 0
+}
+
+// SetIsUpgrade records whether this is an upgrade round.
+func (s *DKGSession) SetIsUpgrade(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.IsUpgrade = v
+	s.LastUpdate = time.Now()
+}
+
+// SetOldCodeCommitment stores the previous active round's code commitment (upgrade routing).
+func (s *DKGSession) SetOldCodeCommitment(oldCC []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.OldCodeCommitment = oldCC
+	s.LastUpdate = time.Now()
+}
+
+// SetCodeCommitmentIfEmpty sets the code commitment only when it is currently unset,
+// as a single atomic check-and-set so a concurrent reader cannot observe a TOCTOU gap.
+func (s *DKGSession) SetCodeCommitmentIfEmpty(cc []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.CodeCommitment) == 0 {
+		s.CodeCommitment = cc
+		s.LastUpdate = time.Now()
+	}
+}
+
+// SetSetupResult atomically stores the key-generation setup fields returned by the kernel
+// GenerateAndSealKey call under a single Lock, so a concurrent reader (e.g. HasSetupData on
+// the ABCI thread) never observes a partially-written set of slice headers.
+func (s *DKGSession) SetSetupResult(codeCommitment, dkgPubKey, commPubKey, enclaveReport, startBlockHash []byte, startBlockHeight int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.CodeCommitment = codeCommitment
+	s.DKGPubKey = dkgPubKey
+	s.CommPubKey = commPubKey
+	s.EnclaveReport = enclaveReport
+	s.StartBlockHash = startBlockHash
+	s.StartBlockHeight = startBlockHeight
+	s.LastUpdate = time.Now()
+}
+
+// Snapshot returns a deep copy of the session under RLock, so it can be marshaled
+// (e.g. by saveSession) without racing a concurrent mutation. Built field-by-field
+// to avoid copying the live mutex (copylocks); do not call other s.mu getters here,
+// as the lock is not reentrant.
+func (s *DKGSession) Snapshot() *DKGSession {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return &DKGSession{
+		CodeCommitment:     bytes.Clone(s.CodeCommitment),
+		Round:              s.Round,
+		GlobalPubKey:       bytes.Clone(s.GlobalPubKey),
+		DKGPubKey:          bytes.Clone(s.DKGPubKey),
+		CommPubKey:         bytes.Clone(s.CommPubKey),
+		EnclaveReport:      bytes.Clone(s.EnclaveReport),
+		StartBlockHeight:   s.StartBlockHeight,
+		StartBlockHash:     bytes.Clone(s.StartBlockHash),
+		Phase:              s.Phase,
+		StartTime:          s.StartTime,
+		LastUpdate:         s.LastUpdate,
+		Index:              s.Index,
+		SigSetupNetwork:    bytes.Clone(s.SigSetupNetwork),
+		SigFinalizeNetwork: bytes.Clone(s.SigFinalizeNetwork),
+		PublicCoeffs:       cloneByteSlices(s.PublicCoeffs),
+		PubKeyShare:        bytes.Clone(s.PubKeyShare),
+		ParticipantsRoot:   bytes.Clone(s.ParticipantsRoot),
+		EnclaveType:        s.EnclaveType,
+		ActiveValidators:   slices.Clone(s.ActiveValidators),
+		Total:              s.Total,
+		Threshold:          s.Threshold,
+		Registrations:      slices.Clone(s.Registrations),
+		Commitments:        bytes.Clone(s.Commitments),
+		Complaints:         slices.Clone(s.Complaints),
+		IsFinalized:        s.IsFinalized,
+		IsResharing:        s.IsResharing,
+		IsUpgrade:          s.IsUpgrade,
+		OldCodeCommitment:  bytes.Clone(s.OldCodeCommitment),
+		DecryptRequests:    slices.Clone(s.DecryptRequests),
+		RecoveryAttempts:   s.RecoveryAttempts,
+	}
+}
+
+// cloneByteSlices deep-copies a slice of byte slices. Returns nil for nil input
+// to preserve JSON round-trip equivalence.
+func cloneByteSlices(in [][]byte) [][]byte {
+	if in == nil {
+		return nil
+	}
+
+	out := make([][]byte, len(in))
+	for i, b := range in {
+		out[i] = bytes.Clone(b)
+	}
+
+	return out
 }

--- a/client/x/dkg/types/dkg_test.go
+++ b/client/x/dkg/types/dkg_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -254,4 +255,162 @@ func TestDKGSession_DecryptRequests(t *testing.T) {
 		require.Len(t, reqs, 1)
 		require.Equal(t, []byte("uuid51"), reqs[0].Ciphertext)
 	})
+}
+
+// TestDKGSession_ByteGettersReturnCopies verifies that the byte-slice getters hand out
+// deep copies, so a caller mutating the returned slice cannot corrupt session state (which
+// would otherwise be an aliasing data race against concurrent readers/writers).
+func TestDKGSession_ByteGettersReturnCopies(t *testing.T) {
+	t.Parallel()
+
+	session := types.NewDKGSession(1, nil, false, [32]byte{})
+	session.SetKeyMaterial(
+		[]byte("participants-root"),
+		[]byte("global-pub-key"),
+		[]byte("sig-finalize"),
+		[]byte("pub-key-share"),
+		[][]byte{[]byte("coeff-0"), []byte("coeff-1")},
+	)
+
+	t.Run("GetGlobalPubKey", func(t *testing.T) {
+		t.Parallel()
+		got := session.GetGlobalPubKey()
+		require.Equal(t, []byte("global-pub-key"), got)
+		got[0] = 'X'
+		require.Equal(t, []byte("global-pub-key"), session.GetGlobalPubKey(), "mutating the returned slice must not affect the session")
+	})
+
+	t.Run("GetSigFinalizeNetwork", func(t *testing.T) {
+		t.Parallel()
+		got := session.GetSigFinalizeNetwork()
+		require.Equal(t, []byte("sig-finalize"), got)
+		got[0] = 'X'
+		require.Equal(t, []byte("sig-finalize"), session.GetSigFinalizeNetwork())
+	})
+
+	t.Run("GetParticipantsRoot", func(t *testing.T) {
+		t.Parallel()
+		got := session.GetParticipantsRoot()
+		require.Equal(t, []byte("participants-root"), got)
+		got[0] = 'X'
+		require.Equal(t, []byte("participants-root"), session.GetParticipantsRoot())
+	})
+
+	t.Run("GetPubKeyShare", func(t *testing.T) {
+		t.Parallel()
+		got := session.GetPubKeyShare()
+		require.Equal(t, []byte("pub-key-share"), got)
+		got[0] = 'X'
+		require.Equal(t, []byte("pub-key-share"), session.GetPubKeyShare())
+	})
+
+	t.Run("GetPublicCoeffs", func(t *testing.T) {
+		t.Parallel()
+		got := session.GetPublicCoeffs()
+		require.Equal(t, [][]byte{[]byte("coeff-0"), []byte("coeff-1")}, got)
+		got[0][0] = 'X'
+		require.Equal(t, [][]byte{[]byte("coeff-0"), []byte("coeff-1")}, session.GetPublicCoeffs(), "mutating an inner coefficient slice must not affect the session")
+	})
+}
+
+// TestDKGSession_ScalarGettersSetters verifies the mutex-guarded scalar accessors round-trip.
+func TestDKGSession_ScalarGettersSetters(t *testing.T) {
+	t.Parallel()
+
+	session := types.NewDKGSession(1, nil, false, [32]byte{})
+
+	require.Equal(t, types.PhaseInitializing, session.GetPhase())
+	session.UpdatePhase(types.PhaseCompleted)
+	require.Equal(t, types.PhaseCompleted, session.GetPhase())
+
+	require.Equal(t, uint32(0), session.GetIndex())
+	session.SetIndex(5)
+	require.Equal(t, uint32(5), session.GetIndex())
+
+	require.False(t, session.GetIsFinalized())
+	session.SetFinalized()
+	require.True(t, session.GetIsFinalized())
+}
+
+// TestDKGSession_Snapshot verifies that Snapshot returns an independent deep copy: field
+// values match, and mutating the snapshot's byte slices does not touch the live session.
+func TestDKGSession_Snapshot(t *testing.T) {
+	t.Parallel()
+
+	session := types.NewDKGSession(7, []string{"0xval"}, true, [32]byte{0xAB})
+	session.UpdatePhase(types.PhaseDealing)
+	session.SetIndex(3)
+	session.SetKeyMaterial(
+		[]byte("proot"),
+		[]byte("gpk"),
+		[]byte("sig"),
+		[]byte("share"),
+		[][]byte{[]byte("c0")},
+	)
+
+	snap := session.Snapshot()
+
+	require.Equal(t, uint32(7), snap.Round)
+	require.Equal(t, types.PhaseDealing, snap.Phase)
+	require.Equal(t, uint32(3), snap.Index)
+	require.True(t, snap.IsResharing)
+	require.Equal(t, []byte("gpk"), snap.GlobalPubKey)
+	require.Equal(t, [][]byte{[]byte("c0")}, snap.PublicCoeffs)
+
+	// Mutating the snapshot's slices must not affect the live session.
+	snap.GlobalPubKey[0] = 'X'
+	snap.PublicCoeffs[0][0] = 'X'
+	require.Equal(t, []byte("gpk"), session.GetGlobalPubKey())
+	require.Equal(t, [][]byte{[]byte("c0")}, session.GetPublicCoeffs())
+}
+
+// TestDKGSession_ConcurrentSetupMutationAndRead runs the atomic setup accessors under
+// concurrent writers and readers so -race guards the atomicity their docs claim: a
+// reader must never observe a torn slice header while SetSetupResult writes the group.
+func TestDKGSession_ConcurrentSetupMutationAndRead(t *testing.T) {
+	t.Parallel()
+
+	session := types.NewDKGSession(1, nil, false, [32]byte{})
+
+	const (
+		goroutines = 8
+		iterations = 1000
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				session.SetCodeCommitmentIfEmpty([]byte("cc"))
+				session.SetSetupResult(
+					[]byte("cc"),
+					[]byte("dkgpub"),
+					[]byte("commpub"),
+					[]byte("report"),
+					[]byte("blockhash"),
+					int64(42),
+				)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_ = session.HasSetupData()
+				_ = session.GetCodeCommitment()
+				_ = session.GetDKGPubKey()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// After all writers, the setup result is fully populated and self-consistent.
+	require.True(t, session.HasSetupData())
+	require.Equal(t, []byte("cc"), session.GetCodeCommitment())
+	require.Equal(t, []byte("dkgpub"), session.GetDKGPubKey())
+	require.Equal(t, int64(42), session.GetStartBlockHeight())
 }


### PR DESCRIPTION
## Problem
`DKGSession` carries a `sync.RWMutex`, but many of its fields were read and written raw across the keeper. The session pointer is shared between the ABCI thread, the async DKG goroutines, and the decrypt worker, so raw access races — most sharply `saveSession` marshaling the live pointer while another goroutine mutates it, which can tear a slice header and panic the validator.

## Fix
- Route every external `DKGSession` field access through mutex-protected accessors: getters clone slices, and grouped setters (`SetSetupResult`, `SetCodeCommitmentIfEmpty`) write related fields atomically under one lock.
- `saveSession` marshals a `Snapshot()` deep copy taken under RLock instead of the live pointer.
- Wrap the async DKG goroutines with a panic-recovery guard so a field-access panic degrades to a logged error instead of crashing the process.

## Test coverage
`go test -race -coverpkg=./client/x/dkg/... ./client/x/dkg/...`

| Symbol / package | Coverage |
|---|---|
| New `DKGSession` accessors (getters, `HasSetupData`, `SetSetupResult`, `SetCodeCommitmentIfEmpty`, `Snapshot`) | 100% |
| `keeper` package | 82.1% |

issue: #859
